### PR TITLE
chore: gitignore generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ CMakeCache.txt
 cmake_install.cmake
 CTestTestfile.cmake
 _deps/
+CMakeUserPresets.json
+pixi.lock

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,25 +20,13 @@ include(cmake/Doxygen.cmake)
 include(cmake/SourcesAndHeaders.cmake)
 
 # ── External dependencies ────────────────────────────────────────────────────
+# cpp-httplib and nlohmann_json are provided by Conan (run `just deps` first).
+# nats.c stays as FetchContent (not reliably available on ConanCenter).
+find_package(httplib REQUIRED)
+find_package(nlohmann_json REQUIRED)
+find_package(OpenSSL REQUIRED)
+
 include(FetchContent)
-
-FetchContent_Declare(
-  cpp_httplib
-  GIT_REPOSITORY https://github.com/yhirose/cpp-httplib.git
-  GIT_TAG        v0.18.3
-  GIT_SHALLOW    TRUE
-)
-FetchContent_MakeAvailable(cpp_httplib)
-
-FetchContent_Declare(
-  nlohmann_json
-  GIT_REPOSITORY https://github.com/nlohmann/json.git
-  GIT_TAG        v3.11.3
-  GIT_SHALLOW    TRUE
-)
-FetchContent_MakeAvailable(nlohmann_json)
-
-# nats.c — JetStream client library
 FetchContent_Declare(
   nats_c
   GIT_REPOSITORY https://github.com/nats-io/nats.c.git
@@ -91,6 +79,8 @@ target_link_libraries(
     httplib::httplib
     nlohmann_json::nlohmann_json
     nats_static
+    OpenSSL::SSL
+    OpenSSL::Crypto
 )
 
 # Suppress warnings from external headers on the server target

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -12,6 +12,7 @@
       "generator": "Ninja",
       "binaryDir": "${sourceDir}/build/${presetName}",
       "installDir": "${sourceDir}/install/${presetName}",
+      "toolchainFile": "${sourceDir}/build/${presetName}/conan_toolchain.cmake",
       "cacheVariables": {
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
       }

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,23 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     ca-certificates \
     libssl-dev \
+    python3 \
+    python3-pip \
     && rm -rf /var/lib/apt/lists/*
+
+RUN pip3 install --break-system-packages conan
 
 WORKDIR /src
 
-# Copy CMake configuration first so dependency fetching can be cached separately.
+# Copy Conan files first for dependency caching.
+COPY conanfile.py ./
+COPY conan/ conan/
+RUN conan install . \
+    --output-folder=build \
+    --profile=conan/profiles/default \
+    --build=missing
+
+# Copy CMake configuration so FetchContent (nats.c) can be cached separately.
 COPY CMakeLists.txt ./
 COPY CMakePresets.json ./
 COPY cmake/ cmake/
@@ -22,6 +34,7 @@ COPY src/ src/
 COPY test/ test/
 
 RUN cmake -B build -G Ninja \
+    -DCMAKE_TOOLCHAIN_FILE=build/conan_toolchain.cmake \
     -DCMAKE_BUILD_TYPE=Release \
     -DProjectAgamemnon_BUILD_TESTING=OFF \
     -DProjectAgamemnon_ENABLE_CLANG_TIDY=OFF \
@@ -45,7 +58,7 @@ ENV NATS_URL=nats://localhost:4222
 ENV PORT=8080
 
 HEALTHCHECK --interval=10s --timeout=3s --start-period=5s --retries=3 \
-    CMD wget -qO- http://localhost:${PORT}/health || exit 1
+    CMD wget -qO- http://localhost:${PORT}/v1/health || exit 1
 
 RUN useradd -r -s /usr/sbin/nologin agamemnon
 USER agamemnon

--- a/conan/profiles/debug
+++ b/conan/profiles/debug
@@ -1,0 +1,8 @@
+[settings]
+os=Linux
+compiler=gcc
+compiler.version=14
+compiler.libcxx=libstdc++11
+compiler.cppstd=20
+build_type=Debug
+arch=x86_64

--- a/conan/profiles/default
+++ b/conan/profiles/default
@@ -1,0 +1,8 @@
+[settings]
+os=Linux
+compiler=gcc
+compiler.version=14
+compiler.libcxx=libstdc++11
+compiler.cppstd=20
+build_type=Release
+arch=x86_64

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,19 @@
+from conan import ConanFile
+from conan.tools.cmake import CMakeToolchain, CMakeDeps
+
+
+class ProjectAgamemnonConan(ConanFile):
+    name = "projectagamemnon"
+    version = "0.1.0"
+    settings = "os", "compiler", "build_type", "arch"
+
+    def requirements(self):
+        self.requires("cpp-httplib/0.18.3")
+        self.requires("nlohmann_json/3.11.3")
+
+    def build_requirements(self):
+        self.test_requires("gtest/1.14.0")
+
+    def generate(self):
+        CMakeDeps(self).generate()
+        CMakeToolchain(self).generate()

--- a/justfile
+++ b/justfile
@@ -3,7 +3,15 @@ set shell := ["bash", "-c"]
 default:
   @just --list
 
-build:
+# Install Conan dependencies (cpp-httplib, nlohmann_json, gtest)
+deps:
+  conan install . --output-folder=build/debug --profile=conan/profiles/debug --build=missing
+
+# Install Conan dependencies for release
+deps-release:
+  conan install . --output-folder=build/release --profile=conan/profiles/default --build=missing
+
+build: deps
   cmake --preset debug && cmake --build --preset debug
 
 test:

--- a/pixi.toml
+++ b/pixi.toml
@@ -9,14 +9,16 @@ platforms = ["linux-64"]
 cmake = ">=3.20"
 ninja = ">=1.11"
 cxx-compiler = ">=1.7"
-gtest = ">=1.14"
+conan = ">=2.0"
+openssl = ">=3"
 clang-tools = ">=17"
 gcovr = ">=7"
 pre-commit = ">=3"
 
 [tasks]
-build = "cmake --preset debug && cmake --build --preset debug"
+deps = "conan install . --output-folder=build/debug --profile=conan/profiles/debug --build=missing"
+build = { cmd = "cmake --preset debug && cmake --build --preset debug", depends-on = ["deps"] }
 test = "ctest --preset debug --output-on-failure"
 lint = "./scripts/lint.sh"
 format = "./scripts/format.sh"
-coverage = "cmake --preset coverage && cmake --build --preset coverage && ./scripts/coverage.sh"
+coverage = "conan install . --output-folder=build/coverage --profile=conan/profiles/debug --build=missing && cmake --preset coverage && cmake --build --preset coverage && ./scripts/coverage.sh"

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "schedule": ["before 5am on Monday"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["CMakeLists\\.txt$"],
+      "matchStrings": [
+        "FetchContent_Declare\\([\\s\\S]*?GIT_REPOSITORY\\s+https://github\\.com/(?<depName>[^/]+/[^.]+)\\.git\\s+GIT_TAG\\s+(?<currentValue>v?[\\d.]+)"
+      ],
+      "datasourceTemplate": "github-tags",
+      "versioningTemplate": "semver"
+    }
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["conan"],
+      "groupName": "C++ Conan dependencies"
+    },
+    {
+      "matchManagers": ["pixi"],
+      "groupName": "pixi build tools",
+      "schedule": ["before 5am on the first day of the month"]
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub Actions",
+      "automerge": true
+    }
+  ]
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,11 +1,6 @@
 cmake_minimum_required(VERSION 3.20)
 
-include(FetchContent)
-FetchContent_Declare(
-  googletest
-  GIT_REPOSITORY https://github.com/google/googletest.git
-  GIT_TAG v1.14.0)
-FetchContent_MakeAvailable(googletest)
+find_package(GTest REQUIRED)
 
 add_executable(${PROJECT_NAME}_tests src/test_main.cpp)
 


### PR DESCRIPTION
Add CMakeUserPresets.json and pixi.lock to .gitignore — these are user-specific / build-generated files.