### PR TITLE
docs: add RELEASING.md with PyPI OIDC trusted publishing setup

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,53 @@
+# Releasing
+
+## Python Client (`HomericIntelligence-Agamemnon`)
+
+Releases are triggered by pushing a `v*` tag (e.g. `v0.1.0`). The
+`python-client-release.yml` workflow builds the wheel/sdist and publishes to
+PyPI using **OIDC Trusted Publishing** — no API token is stored in the repo.
+
+### Prerequisites (one-time setup)
+
+Both of the following must be configured before the first tag push or the
+publish step will fail with a 403.
+
+#### 1. GitHub `pypi` environment
+
+The `pypi` Actions environment must exist and be scoped to `v*` tags:
+
+- Repo → **Settings → Environments → New environment**
+- Name: `pypi` (lowercase, exact)
+- Under *Deployment branches and tags* → *Add rule*: type **Tag**, pattern `v*`
+
+> Already configured: environment ID `14476785067`, tag policy `v*` (tag ID
+> `47723547`).
+
+#### 2. PyPI pending publisher
+
+Register the OIDC publisher at <https://pypi.org/manage/account/publishing/>
+**before** pushing the first `v*` tag (the package does not need to exist yet):
+
+| Field | Value |
+|---|---|
+| PyPI Project Name | `HomericIntelligence-Agamemnon` |
+| Owner | `HomericIntelligence` |
+| Repository name | `ProjectAgamemnon` |
+| Workflow name | `python-client-release.yml` |
+| Environment name | `pypi` |
+
+These five values must match the workflow file exactly or the OIDC exchange
+will be rejected.
+
+### Cutting a release
+
+```bash
+# Bump version in pyproject.toml, commit, then:
+git tag -s v0.1.0 -m "release: v0.1.0"
+git push origin v0.1.0
+```
+
+The workflow runs automatically and publishes the package. Verify with:
+
+```bash
+pip index versions HomericIntelligence-Agamemnon
+```


### PR DESCRIPTION
## Summary

- Adds `RELEASING.md` documenting the one-time infrastructure setup required before the first `v*` tag push
- Creates the GitHub `pypi` Actions environment via API (scoped to `v*` tags) — no longer a manual step
- Documents the PyPI pending publisher fields that must match `python-client-release.yml` exactly

## What was done

**Automated (via GitHub API):**
- Created `pypi` environment (ID `14476785067`)
- Added `v*` tag deployment policy (ID `47723547`)

**Still requires manual action:**
- PyPI pending publisher registration at pypi.org — cannot be done via API; instructions are in `RELEASING.md`

## Test plan

- [ ] Verify GitHub `pypi` environment exists: repo → Settings → Environments
- [ ] Register PyPI pending publisher using values in `RELEASING.md`
- [ ] Push a `v*` tag and confirm the `python-client-release.yml` workflow publishes without a 403

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)