### PR TITLE
ci(python-client): switch CI to pixi and pin dev-dep upper bounds

### DIFF
--- a/.github/workflows/python-client.yml
+++ b/.github/workflows/python-client.yml
@@ -20,68 +20,65 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-24.04
-    defaults:
-      run:
-        working-directory: clients/python
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - uses: actions/cache@v4
         with:
-          python-version: "3.11"
+          path: |
+            clients/python/.pixi
+            ~/.cache/rattler/cache
+          key: pixi-${{ runner.os }}-${{ hashFiles('clients/python/pixi.lock') }}
+          restore-keys: pixi-${{ runner.os }}-
 
-      - name: Install ruff
-        run: pip install ruff>=0.4
+      - uses: prefix-dev/setup-pixi@v0.8.1
+        with:
+          pixi-version: v0.39.5
+          manifest-path: clients/python/pixi.toml
 
       - name: Run ruff
-        run: ruff check src/ tests/
+        run: pixi run --manifest-path clients/python/pixi.toml lint
 
   typecheck:
     name: Type Check
     runs-on: ubuntu-24.04
-    defaults:
-      run:
-        working-directory: clients/python
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - uses: actions/cache@v4
         with:
-          python-version: "3.11"
+          path: |
+            clients/python/.pixi
+            ~/.cache/rattler/cache
+          key: pixi-${{ runner.os }}-${{ hashFiles('clients/python/pixi.lock') }}
+          restore-keys: pixi-${{ runner.os }}-
 
-      - name: Install package and mypy
-        run: pip install -e ".[dev]" mypy>=1.10 pydantic>=2.0 httpx>=0.27
+      - uses: prefix-dev/setup-pixi@v0.8.1
+        with:
+          pixi-version: v0.39.5
+          manifest-path: clients/python/pixi.toml
 
       - name: Run mypy
-        run: mypy src/
+        run: pixi run --manifest-path clients/python/pixi.toml typecheck
 
   test:
-    name: Test (Python ${{ matrix.python-version }})
+    name: Test
     runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        python-version: ["3.11", "3.12"]
-    defaults:
-      run:
-        working-directory: clients/python
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+      - uses: actions/cache@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          path: |
+            clients/python/.pixi
+            ~/.cache/rattler/cache
+          key: pixi-${{ runner.os }}-${{ hashFiles('clients/python/pixi.lock') }}
+          restore-keys: pixi-${{ runner.os }}-
 
-      - name: Install package and test deps
-        run: |
-          pip install -e .
-          pip install pytest>=8.0 pytest-asyncio>=0.23 pytest-cov>=5.0 respx>=0.21
+      - uses: prefix-dev/setup-pixi@v0.8.1
+        with:
+          pixi-version: v0.39.5
+          manifest-path: clients/python/pixi.toml
 
       - name: Run tests
-        run: |
-          python -m pytest tests/ -v \
-            --cov=agamemnon_client \
-            --cov-report=term-missing \
-            --cov-fail-under=96
+        run: pixi run --manifest-path clients/python/pixi.toml test

--- a/clients/python/pixi.toml
+++ b/clients/python/pixi.toml
@@ -14,15 +14,15 @@ httpx = ">=0.27,<1"
 pydantic = ">=2.0,<3"
 
 [feature.dev.pypi-dependencies]
-pytest = ">=8.0"
-pytest-asyncio = ">=0.23"
-pytest-cov = ">=5.0"
-respx = ">=0.21"
-mypy = ">=1.10"
-ruff = ">=0.4"
+pytest = ">=8.0,<9"
+pytest-asyncio = ">=0.23,<1"
+pytest-cov = ">=5.0,<6"
+respx = ">=0.21,<1"
+mypy = ">=1.10,<2"
+ruff = ">=0.4,<1"
 
 [feature.dev.tasks]
-test = "python -m pytest tests/ -v --cov=agamemnon_client --cov-report=term-missing"
+test = "python -m pytest tests/ -v --cov=agamemnon_client --cov-report=term-missing --cov-fail-under=96"
 lint = "ruff check src/ tests/"
 format = "ruff format src/ tests/"
 typecheck = "mypy src/"


### PR DESCRIPTION
## Summary

- Replaces bare `pip install` + `pytest` in `python-client.yml` with `prefix-dev/setup-pixi@v0.8.1` so all three CI jobs (lint, typecheck, test) use pixi — enforcing the same dep constraints as local development
- Adds `actions/cache@v4` keyed on `pixi.lock` hash for faster CI restores
- Drops the Python version matrix (pixi controls the interpreter via `pixi.toml`)
- Adds upper bounds (`<N`) to all dev deps in `pixi.toml` (`pytest`, `pytest-asyncio`, `pytest-cov`, `respx`, `mypy`, `ruff`) to prevent surprise breakage from future major-version bumps
- Adds `--cov-fail-under=96` to the pixi `test` task so the coverage threshold is enforced both locally and in CI

## Test plan

- [x] `pixi run lint` — passes (ruff: all checks passed)
- [x] `pixi run typecheck` — passes (mypy: no issues in 4 source files)
- [x] `pixi run test` — passes (78 tests, 99.25% coverage ≥ 96% threshold)
- [x] The `test_update_agent` PATCH test (which triggered issue #10) is already present and passes

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)