### PR TITLE
feat(nats): publish hi.logs.agamemnon.* structured log events

### DIFF
--- a/include/projectagamemnon/nats_client.hpp
+++ b/include/projectagamemnon/nats_client.hpp
@@ -43,8 +43,8 @@ class NatsClient {
 
   /// Publish a structured log event to hi.logs.agamemnon.<event> (ADR-005).
   /// Fire-and-forget: NATS failures are logged but do not propagate.
-  void publish_log(const std::string& subject, const std::string& level,
-                   const std::string& message, const nlohmann::json& metadata);
+  void publish_log(const std::string& subject, const std::string& level, const std::string& message,
+                   const nlohmann::json& metadata);
 
  private:
   std::string url_;

--- a/include/projectagamemnon/nats_client.hpp
+++ b/include/projectagamemnon/nats_client.hpp
@@ -3,6 +3,8 @@
 #include <functional>
 #include <string>
 
+#include "nlohmann/json.hpp"
+
 namespace projectagamemnon {
 
 /// Thin wrapper around the nats.c client library with JetStream support.
@@ -38,6 +40,11 @@ class NatsClient {
   /// The callback receives (subject, data) strings.
   using MessageCallback = std::function<void(const std::string& subject, const std::string& data)>;
   bool subscribe(const std::string& subject, MessageCallback cb);
+
+  /// Publish a structured log event to hi.logs.agamemnon.<event> (ADR-005).
+  /// Fire-and-forget: NATS failures are logged but do not propagate.
+  void publish_log(const std::string& subject, const std::string& level,
+                   const std::string& message, const nlohmann::json& metadata);
 
  private:
   std::string url_;

--- a/src/nats_client.cpp
+++ b/src/nats_client.cpp
@@ -1,10 +1,12 @@
 #include "projectagamemnon/nats_client.hpp"
 
 // NOLINTNEXTLINE(misc-include-cleaner) — nats.h brings in its own transitive includes
+#include <chrono>
 #include <iostream>
 #include <string>
 
 #include "nats.h"
+#include "nlohmann/json.hpp"
 
 namespace projectagamemnon {
 
@@ -124,6 +126,28 @@ bool NatsClient::publish(const std::string& subject, const std::string& payload)
     return false;
   }
   return true;
+}
+
+// ── publish_log ───────────────────────────────────────────────────────────────
+
+void NatsClient::publish_log(const std::string& subject, const std::string& level,
+                              const std::string& message, const nlohmann::json& metadata) {
+  // Build ADR-005 structured log payload.
+  auto now = std::chrono::system_clock::now();
+  double ts =
+      std::chrono::duration<double>(now.time_since_epoch()).count();
+
+  nlohmann::json payload = {
+      {"timestamp", ts},
+      {"service", "agamemnon"},
+      {"level", level},
+      {"message", message},
+      {"metadata", metadata},
+  };
+
+  // Fire-and-forget: ignore publish return value so NATS errors never affect
+  // the caller's request handling path.
+  publish(subject, payload.dump());
 }
 
 // ── subscribe ─────────────────────────────────────────────────────────────────

--- a/src/nats_client.cpp
+++ b/src/nats_client.cpp
@@ -131,18 +131,14 @@ bool NatsClient::publish(const std::string& subject, const std::string& payload)
 // ── publish_log ───────────────────────────────────────────────────────────────
 
 void NatsClient::publish_log(const std::string& subject, const std::string& level,
-                              const std::string& message, const nlohmann::json& metadata) {
+                             const std::string& message, const nlohmann::json& metadata) {
   // Build ADR-005 structured log payload.
   auto now = std::chrono::system_clock::now();
-  double ts =
-      std::chrono::duration<double>(now.time_since_epoch()).count();
+  double ts = std::chrono::duration<double>(now.time_since_epoch()).count();
 
   nlohmann::json payload = {
-      {"timestamp", ts},
-      {"service", "agamemnon"},
-      {"level", level},
-      {"message", message},
-      {"metadata", metadata},
+      {"timestamp", ts},    {"service", "agamemnon"}, {"level", level},
+      {"message", message}, {"metadata", metadata},
   };
 
   // Fire-and-forget: ignore publish return value so NATS errors never affect

--- a/src/routes.cpp
+++ b/src/routes.cpp
@@ -87,8 +87,7 @@ void register_routes(httplib::Server& server, Store& store, NatsClient& nats) {
     std::string agent_id = agent.value("id", "unknown");
     std::string agent_type = agent.value("type", "unknown");
     np->publish("hi.agents." + host + "." + name + ".created", result.dump());
-    np->publish_log("hi.logs.agamemnon.agent_created", "info",
-                    "Agent created: " + agent_id,
+    np->publish_log("hi.logs.agamemnon.agent_created", "info", "Agent created: " + agent_id,
                     {{"agent_id", agent_id}, {"name", name}, {"type", agent_type}, {"host", host}});
     reply_json(res, 201, result);
   });
@@ -104,8 +103,7 @@ void register_routes(httplib::Server& server, Store& store, NatsClient& nats) {
     std::string agent_id = agent.value("id", "unknown");
     std::string agent_type = agent.value("type", "unknown");
     np->publish("hi.agents." + host + "." + name + ".created", result.dump());
-    np->publish_log("hi.logs.agamemnon.agent_created", "info",
-                    "Agent created: " + agent_id,
+    np->publish_log("hi.logs.agamemnon.agent_created", "info", "Agent created: " + agent_id,
                     {{"agent_id", agent_id}, {"name", name}, {"type", agent_type}, {"host", host}});
     reply_json(res, 201, result);
   });
@@ -263,35 +261,34 @@ void register_routes(httplib::Server& server, Store& store, NatsClient& nats) {
              });
 
   // POST /v1/teams/:team_id/tasks
-  server.Post(R"(/v1/teams/([^/]+)/tasks)",
-              [sp, np](const httplib::Request& req, httplib::Response& res) {
-                std::string team_id = req.matches[1];
-                json body;
-                if (!parse_body(req, res, body)) return;
-                json result = sp->create_task(team_id, body);
-                np->publish("hi.tasks.created", result.dump());
+  server.Post(
+      R"(/v1/teams/([^/]+)/tasks)", [sp, np](const httplib::Request& req, httplib::Response& res) {
+        std::string team_id = req.matches[1];
+        json body;
+        if (!parse_body(req, res, body)) return;
+        json result = sp->create_task(team_id, body);
+        np->publish("hi.tasks.created", result.dump());
 
-                // Dispatch to myrmidon work queue: hi.myrmidon.{type}.{task_id}
-                const auto& task = result["task"];
-                std::string task_type = task.value("type", "general");
-                std::string task_id = task.value("id", "unknown");
-                std::string myrmidon_subject = "hi.myrmidon." + task_type + "." + task_id;
-                json myrmidon_payload = {{"task_id", task_id},
-                                         {"team_id", team_id},
-                                         {"subject", task.value("subject", "")},
-                                         {"description", task.value("description", "")},
-                                         {"type", task_type},
-                                         {"assignee", task.value("assigneeAgentId", "")}};
-                np->publish(myrmidon_subject, myrmidon_payload.dump());
-                np->publish_log("hi.logs.agamemnon.task_dispatched", "info",
-                                "Task dispatched: " + task_id,
-                                {{"task_id", task_id},
+        // Dispatch to myrmidon work queue: hi.myrmidon.{type}.{task_id}
+        const auto& task = result["task"];
+        std::string task_type = task.value("type", "general");
+        std::string task_id = task.value("id", "unknown");
+        std::string myrmidon_subject = "hi.myrmidon." + task_type + "." + task_id;
+        json myrmidon_payload = {{"task_id", task_id},
                                  {"team_id", team_id},
+                                 {"subject", task.value("subject", "")},
+                                 {"description", task.value("description", "")},
                                  {"type", task_type},
-                                 {"subject", myrmidon_subject}});
+                                 {"assignee", task.value("assigneeAgentId", "")}};
+        np->publish(myrmidon_subject, myrmidon_payload.dump());
+        np->publish_log("hi.logs.agamemnon.task_dispatched", "info", "Task dispatched: " + task_id,
+                        {{"task_id", task_id},
+                         {"team_id", team_id},
+                         {"type", task_type},
+                         {"subject", myrmidon_subject}});
 
-                reply_json(res, 201, result);
-              });
+        reply_json(res, 201, result);
+      });
 
   // GET /v1/teams/:team_id/tasks/:task_id
   server.Get(R"(/v1/teams/([^/]+)/tasks/([^/]+))",
@@ -307,60 +304,58 @@ void register_routes(httplib::Server& server, Store& store, NatsClient& nats) {
              });
 
   // PUT /v1/teams/:team_id/tasks/:task_id — Telemachy uses PUT for task updates
-  server.Put(R"(/v1/teams/([^/]+)/tasks/([^/]+))",
-             [sp, np](const httplib::Request& req, httplib::Response& res) {
-               std::string team_id = req.matches[1];
-               std::string task_id = req.matches[2];
-               json body;
-               if (!parse_body(req, res, body)) return;
-               json result = sp->update_task(team_id, task_id, body);
-               if (result.is_null()) {
-                 reply_not_found(res, "task");
-                 return;
-               }
-               const auto& task = result["task"].is_null() ? result : result["task"];
-               std::string status = task.value("status", "");
-               np->publish("hi.tasks." + team_id + "." + task_id + ".updated", result.dump());
-               if (status == "completed") {
-                 std::string task_type = task.value("type", "unknown");
-                 std::string assignee = task.value("assigneeAgentId", "");
-                 np->publish_log("hi.logs.agamemnon.task_completed", "info",
-                                 "Task completed: " + task_id,
-                                 {{"task_id", task_id},
-                                  {"team_id", team_id},
-                                  {"type", task_type},
-                                  {"assignee", assignee}});
-               }
-               reply_json(res, 200, {{"task", result}});
-             });
+  server.Put(R"(/v1/teams/([^/]+)/tasks/([^/]+))", [sp, np](const httplib::Request& req,
+                                                            httplib::Response& res) {
+    std::string team_id = req.matches[1];
+    std::string task_id = req.matches[2];
+    json body;
+    if (!parse_body(req, res, body)) return;
+    json result = sp->update_task(team_id, task_id, body);
+    if (result.is_null()) {
+      reply_not_found(res, "task");
+      return;
+    }
+    const auto& task = result["task"].is_null() ? result : result["task"];
+    std::string status = task.value("status", "");
+    np->publish("hi.tasks." + team_id + "." + task_id + ".updated", result.dump());
+    if (status == "completed") {
+      std::string task_type = task.value("type", "unknown");
+      std::string assignee = task.value("assigneeAgentId", "");
+      np->publish_log("hi.logs.agamemnon.task_completed", "info", "Task completed: " + task_id,
+                      {{"task_id", task_id},
+                       {"team_id", team_id},
+                       {"type", task_type},
+                       {"assignee", assignee}});
+    }
+    reply_json(res, 200, {{"task", result}});
+  });
 
   // PATCH /v1/teams/:team_id/tasks/:task_id
-  server.Patch(R"(/v1/teams/([^/]+)/tasks/([^/]+))",
-               [sp, np](const httplib::Request& req, httplib::Response& res) {
-                 std::string team_id = req.matches[1];
-                 std::string task_id = req.matches[2];
-                 json body;
-                 if (!parse_body(req, res, body)) return;
-                 json result = sp->update_task(team_id, task_id, body);
-                 if (result.is_null()) {
-                   reply_not_found(res, "task");
-                   return;
-                 }
-                 const auto& task = result["task"].is_null() ? result : result["task"];
-                 std::string status = task.value("status", "");
-                 np->publish("hi.tasks." + team_id + "." + task_id + ".updated", result.dump());
-                 if (status == "completed") {
-                   std::string task_type = task.value("type", "unknown");
-                   std::string assignee = task.value("assigneeAgentId", "");
-                   np->publish_log("hi.logs.agamemnon.task_completed", "info",
-                                   "Task completed: " + task_id,
-                                   {{"task_id", task_id},
-                                    {"team_id", team_id},
-                                    {"type", task_type},
-                                    {"assignee", assignee}});
-                 }
-                 reply_json(res, 200, {{"task", result}});
-               });
+  server.Patch(R"(/v1/teams/([^/]+)/tasks/([^/]+))", [sp, np](const httplib::Request& req,
+                                                              httplib::Response& res) {
+    std::string team_id = req.matches[1];
+    std::string task_id = req.matches[2];
+    json body;
+    if (!parse_body(req, res, body)) return;
+    json result = sp->update_task(team_id, task_id, body);
+    if (result.is_null()) {
+      reply_not_found(res, "task");
+      return;
+    }
+    const auto& task = result["task"].is_null() ? result : result["task"];
+    std::string status = task.value("status", "");
+    np->publish("hi.tasks." + team_id + "." + task_id + ".updated", result.dump());
+    if (status == "completed") {
+      std::string task_type = task.value("type", "unknown");
+      std::string assignee = task.value("assigneeAgentId", "");
+      np->publish_log("hi.logs.agamemnon.task_completed", "info", "Task completed: " + task_id,
+                      {{"task_id", task_id},
+                       {"team_id", team_id},
+                       {"type", task_type},
+                       {"assignee", assignee}});
+    }
+    reply_json(res, 200, {{"task", result}});
+  });
 
   // ── Workflows ────────────────────────────────────────────────────────────
 

--- a/src/routes.cpp
+++ b/src/routes.cpp
@@ -84,7 +84,12 @@ void register_routes(httplib::Server& server, Store& store, NatsClient& nats) {
     auto& agent = result["agent"];
     std::string host = agent.value("host", "docker");
     std::string name = agent.value("name", "unknown");
+    std::string agent_id = agent.value("id", "unknown");
+    std::string agent_type = agent.value("type", "unknown");
     np->publish("hi.agents." + host + "." + name + ".created", result.dump());
+    np->publish_log("hi.logs.agamemnon.agent_created", "info",
+                    "Agent created: " + agent_id,
+                    {{"agent_id", agent_id}, {"name", name}, {"type", agent_type}, {"host", host}});
     reply_json(res, 201, result);
   });
 
@@ -96,7 +101,12 @@ void register_routes(httplib::Server& server, Store& store, NatsClient& nats) {
     auto& agent = result["agent"];
     std::string host = agent.value("host", "local");
     std::string name = agent.value("name", "unknown");
+    std::string agent_id = agent.value("id", "unknown");
+    std::string agent_type = agent.value("type", "unknown");
     np->publish("hi.agents." + host + "." + name + ".created", result.dump());
+    np->publish_log("hi.logs.agamemnon.agent_created", "info",
+                    "Agent created: " + agent_id,
+                    {{"agent_id", agent_id}, {"name", name}, {"type", agent_type}, {"host", host}});
     reply_json(res, 201, result);
   });
 
@@ -273,6 +283,12 @@ void register_routes(httplib::Server& server, Store& store, NatsClient& nats) {
                                          {"type", task_type},
                                          {"assignee", task.value("assigneeAgentId", "")}};
                 np->publish(myrmidon_subject, myrmidon_payload.dump());
+                np->publish_log("hi.logs.agamemnon.task_dispatched", "info",
+                                "Task dispatched: " + task_id,
+                                {{"task_id", task_id},
+                                 {"team_id", team_id},
+                                 {"type", task_type},
+                                 {"subject", myrmidon_subject}});
 
                 reply_json(res, 201, result);
               });
@@ -302,7 +318,19 @@ void register_routes(httplib::Server& server, Store& store, NatsClient& nats) {
                  reply_not_found(res, "task");
                  return;
                }
+               const auto& task = result["task"].is_null() ? result : result["task"];
+               std::string status = task.value("status", "");
                np->publish("hi.tasks." + team_id + "." + task_id + ".updated", result.dump());
+               if (status == "completed") {
+                 std::string task_type = task.value("type", "unknown");
+                 std::string assignee = task.value("assigneeAgentId", "");
+                 np->publish_log("hi.logs.agamemnon.task_completed", "info",
+                                 "Task completed: " + task_id,
+                                 {{"task_id", task_id},
+                                  {"team_id", team_id},
+                                  {"type", task_type},
+                                  {"assignee", assignee}});
+               }
                reply_json(res, 200, {{"task", result}});
              });
 
@@ -318,7 +346,19 @@ void register_routes(httplib::Server& server, Store& store, NatsClient& nats) {
                    reply_not_found(res, "task");
                    return;
                  }
+                 const auto& task = result["task"].is_null() ? result : result["task"];
+                 std::string status = task.value("status", "");
                  np->publish("hi.tasks." + team_id + "." + task_id + ".updated", result.dump());
+                 if (status == "completed") {
+                   std::string task_type = task.value("type", "unknown");
+                   std::string assignee = task.value("assigneeAgentId", "");
+                   np->publish_log("hi.logs.agamemnon.task_completed", "info",
+                                   "Task completed: " + task_id,
+                                   {{"task_id", task_id},
+                                    {"team_id", team_id},
+                                    {"type", task_type},
+                                    {"assignee", assignee}});
+                 }
                  reply_json(res, 200, {{"task", result}});
                });
 


### PR DESCRIPTION
Implements HomericIntelligence/Odysseus#76

Adds NATS publish calls on key Agamemnon operations:
- `hi.logs.agamemnon.agent_created` — on agent CRUD (POST /v1/agents and POST /v1/agents/docker)
- `hi.logs.agamemnon.task_dispatched` — on task dispatch to myrmidons (POST /v1/teams/:id/tasks)
- `hi.logs.agamemnon.task_completed` — on task completion received (PUT/PATCH /v1/teams/:id/tasks/:id when status == "completed")

Payload format:
```json
{"timestamp": 1712160000.123, "service": "agamemnon", "level": "info", "message": "...", "metadata": {...}}
```

Publish is fire-and-forget — NATS failures do not fail request handling.

### Implementation details

- Added `publish_log(subject, level, message, metadata)` to `NatsClient` — builds the ADR-005 JSON envelope and delegates to the existing `publish()` method. Return value is intentionally discarded.
- `<chrono>` used for the `double` Unix timestamp (seconds since epoch).
- `nlohmann/json` already a dependency; no new deps introduced.

### Build note

The pre-existing clang-tidy `stddef.h` error in the conda sysroot prevents a local `just build` from completing, but this is unrelated to this PR (reproduced on upstream `main` before any changes).