### PR TITLE
feat(ci): add markdownlint/pixi/justfile/symlink CI jobs + fix lint blockers

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -30,8 +30,6 @@ jobs:
       - name: Python client lint
         run: ruff check clients/python/
 
-      - uses: actions/checkout@v4
-
       - name: Install system dependencies
         run: |
           sudo apt-get update
@@ -58,6 +56,96 @@ jobs:
       - name: Python client type check
         continue-on-error: true
         run: mypy clients/python/ --ignore-missing-imports
+
+  markdownlint:
+    name: markdownlint
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    needs: lint
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - name: Run markdownlint-cli2
+        uses: DavidAnson/markdownlint-cli2-action@05f32210e84442804257b2a6f20b273450ec8265  # v20.0.0
+        with:
+          globs: "**/*.md"
+          config: ".markdownlint.yaml"
+
+  pixi-check:
+    name: pixi-check
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    needs: lint
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - name: Skip if no pixi.toml
+        id: detect
+        run: |
+          if [ ! -f pixi.toml ]; then
+            echo "::notice::No pixi.toml in repo, skipping pixi-check"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Setup pixi
+        if: steps.detect.outputs.skip == 'false'
+        uses: prefix-dev/setup-pixi@v0.9.5
+        with:
+          pixi-version: v0.67.2
+          cache: true
+      - name: pixi install (locked)
+        if: steps.detect.outputs.skip == 'false'
+        run: |
+          if [ -f pixi.lock ]; then
+            pixi install --locked
+          else
+            echo "::warning::pixi.toml present but pixi.lock missing — running unlocked"
+            pixi install
+          fi
+
+  justfile-check:
+    name: justfile-check
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    needs: lint
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - name: Skip if no justfile
+        id: detect
+        run: |
+          if [ ! -f justfile ] && [ ! -f Justfile ]; then
+            echo "::notice::No justfile in repo, skipping justfile-check"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Install just
+        if: steps.detect.outputs.skip == 'false'
+        uses: extractions/setup-just@dd310ad5a97d8e7b41793f8ef055398d51ad4de6  # v2.0.0
+        with:
+          just-version: "1.36.0"
+      - name: Validate justfile
+        if: steps.detect.outputs.skip == 'false'
+        run: |
+          just --evaluate >/dev/null
+          just --list >/dev/null
+
+  symlink-check:
+    name: symlink-check
+    runs-on: ubuntu-24.04
+    timeout-minutes: 3
+    needs: lint
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - name: Run symlink check
+        run: bash scripts/check-symlinks.sh
 
   # ── 2. unit-tests ──────────────────────────────────────────────────────────
   unit-tests:

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,22 @@
+# Markdownlint configuration
+# https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md
+
+default: true
+
+MD013:
+  line_length: 120
+  heading_line_length: 120
+  code_block_line_length: 120
+  tables: false
+  headings: true
+  code_blocks: true
+
+MD033:
+  allowed_elements: [T, img, br, details, summary]
+
+MD036: false
+MD040: false
+MD041: false
+
+MD046:
+  style: fenced

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,21 @@
+# YAML Lint configuration
+# See https://yamllint.readthedocs.io/en/stable/configuration.html
+
+extends: default
+
+ignore: |
+  helm/**/templates/
+
+rules:
+  line-length:
+    max: 120
+    level: warning
+  indentation:
+    spaces: 2
+    indent-sequences: true
+  comments:
+    min-spaces-from-content: 1
+  document-start: disable
+  truthy:
+    allowed-values: ['true', 'false', 'yes', 'no']
+    check-keys: false

--- a/scripts/check-symlinks.sh
+++ b/scripts/check-symlinks.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Verify no symlinks escape the repository root and none are broken.
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd -P)"
+ROOT="$(cd "$ROOT" && pwd -P)"
+fail=0
+
+while IFS= read -r -d '' link; do
+  target="$(readlink -- "$link")"
+  case "$target" in
+    /*) abs="$target" ;;
+    *)  abs="$(cd "$(dirname -- "$link")" && pwd -P)/$target" ;;
+  esac
+  resolved="$(readlink -m -- "$abs")"
+  case "$resolved" in
+    "$ROOT"|"$ROOT"/*) ;;
+    *) echo "ERROR: symlink escapes repo: $link -> $target"; fail=1 ;;
+  esac
+  if [ ! -e "$link" ]; then
+    echo "ERROR: broken symlink: $link -> $target"; fail=1
+  fi
+done < <(find "$ROOT" -path "$ROOT/.git" -prune -o -type l -print0)
+
+[ "$fail" -eq 0 ] && echo "symlink-check: OK" || exit 1


### PR DESCRIPTION
## Summary

- Add 4 new CI jobs: markdownlint, pixi-check, justfile-check, symlink-check
- Remove duplicate `actions/checkout` step in `lint` job
- Add `.markdownlint.yaml`, `.yamllint.yaml`, and `scripts/check-symlinks.sh`

## Test plan

- [ ] yamllint passes on updated workflow
- [ ] All 4 new jobs run successfully in CI
- [ ] Existing C++ build/test jobs are untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)