### PR TITLE
feat(ci): add pypi environment and OIDC preflight check to release workflow

### DIFF
--- a/.github/workflows/python-client-release.yml
+++ b/.github/workflows/python-client-release.yml
@@ -9,16 +9,42 @@ permissions:
   contents: read
   id-token: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   build-and-publish:
     name: Build and publish to PyPI
     runs-on: ubuntu-24.04
     environment: pypi
+    timeout-minutes: 20
     defaults:
       run:
         working-directory: clients/python
     steps:
       - uses: actions/checkout@v4
+
+      - name: Verify pypi environment and OIDC permissions
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Fail fast if the pypi GitHub environment is missing or misconfigured
+          if ! gh api "repos/${{ github.repository }}/environments/pypi" --silent 2>/dev/null; then
+            echo "::error::GitHub environment 'pypi' does not exist or is inaccessible."
+            echo "::error::Create the environment at: https://github.com/${{ github.repository }}/settings/environments"
+            echo "::error::It must be named exactly 'pypi' and scoped to the 'v*' tag pattern."
+            exit 1
+          fi
+
+          # Verify OIDC token endpoint is available (set by runner when id-token: write is granted)
+          if [ -z "${ACTIONS_ID_TOKEN_REQUEST_URL}" ]; then
+            echo "::error::OIDC token endpoint is not available."
+            echo "::error::Ensure 'id-token: write' is present in the workflow permissions block."
+            exit 1
+          fi
+
+          echo "Preflight passed: 'pypi' environment exists and OIDC is available."
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary

- Adds a `Verify pypi environment and OIDC permissions` step as the second step in `build-and-publish`, running before `Set up Python` to fail fast (~5s) rather than after a 3+ minute wheel build
- Uses `gh api repos/${{ github.repository }}/environments/pypi` to detect a missing or misconfigured `pypi` environment, printing an actionable error with the settings URL
- Checks `ACTIONS_ID_TOKEN_REQUEST_URL` to verify `id-token: write` is active (the runner only sets this env var when the permission is granted)
- Adds `concurrency` group at workflow level to cancel redundant runs on rapid tag pushes
- Adds `timeout-minutes: 20` to prevent the job hanging indefinitely if the publish step stalls

## Test plan

- [x] YAML validated with `python3 -c "import yaml; yaml.safe_load(open(...))"` — passes
- [x] All 78 existing Python client tests pass (`pixi run python -m pytest tests/ -v`)
- [ ] Live verification: confirm `Preflight passed` appears in run log on a real tag push
- [ ] Failure path: temporarily rename the `pypi` environment to confirm the 404 error fires before `Set up Python`
- [ ] Failure path: remove `id-token: write` from a fork and confirm the OIDC check fires

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)