### PR TITLE
chore(pixi): migrate [project] to [workspace] in clients/python/pixi.toml

### DIFF
--- a/clients/python/pixi.toml
+++ b/clients/python/pixi.toml
@@ -1,4 +1,4 @@
-[project]
+[workspace]
 name = "agamemnon-client"
 version = "0.1.0"
 description = "Async Python client for the Agamemnon REST API"


### PR DESCRIPTION
## Summary

- Renames the deprecated `[project]` section to `[workspace]` in `clients/python/pixi.toml`
- Silences the pixi deprecation warning that would become an error in a future pixi release

## Test plan

- [x] `pixi install` — no deprecation warning
- [x] `pixi run test` — 78 tests pass, 99.25% coverage
- [x] `pixi run lint` — all checks passed
- [x] `pixi run typecheck` — no issues found

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)