### PR TITLE
fix(python-client): suppress pytest-asyncio DeprecationWarning on Python 3.14

### DIFF
--- a/clients/python/pixi.toml
+++ b/clients/python/pixi.toml
@@ -15,7 +15,7 @@ pydantic = ">=2.0,<3"
 
 [feature.dev.pypi-dependencies]
 pytest = ">=8.0,<9"
-pytest-asyncio = ">=0.23,<1"
+pytest-asyncio = ">=0.23,<0.26"
 pytest-cov = ">=5.0,<6"
 respx = ">=0.21,<1"
 mypy = ">=1.10,<2"

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -36,6 +36,9 @@ packages = ["agamemnon_client"]
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
+filterwarnings = [
+    "ignore::DeprecationWarning:pytest_asyncio",
+]
 
 [tool.coverage.run]
 source = ["agamemnon_client"]


### PR DESCRIPTION
## Summary

- Pin `pytest-asyncio` to `>=0.23,<0.26` in `clients/python/pixi.toml` to avoid the noisy 0.26+ version
- Add `filterwarnings = ["ignore::DeprecationWarning:pytest_asyncio"]` to `[tool.pytest.ini_options]` in `clients/python/pyproject.toml` as a belt-and-suspenders fix for Python 3.14 environments where even 0.25.x emits the warnings

The 334 `DeprecationWarning: asyncio.get_event_loop_policy is deprecated` warnings originated inside `pytest-asyncio` (not test code), triggered by Python 3.14's deprecation of `get_event_loop_policy`. The pin constrains the resolved version; the filterwarnings entry suppresses the noise in the current Python 3.14 environment where `pytest-asyncio 0.25.x` also emits the warning.

## Test plan

- [x] `pixi run python -c "import pytest_asyncio; print(pytest_asyncio.__version__)"` → `0.25.3` (within `[0.23, 0.26)`)
- [x] `pixi run test` → 78 passed, **0 warnings** (was 334 warnings before)
- [x] Coverage remains at 99.25% (above 96% threshold)
- [x] No test failures introduced

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)