### PR TITLE
docs(clients/python): add PyPI version badge to README

### DIFF
--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -1,5 +1,7 @@
 # agamemnon-client
 
+[![PyPI version](https://badge.fury.io/py/HomericIntelligence-Agamemnon.svg)](https://pypi.org/project/HomericIntelligence-Agamemnon/)
+
 Async Python client for the [Agamemnon](https://github.com/HomericIntelligence/ProjectAgamemnon) REST API.
 
 ## Installation


### PR DESCRIPTION
## Summary

- Adds a PyPI version badge to `clients/python/README.md` immediately below the `# agamemnon-client` heading
- Badge links to the PyPI project page for `HomericIntelligence-Agamemnon` and displays the current published version

## Test plan

- [ ] Markdownlint passes with no errors (verified locally with `npx markdownlint-cli`)
- [ ] Badge renders correctly in GitHub Markdown preview
- [ ] No existing CI jobs broken (documentation-only change)
- [ ] After first PyPI release: badge resolves to a version number at https://pypi.org/project/HomericIntelligence-Agamemnon/

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)