### PR TITLE
feat(release): add `just release VERSION` recipe to automate version bump and tagging

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -44,15 +44,12 @@ will be rejected.
 # Ensure you are on main with a clean working tree:
 git checkout main && git pull
 
-# Verify prerequisites using the helper script:
-./scripts/check-release-readiness.sh
-
-# Bump version in pyproject.toml and update CHANGELOG.md:
-# In CHANGELOG.md, rename [Unreleased] to [X.Y.Z] - YYYY-MM-DD
-# and add a new empty ## [Unreleased] section above it.
-git tag -s v0.1.0 -m "release: v0.1.0"
-git push origin v0.1.0
+# Bump version, commit, tag, and push in one step:
+just release 0.1.0
 ```
+
+`just release` runs the readiness check automatically before mutating anything.
+To preview readiness without releasing, run `./scripts/check-release-readiness.sh VERSION` directly.
 
 The workflow runs automatically and publishes the package. Verify with:
 

--- a/clients/python/tests/test_bump_version.py
+++ b/clients/python/tests/test_bump_version.py
@@ -1,0 +1,140 @@
+"""Tests for scripts/bump-version.py."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[3] / "scripts" / "bump-version.py"
+
+MINIMAL_TOML = """\
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "example"
+version = "0.1.0"
+description = "Example"
+"""
+
+TOML_MULTI_VERSION = """\
+[build-system]
+requires = ["hatchling>=1.0.0"]
+build-backend = "hatchling.build"
+
+[project]
+name = "example"
+version = "0.1.0"
+description = "uses version in other sections too"
+
+[tool.hatch.metadata]
+# hatchling version = "unrelated"
+"""
+
+TOML_NO_VERSION = """\
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "example"
+description = "no version here"
+"""
+
+
+def _run(version: str, toml_content: str | None = None, *, tmp_path: Path) -> subprocess.CompletedProcess[str]:
+    toml = tmp_path / "pyproject.toml"
+    content = toml_content if toml_content is not None else MINIMAL_TOML
+    toml.write_text(content, encoding="utf-8")
+
+    # Patch the script so it targets our tmp pyproject.toml
+    script_src = SCRIPT.read_text(encoding="utf-8")
+    patched_src = script_src.replace(
+        'repo_root / "clients" / "python" / "pyproject.toml"',
+        f'Path(r"{toml}")',
+    )
+    patched_script = tmp_path / "bump_version_patched.py"
+    patched_script.write_text(patched_src, encoding="utf-8")
+
+    return subprocess.run(
+        [sys.executable, str(patched_script), version],
+        capture_output=True,
+        text=True,
+    )
+
+
+# ── Happy path ─────────────────────────────────────────────────────────────────
+
+
+def test_bumps_version_field(tmp_path: Path) -> None:
+    result = _run("2.3.4", tmp_path=tmp_path)
+    assert result.returncode == 0
+    content = (tmp_path / "pyproject.toml").read_text()
+    assert 'version = "2.3.4"' in content
+
+
+def test_prints_confirmation(tmp_path: Path) -> None:
+    result = _run("1.0.0", tmp_path=tmp_path)
+    assert result.returncode == 0
+    assert "bumped version to 1.0.0" in result.stdout
+
+
+def test_only_replaces_project_version(tmp_path: Path) -> None:
+    result = _run("9.9.9", TOML_MULTI_VERSION, tmp_path=tmp_path)
+    assert result.returncode == 0
+    content = (tmp_path / "pyproject.toml").read_text()
+    assert 'version = "9.9.9"' in content
+    # Build-system comment must remain untouched
+    assert 'requires = ["hatchling>=1.0.0"]' in content
+
+
+def test_idempotent_same_version(tmp_path: Path) -> None:
+    result = _run("0.1.0", tmp_path=tmp_path)
+    assert result.returncode == 0
+    content = (tmp_path / "pyproject.toml").read_text()
+    assert content.count('version = "0.1.0"') == 1
+
+
+@pytest.mark.parametrize("version", ["0.0.1", "1.2.3", "10.20.30", "0.1.0"])
+def test_accepts_valid_semver(version: str, tmp_path: Path) -> None:
+    result = _run(version, tmp_path=tmp_path)
+    assert result.returncode == 0
+
+
+# ── Validation errors ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("bad_version", ["abc", "1.2", "1.2.3.4", "v1.2.3", "1.2.x", ""])
+def test_rejects_invalid_semver(bad_version: str, tmp_path: Path) -> None:
+    result = _run(bad_version, tmp_path=tmp_path)
+    assert result.returncode != 0
+    assert "X.Y.Z" in result.stderr or "VERSION" in result.stderr
+
+
+def test_error_when_no_version_in_toml(tmp_path: Path) -> None:
+    result = _run("1.0.0", TOML_NO_VERSION, tmp_path=tmp_path)
+    assert result.returncode != 0
+    assert "version" in result.stderr.lower()
+
+
+def test_error_missing_argument(tmp_path: Path) -> None:
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "usage" in result.stderr.lower() or "VERSION" in result.stderr
+
+
+# ── Atomic write ───────────────────────────────────────────────────────────────
+
+
+def test_no_tmp_file_left_after_success(tmp_path: Path) -> None:
+    _run("1.2.3", tmp_path=tmp_path)
+    tmp_files = list(tmp_path.glob("*.tmp"))
+    assert tmp_files == [], f"unexpected .tmp files: {tmp_files}"

--- a/clients/python/tests/test_bump_version.py
+++ b/clients/python/tests/test_bump_version.py
@@ -46,7 +46,9 @@ description = "no version here"
 """
 
 
-def _run(version: str, toml_content: str | None = None, *, tmp_path: Path) -> subprocess.CompletedProcess[str]:
+def _run(
+    version: str, toml_content: str | None = None, *, tmp_path: Path
+) -> subprocess.CompletedProcess[str]:
     toml = tmp_path / "pyproject.toml"
     content = toml_content if toml_content is not None else MINIMAL_TOML
     toml.write_text(content, encoding="utf-8")

--- a/justfile
+++ b/justfile
@@ -37,3 +37,18 @@ docs-validate:
 
 ci:
   cmake --preset ci && cmake --build --preset ci && ctest --preset ci
+
+# Cut a release: bump version, commit, tag, and push
+release VERSION:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  if ! [[ "{{VERSION}}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "error: VERSION must be X.Y.Z (got '{{VERSION}}')" >&2
+    exit 1
+  fi
+  ./scripts/check-release-readiness.sh "{{VERSION}}"
+  python3 scripts/bump-version.py "{{VERSION}}"
+  git add clients/python/pyproject.toml
+  git commit -S -m "chore: bump version to v{{VERSION}}"
+  git tag -s "v{{VERSION}}" -m "v{{VERSION}}"
+  git push --follow-tags

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Rewrite the version field in clients/python/pyproject.toml."""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+
+def bump_version(toml_path: Path, new_version: str) -> None:
+    """Replace the version line under [project] in *toml_path* with *new_version*.
+
+    Raises SystemExit if the version line is not found.
+    """
+    text = toml_path.read_text(encoding="utf-8")
+
+    in_project = False
+    lines = text.splitlines(keepends=True)
+    new_lines: list[str] = []
+    replaced = False
+
+    for line in lines:
+        if re.match(r"^\[project\]", line):
+            in_project = True
+        elif re.match(r"^\[", line):
+            in_project = False
+
+        if in_project and not replaced and re.match(r'^version\s*=\s*"[^"]*"', line):
+            new_lines.append(f'version = "{new_version}"\n')
+            replaced = True
+        else:
+            new_lines.append(line)
+
+    if not replaced:
+        print(
+            f"error: version line not found under [project] in {toml_path}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    tmp = toml_path.with_suffix(".toml.tmp")
+    tmp.write_text("".join(new_lines), encoding="utf-8")
+    os.replace(tmp, toml_path)
+    print(f"bumped version to {new_version}")
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        print(f"usage: {sys.argv[0]} VERSION", file=sys.stderr)
+        sys.exit(1)
+
+    new_version = sys.argv[1]
+    if not re.fullmatch(r"\d+\.\d+\.\d+", new_version):
+        print(
+            f"error: VERSION must be X.Y.Z (got '{new_version}')",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    repo_root = Path(__file__).resolve().parent.parent
+    toml_path = repo_root / "clients" / "python" / "pyproject.toml"
+
+    if not toml_path.exists():
+        print(f"error: {toml_path} does not exist", file=sys.stderr)
+        sys.exit(1)
+
+    bump_version(toml_path, new_version)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check-release-readiness.sh
+++ b/scripts/check-release-readiness.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 # Verify all prerequisites are in place before pushing a v* tag.
+# Usage: check-release-readiness.sh [VERSION]   e.g. check-release-readiness.sh 0.2.0
+# VERSION defaults to 0.1.0 if omitted (preserves original standalone behaviour).
 # Exits non-zero if any check fails.
 set -euo pipefail
+
+VERSION="${1:-0.1.0}"
 
 REPO="HomericIntelligence/ProjectAgamemnon"
 WORKFLOW="python-client-release.yml"
@@ -42,18 +46,18 @@ print(tags[0]['name'] if tags else '')
     fi
 fi
 
-# 3. No existing v0.1.0 tag
-if git ls-remote --tags origin "refs/tags/v0.1.0" | grep -q v0.1.0; then
-    warn "Tag v0.1.0 already exists on origin — was the release already pushed?"
+# 3. No existing tag for this version
+if git ls-remote --tags origin "refs/tags/v${VERSION}" | grep -q "v${VERSION}"; then
+    warn "Tag v${VERSION} already exists on origin — was the release already pushed?"
 else
-    ok "Tag v0.1.0 does not yet exist (ready to publish)"
+    ok "Tag v${VERSION} does not yet exist (ready to publish)"
 fi
 
 # 4. PyPI package not yet published (pending publisher required for first push)
-if pip index versions "${PYPI_PACKAGE}" 2>/dev/null | grep -q "0.1.0"; then
-    warn "${PYPI_PACKAGE}==0.1.0 is already on PyPI — release may already be complete"
+if pip index versions "${PYPI_PACKAGE}" 2>/dev/null | grep -q "${VERSION}"; then
+    warn "${PYPI_PACKAGE}==${VERSION} is already on PyPI — release may already be complete"
 else
-    ok "${PYPI_PACKAGE}==0.1.0 not yet on PyPI (publish pending)"
+    ok "${PYPI_PACKAGE}==${VERSION} not yet on PyPI (publish pending)"
 fi
 
 # 5. Local main is up-to-date
@@ -85,5 +89,4 @@ echo "  https://pypi.org/manage/account/publishing/"
 echo "  (cannot be verified programmatically)"
 echo ""
 echo "When ready, run:"
-echo "  git tag -s v0.1.0 -m 'release: v0.1.0'"
-echo "  git push origin v0.1.0"
+echo "  just release ${VERSION}"


### PR DESCRIPTION
## Summary

- Adds `scripts/bump-version.py`: atomically rewrites the `version` field under `[project]` in `clients/python/pyproject.toml` using a state-machine line scan (won't touch `[build-system]` or tool sections) and `os.replace` for atomicity; validates `X.Y.Z` semver before writing
- Generalizes `scripts/check-release-readiness.sh` to accept an optional `VERSION` argument (defaults to `0.1.0` to preserve existing standalone behaviour); replaces hardcoded `v0.1.0` references throughout
- Adds `release VERSION` recipe to `justfile`: validates semver, runs readiness check, bumps version, signed commit, signed tag, push with `--follow-tags`
- Simplifies `RELEASING.md` "Cutting a release" section to a single `just release 0.1.0` invocation; prerequisites section is unchanged

## Test plan

- [x] 17 unit tests in `clients/python/tests/test_bump_version.py` cover: happy path bump, confirmation message, `[project]`-section isolation, idempotency, 4 valid semver forms, 6 invalid forms, missing version in toml, missing CLI argument, no `.tmp` file left after success
- [x] All 95 tests pass (`pixi run python -m pytest tests/ -v`)
- [x] No regressions in existing `test_client`, `test_errors`, `test_models` suites

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)