### PR TITLE
test(orchestration): migrate test suite from Keystone and verify green

### DIFF
--- a/clients/python/pixi.lock
+++ b/clients/python/pixi.lock
@@ -5,8 +5,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -59,7 +57,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/e8/39/c61d193b8a1daaa8977f7dea9e8d8ba866e02ea7b65d32f6861693aa4c12/ruff-0.15.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
-      - pypi: ./
+      - pypi: .
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h500dc9f_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.4.22-hbd8a1cb_0.conda
@@ -105,7 +103,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ae/08/a317bc231fb9e7b93e4ef3089501e51922ff88d6936ce5cf870c4fe55419/ruff-0.15.12-py3-none-macosx_10_12_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
-      - pypi: ./
+      - pypi: .
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.4.22-hbd8a1cb_0.conda
@@ -150,7 +148,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/aa/a4/f828e9718d3dce1f5f11c39c4f65afd32783c8b2aebb2e3d259e492c47bd/ruff-0.15.12-py3-none-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
-      - pypi: ./
+      - pypi: .
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.4.22-h4c7d964_0.conda
@@ -198,14 +196,12 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
-      - pypi: ./
+      - pypi: .
   lint:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -269,7 +265,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
-      - pypi: ./
+      - pypi: .
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h500dc9f_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.4.22-hbd8a1cb_0.conda
@@ -326,7 +322,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
-      - pypi: ./
+      - pypi: .
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.4.22-hbd8a1cb_0.conda
@@ -382,7 +378,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
-      - pypi: ./
+      - pypi: .
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.4.22-h4c7d964_0.conda
@@ -440,7 +436,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
-      - pypi: ./
+      - pypi: .
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
   build_number: 20
@@ -655,7 +651,7 @@ packages:
   version: 0.16.0
   sha256: 63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86
   requires_python: '>=3.8'
-- pypi: ./
+- pypi: .
   name: homericintelligence-agamemnon
   version: 0.1.0
   sha256: c9ea8755e4d9f2000276304fadff7d167ed513a7691b96ae432497418449e33c
@@ -665,6 +661,7 @@ packages:
   - eval-type-backport>=0.2 ; python_full_version < '3.10'
   - nats-py>=2.6,<3
   requires_python: '>=3.9'
+  editable: true
 - pypi: https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl
   name: httpcore
   version: 1.0.9
@@ -1444,7 +1441,7 @@ packages:
   - typing-extensions>=4.14.1
   - typing-inspection>=0.4.2
   - email-validator>=2.0.0 ; extra == 'email'
-  - tzdata ; python_full_version >= '3.9' and sys_platform == 'win32' and extra == 'timezone'
+  - tzdata ; python_full_version >= '3.9' and platform_system == 'Windows' and extra == 'timezone'
   requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/20/eb/59980e5f1ae54a3b86372bd9f0fa373ea2d402e8cdcd3459334430f91e91/pydantic_core-2.46.3-cp314-cp314-win_amd64.whl
   name: pydantic-core

--- a/clients/python/pixi.lock
+++ b/clients/python/pixi.lock
@@ -5,6 +5,8 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -42,6 +44,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f2/94/a2025fe442abedf8b038038dab3dba942009ad42b38ea064a1a9e6094241/librt-0.9.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/19/65/0cd9285ab010ee8214c83d67c6b49417c40d86ce46f1aa109457b5a9b8d7/mypy-1.20.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f9/39/0e87753df1072254bac190b33ed34b264f28f6aa9bea0f01b7e818071756/nats_py-2.14.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
@@ -56,7 +59,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/e8/39/c61d193b8a1daaa8977f7dea9e8d8ba866e02ea7b65d32f6861693aa4c12/ruff-0.15.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
-      - pypi: .
+      - pypi: ./
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h500dc9f_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.4.22-hbd8a1cb_0.conda
@@ -87,6 +90,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/cd/c1/184e539543f06ea2912f4b92a5ffaede4f9b392689e3f00acbf8134bee92/librt-0.9.0-cp314-cp314-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/ae/d1/b4ec96b0ecc620a4443570c6e95c867903428cfcde4206518eafdd5880c3/mypy-1.20.2-cp314-cp314-macosx_10_15_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f9/39/0e87753df1072254bac190b33ed34b264f28f6aa9bea0f01b7e818071756/nats_py-2.14.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
@@ -101,7 +105,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ae/08/a317bc231fb9e7b93e4ef3089501e51922ff88d6936ce5cf870c4fe55419/ruff-0.15.12-py3-none-macosx_10_12_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
-      - pypi: .
+      - pypi: ./
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.4.22-hbd8a1cb_0.conda
@@ -131,6 +135,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f3/ad/23399bdcb7afca819acacdef31b37ee59de261bd66b503a7995c03c4b0dc/librt-0.9.0-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/3a/63/d2c2ff4fa66bc49477d32dfa26e8a167ba803ea6a69c5efb416036909d30/mypy-1.20.2-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f9/39/0e87753df1072254bac190b33ed34b264f28f6aa9bea0f01b7e818071756/nats_py-2.14.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
@@ -145,7 +150,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/aa/a4/f828e9718d3dce1f5f11c39c4f65afd32783c8b2aebb2e3d259e492c47bd/ruff-0.15.12-py3-none-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
-      - pypi: .
+      - pypi: ./
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.4.22-h4c7d964_0.conda
@@ -178,6 +183,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/24/ed/c22ca4db0ca3cbc285e4d9206108746beda561a9792289c3c31281d7e9df/librt-0.9.0-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/fd/a1/1b4233d255bdd0b38a1f284feeb1c143ca508c19184964e22f8d837ec851/mypy-1.20.2-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f9/39/0e87753df1072254bac190b33ed34b264f28f6aa9bea0f01b7e818071756/nats_py-2.14.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
@@ -192,12 +198,14 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
-      - pypi: .
+      - pypi: ./
   lint:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -240,6 +248,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/40/dc34d1a8d5f1e51fc64640b62b191684da52ca469da9cd74e84936ffa4a6/msgpack-1.1.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/f9/39/0e87753df1072254bac190b33ed34b264f28f6aa9bea0f01b7e818071756/nats_py-2.14.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b1/2f/c7277b7615a93f51b5fbc1eacfc1b75e8103370e786fd8ce2abf6e5c04ab/packageurl_python-0.17.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3a/eb/fea4d1d51c49832120f7f285d07306db3960f423a2612c6057caf3e8196f/pip-26.1.1-py3-none-any.whl
@@ -260,7 +269,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
-      - pypi: .
+      - pypi: ./
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h500dc9f_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.4.22-hbd8a1cb_0.conda
@@ -296,6 +305,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/22/71/201105712d0a2ff07b7873ed3c220292fb2ea5120603c00c4b634bcdafb3/msgpack-1.1.2-cp314-cp314-macosx_10_13_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/f9/39/0e87753df1072254bac190b33ed34b264f28f6aa9bea0f01b7e818071756/nats_py-2.14.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b1/2f/c7277b7615a93f51b5fbc1eacfc1b75e8103370e786fd8ce2abf6e5c04ab/packageurl_python-0.17.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3a/eb/fea4d1d51c49832120f7f285d07306db3960f423a2612c6057caf3e8196f/pip-26.1.1-py3-none-any.whl
@@ -316,7 +326,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
-      - pypi: .
+      - pypi: ./
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.4.22-hbd8a1cb_0.conda
@@ -351,6 +361,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1b/9f/38ff9e57a2eade7bf9dfee5eae17f39fc0e998658050279cbb14d97d36d9/msgpack-1.1.2-cp314-cp314-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/f9/39/0e87753df1072254bac190b33ed34b264f28f6aa9bea0f01b7e818071756/nats_py-2.14.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b1/2f/c7277b7615a93f51b5fbc1eacfc1b75e8103370e786fd8ce2abf6e5c04ab/packageurl_python-0.17.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3a/eb/fea4d1d51c49832120f7f285d07306db3960f423a2612c6057caf3e8196f/pip-26.1.1-py3-none-any.whl
@@ -371,7 +382,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
-      - pypi: .
+      - pypi: ./
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.4.22-h4c7d964_0.conda
@@ -408,6 +419,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6e/f1/abd09c2ae91228c5f3998dbd7f41353def9eac64253de3c8105efa2082f7/msgpack-1.1.2-cp314-cp314-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/f9/39/0e87753df1072254bac190b33ed34b264f28f6aa9bea0f01b7e818071756/nats_py-2.14.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b1/2f/c7277b7615a93f51b5fbc1eacfc1b75e8103370e786fd8ce2abf6e5c04ab/packageurl_python-0.17.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3a/eb/fea4d1d51c49832120f7f285d07306db3960f423a2612c6057caf3e8196f/pip-26.1.1-py3-none-any.whl
@@ -428,7 +440,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
-      - pypi: .
+      - pypi: ./
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
   build_number: 20
@@ -643,16 +655,16 @@ packages:
   version: 0.16.0
   sha256: 63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86
   requires_python: '>=3.8'
-- pypi: .
+- pypi: ./
   name: homericintelligence-agamemnon
   version: 0.1.0
-  sha256: d7146612cac95fdbfe6af248cebe4eb5c8dda6b045fca54166077bde20b2b452
+  sha256: c9ea8755e4d9f2000276304fadff7d167ed513a7691b96ae432497418449e33c
   requires_dist:
   - httpx>=0.27,<1
   - pydantic>=2.0,<3
   - eval-type-backport>=0.2 ; python_full_version < '3.10'
+  - nats-py>=2.6,<3
   requires_python: '>=3.9'
-  editable: true
 - pypi: https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl
   name: httpcore
   version: 1.0.9
@@ -1233,6 +1245,15 @@ packages:
   version: 1.1.0
   sha256: 1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505
   requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/f9/39/0e87753df1072254bac190b33ed34b264f28f6aa9bea0f01b7e818071756/nats_py-2.14.0-py3-none-any.whl
+  name: nats-py
+  version: 2.14.0
+  sha256: 4116f5d2233ce16e63c3d5538fa40a5e207f75fcf42a741773929ddf1e29d19d
+  requires_dist:
+  - nkeys ; extra == 'nkeys'
+  - aiohttp ; extra == 'aiohttp'
+  - fast-mail-parser ; extra == 'fast-parse'
+  requires_python: '>=3.7'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
   sha256: fc89f74bbe362fb29fa3c037697a89bec140b346a2469a90f7936d1d7ea4d8a3
   md5: fc21868a1a5aacc937e7a18747acb8a5
@@ -1423,7 +1444,7 @@ packages:
   - typing-extensions>=4.14.1
   - typing-inspection>=0.4.2
   - email-validator>=2.0.0 ; extra == 'email'
-  - tzdata ; python_full_version >= '3.9' and platform_system == 'Windows' and extra == 'timezone'
+  - tzdata ; python_full_version >= '3.9' and sys_platform == 'win32' and extra == 'timezone'
   requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/20/eb/59980e5f1ae54a3b86372bd9f0fa373ea2d402e8cdcd3459334430f91e91/pydantic_core-2.46.3-cp314-cp314-win_amd64.whl
   name: pydantic-core

--- a/clients/python/pixi.toml
+++ b/clients/python/pixi.toml
@@ -12,6 +12,7 @@ python = ">=3.9,<4"
 "HomericIntelligence-Agamemnon" = { path = ".", editable = true }
 httpx = ">=0.27,<1"
 pydantic = ">=2.0,<3"
+nats-py = ">=2.6,<3"
 
 [feature.dev.pypi-dependencies]
 pytest = ">=8.0,<9"

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -13,13 +13,14 @@ dependencies = [
     "httpx>=0.27,<1",
     "pydantic>=2.0,<3",
     "eval_type_backport>=0.2; python_version < '3.10'",
+    "nats-py>=2.6,<3",
 ]
 
 [project.urls]
 Repository = "https://github.com/HomericIntelligence/ProjectAgamemnon"
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/agamemnon_client"]
+packages = ["src/agamemnon_client", "src/agamemnon"]
 
 [tool.ruff]
 line-length = 100
@@ -31,7 +32,7 @@ select = ["E", "F", "I", "UP"]
 [tool.mypy]
 strict = true
 python_version = "3.9"
-packages = ["agamemnon_client"]
+packages = ["agamemnon_client", "agamemnon"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
@@ -39,9 +40,10 @@ testpaths = ["tests"]
 filterwarnings = [
     "ignore::DeprecationWarning:pytest_asyncio",
 ]
+pythonpath = ["src", "tests"]
 
 [tool.coverage.run]
-source = ["agamemnon_client"]
+source = ["agamemnon_client", "agamemnon"]
 
 [tool.coverage.report]
 fail_under = 96

--- a/clients/python/src/agamemnon/__init__.py
+++ b/clients/python/src/agamemnon/__init__.py
@@ -1,0 +1,1 @@
+# agamemnon namespace package

--- a/clients/python/src/agamemnon/orchestration/__init__.py
+++ b/clients/python/src/agamemnon/orchestration/__init__.py
@@ -1,0 +1,17 @@
+"""Agamemnon orchestration layer — migrated from ProjectKeystone."""
+
+from agamemnon.orchestration.models import (
+    TERMINAL_STATUSES,
+    Agent,
+    Task,
+    TaskEvent,
+    resolve_event_status,
+)
+
+__all__ = [
+    "TERMINAL_STATUSES",
+    "Agent",
+    "Task",
+    "TaskEvent",
+    "resolve_event_status",
+]

--- a/clients/python/src/agamemnon/orchestration/config.py
+++ b/clients/python/src/agamemnon/orchestration/config.py
@@ -1,0 +1,27 @@
+"""Configuration settings for the Agamemnon orchestration daemon."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+
+
+@dataclass
+class Settings:
+    """Runtime configuration for the Agamemnon orchestration daemon.
+
+    All values can be overridden via environment variables.
+    """
+
+    log_level: str = field(default_factory=lambda: os.environ.get("KEYSTONE_LOG_LEVEL", "INFO"))
+    poll_interval: float = field(
+        default_factory=lambda: float(os.environ.get("KEYSTONE_POLL_INTERVAL", "1.0"))
+    )
+    shutdown_timeout: float = field(
+        default_factory=lambda: float(os.environ.get("KEYSTONE_SHUTDOWN_TIMEOUT", "30.0"))
+    )
+
+
+def load_settings() -> Settings:
+    """Load settings from environment variables with defaults."""
+    return Settings()

--- a/clients/python/src/agamemnon/orchestration/daemon.py
+++ b/clients/python/src/agamemnon/orchestration/daemon.py
@@ -1,0 +1,140 @@
+"""Agamemnon orchestration daemon — routes messages between publishers and subscribers."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging as stdlib_logging
+import signal
+import sys
+import time
+from typing import Any
+
+from agamemnon.orchestration.config import Settings, load_settings
+from agamemnon.orchestration.logging import KeystoneLogger, configure_logging, get_logger
+from agamemnon.orchestration.nats_listener import NATSListener
+from agamemnon.orchestration.task_claimer import TaskClaimer
+
+logger: KeystoneLogger = get_logger(component="daemon")
+
+_shutdown_event: asyncio.Event | None = None
+
+
+def handle_sigterm(signum: int, frame: Any) -> None:
+    """Handle SIGTERM by raising SystemExit so cleanup runs."""
+    raise SystemExit(0)
+
+
+def _handle_signal(signum: int, listener: NATSListener) -> None:
+    """Set the shutdown event and stop the listener from accepting new events."""
+    logger.info("shutdown_signal_received", signal=signum)
+    listener.begin_shutdown()
+    if _shutdown_event is not None:
+        _shutdown_event.set()
+
+
+def run_routing_loop(poll_interval: float = 1.0) -> None:
+    """Run the main message-routing loop until interrupted."""
+    logger.info("routing_loop_started", poll_interval=poll_interval)
+    try:
+        while True:
+            time.sleep(poll_interval)
+    except (KeyboardInterrupt, SystemExit):
+        logger.info("routing_loop_stopped")
+
+
+def assign_task(team_id: str, task_id: str, agent_id: str) -> None:
+    """Record a task assignment in the structured log."""
+    logger.info(
+        "task_assigned",
+        team_id=team_id,
+        task_id=task_id,
+        agent_id=agent_id,
+    )
+
+
+async def run(settings: Settings) -> int:
+    """Run the daemon until a shutdown signal is received.
+
+    Shutdown sequence:
+    1. Stop accepting new NATS events (begin_shutdown).
+    2. Wait for in-flight advance_dag calls to complete (drain with timeout).
+    3. Drain the NATS connection (listener.stop).
+    """
+    global _shutdown_event
+    _shutdown_event = asyncio.Event()
+
+    async def _noop_get_tasks(team_id: str) -> list[dict[str, Any]]:
+        return []
+
+    async def _noop_claim_task(team_id: str, task_id: str) -> bool:
+        return False
+
+    task_claimer = TaskClaimer(
+        get_tasks=_noop_get_tasks,
+        claim_task=_noop_claim_task,
+    )
+    listener = NATSListener(task_claimer)
+
+    loop = asyncio.get_running_loop()
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        loop.add_signal_handler(sig, _handle_signal, sig, listener)
+
+    logger.info("daemon_started")
+    try:
+        await _shutdown_event.wait()
+    finally:
+        drained = await task_claimer.drain(settings.shutdown_timeout)
+        if not drained:
+            logger.warning("drain_incomplete_forcing_shutdown")
+        try:
+            await listener.stop()
+        except Exception as exc:  # noqa: BLE001
+            logger.error("nats_stop_error", error=str(exc))
+
+    logger.info("daemon_stopped")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point for the Agamemnon orchestration daemon."""
+    parser = argparse.ArgumentParser(description="Agamemnon orchestration daemon")
+    parser.add_argument(
+        "--log-level",
+        default=None,
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        help="Logging verbosity level (default: from KEYSTONE_LOG_LEVEL env var or INFO)",
+    )
+    parser.add_argument(
+        "--poll-interval",
+        type=float,
+        default=1.0,
+        help="Routing loop poll interval in seconds",
+    )
+    parser.add_argument(
+        "--shutdown-timeout",
+        type=float,
+        default=None,
+        help="Seconds to wait for in-flight operations during shutdown",
+    )
+    args = parser.parse_args(argv)
+
+    settings = load_settings()
+    if args.log_level is not None:
+        settings.log_level = args.log_level
+    if args.shutdown_timeout is not None:
+        settings.shutdown_timeout = args.shutdown_timeout
+
+    configure_logging(level=getattr(stdlib_logging, settings.log_level))
+    signal.signal(signal.SIGTERM, handle_sigterm)
+
+    logger.info("daemon_starting", log_level=settings.log_level)
+    try:
+        return asyncio.run(run(settings))
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("daemon_error", error=str(exc))
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/clients/python/src/agamemnon/orchestration/dag_walker.py
+++ b/clients/python/src/agamemnon/orchestration/dag_walker.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Any, Optional
+from typing import Any
 
-from agamemnon.orchestration.models import Agent, Task, TERMINAL_STATUSES
+from agamemnon.orchestration.models import TERMINAL_STATUSES, Agent, Task
 
 logger = logging.getLogger(__name__)
 
@@ -16,14 +16,14 @@ class DAGWalker:
         self,
         tasks: list[Task],
         agents: list[Agent],
-        client: Optional[Any] = None,
+        client: Any | None = None,
         scan_interval: float = 60.0,
     ) -> None:
         self.tasks = tasks
         self.agents = agents
         self.client = client
         self.scan_interval = scan_interval
-        self._scan_task: Optional[asyncio.Task[None]] = None
+        self._scan_task: asyncio.Task[None] | None = None
 
     def get_available_agents(self) -> list[Agent]:
         """Return agents that are active, online, and not currently assigned a task."""
@@ -204,7 +204,7 @@ class DAGWalker:
 
     def start_background_scan(
         self, stop_event: asyncio.Event
-    ) -> "asyncio.Task[None]":
+    ) -> asyncio.Task[None]:
         """Schedule a background scan loop and return the created task (issue #98).
 
         The caller is responsible for cancelling or awaiting the returned task on

--- a/clients/python/src/agamemnon/orchestration/dag_walker.py
+++ b/clients/python/src/agamemnon/orchestration/dag_walker.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Optional
+
+from agamemnon.orchestration.models import Agent, Task, TERMINAL_STATUSES
+
+logger = logging.getLogger(__name__)
+
+
+class DAGWalker:
+    """Walks a task DAG and assigns ready tasks to available agents."""
+
+    def __init__(
+        self,
+        tasks: list[Task],
+        agents: list[Agent],
+        client: Optional[Any] = None,
+        scan_interval: float = 60.0,
+    ) -> None:
+        self.tasks = tasks
+        self.agents = agents
+        self.client = client
+        self.scan_interval = scan_interval
+        self._scan_task: Optional[asyncio.Task[None]] = None
+
+    def get_available_agents(self) -> list[Agent]:
+        """Return agents that are active, online, and not currently assigned a task."""
+        return [
+            a
+            for a in self.agents
+            if a.status == "active"
+            and a.session_status == "online"
+            and a.current_task_id is None
+        ]
+
+    def get_ready_tasks(self) -> list[Task]:
+        """Return tasks whose dependencies are all in terminal status."""
+        completed_ids = {
+            t.id for t in self.tasks if t.status in TERMINAL_STATUSES
+        }
+        return [
+            t
+            for t in self.tasks
+            if t.status == "pending"
+            and t.assigned_agent_id is None
+            and all(dep in completed_ids for dep in t.dependencies)
+        ]
+
+    def _find_cycle_path(self) -> list[str]:
+        """Return the IDs of tasks forming a cycle, or an empty list if the DAG is acyclic.
+
+        Uses an iterative three-color DFS (WHITE/GRAY/BLACK) with parent tracking to
+        reconstruct the cycle path when a back-edge is found.  An unknown dependency ID
+        (one not present in ``self.tasks``) raises :exc:`ValueError` immediately.
+        """
+        task_ids = {t.id for t in self.tasks}
+
+        # Validate all dependency IDs before traversal (Issue #233).
+        for t in self.tasks:
+            for dep_id in t.dependencies:
+                if dep_id not in task_ids:
+                    raise ValueError(
+                        f"Unknown dependency {dep_id!r} referenced by task {t.id!r}"
+                    )
+
+        adj: dict[str, list[str]] = {t.id: list(t.dependencies) for t in self.tasks}
+
+        WHITE, GRAY, BLACK = 0, 1, 2
+        color: dict[str, int] = {t.id: WHITE for t in self.tasks}
+        # parent[node] = the node that first pushed *node* onto the DFS stack
+        parent: dict[str, str | None] = {t.id: None for t in self.tasks}
+
+        for start in task_ids:
+            if color[start] != WHITE:
+                continue
+
+            # Stack holds (node_id, processed) tuples.
+            # processed=False: first visit — mark GRAY, push neighbors.
+            # processed=True:  all neighbors done — mark BLACK.
+            stack: list[tuple[str, bool]] = [(start, False)]
+
+            while stack:
+                node, processed = stack.pop()
+
+                if processed:
+                    color[node] = BLACK
+                    continue
+
+                if color[node] == GRAY:
+                    # Back-edge detected; reconstruct cycle starting from *node*.
+                    cycle: list[str] = [node]
+                    cur: str | None = parent[node]
+                    while cur is not None and cur != node:
+                        cycle.append(cur)
+                        cur = parent[cur]
+                    cycle.append(node)
+                    cycle.reverse()
+                    return cycle
+
+                if color[node] == BLACK:
+                    continue
+
+                color[node] = GRAY
+                stack.append((node, True))
+                for neighbor in adj[node]:
+                    if color[neighbor] == GRAY:
+                        # Immediate back-edge to an already-gray neighbor.
+                        cycle = [neighbor]
+                        cur2: str | None = node
+                        while cur2 is not None and cur2 != neighbor:
+                            cycle.append(cur2)
+                            cur2 = parent[cur2]
+                        cycle.append(neighbor)
+                        cycle.reverse()
+                        return cycle
+                    if color[neighbor] == WHITE:
+                        parent[neighbor] = node
+                        stack.append((neighbor, False))
+
+        return []
+
+    def validate_no_cycles(self) -> bool:
+        """Return True if the task DAG is acyclic, False if a cycle exists.
+
+        Delegates to :meth:`_find_cycle_path`.  Unknown dependency IDs cause a
+        :exc:`ValueError` to be raised (see :meth:`_find_cycle_path`).
+        """
+        return len(self._find_cycle_path()) == 0
+
+    async def advance_dag(self) -> list[tuple[Task, Agent]]:
+        """Assign ready tasks to available agents, returning the assignments made.
+
+        When a ``client`` is configured and it exposes a ``get_agents()`` coroutine,
+        the method fetches a fresh agent list before evaluating availability (issue
+        #196).  This prevents double-assignment races caused by a stale cached list.
+
+        Raises :exc:`ValueError` if the task DAG contains a cycle or if any task
+        references an unknown dependency ID.  Agents are marked busy immediately upon
+        selection so a single call cannot double-assign the same agent even if the
+        local list is stale.
+        """
+        cycle_path = self._find_cycle_path()
+        if cycle_path:
+            raise ValueError(f"Cycle detected in task DAG: {cycle_path}")
+
+        # Issue #196: refresh the agent list from the client before assigning so
+        # that stale in-memory state doesn't cause double-assignment.
+        if self.client is not None and hasattr(self.client, "get_agents"):
+            try:
+                fresh_agents = await self.client.get_agents()
+                if fresh_agents is not None:
+                    self.agents = fresh_agents
+            except Exception:  # noqa: BLE001
+                logger.warning(
+                    "advance_dag: get_agents() failed — falling back to cached list",
+                    exc_info=True,
+                )
+
+        assignments: list[tuple[Task, Agent]] = []
+        available = self.get_available_agents()
+
+        for task in self.get_ready_tasks():
+            if not available:
+                break
+
+            agent = available.pop(0)
+            # Mark agent busy immediately — guards against double-assignment within
+            # this call if the list was stale when we entered.
+            agent.current_task_id = task.id
+            task.assigned_agent_id = agent.id
+
+            if self.client is not None:
+                await self.client.assign_task(task.id, agent.id)
+
+            assignments.append((task, agent))
+
+        return assignments
+
+    async def _background_scan_loop(self, stop_event: asyncio.Event) -> None:
+        """Periodically call :meth:`advance_dag` as a safety net (issue #98).
+
+        Uses ``asyncio.wait_for`` on *stop_event* so the loop wakes up
+        immediately on shutdown rather than sleeping for the full interval.
+        """
+        logger.info(
+            "DAGWalker background scan started (interval=%.1fs)", self.scan_interval
+        )
+        while not stop_event.is_set():
+            try:
+                await asyncio.wait_for(
+                    stop_event.wait(), timeout=self.scan_interval
+                )
+                # stop_event was set — exit cleanly.
+                break
+            except asyncio.TimeoutError:
+                pass
+            try:
+                await self.advance_dag()
+            except Exception:  # noqa: BLE001
+                logger.exception("DAGWalker background scan failed — continuing")
+        logger.info("DAGWalker background scan stopped")
+
+    def start_background_scan(
+        self, stop_event: asyncio.Event
+    ) -> "asyncio.Task[None]":
+        """Schedule a background scan loop and return the created task (issue #98).
+
+        The caller is responsible for cancelling or awaiting the returned task on
+        shutdown.  Passing *stop_event* allows a graceful, prompt exit.
+        """
+        self._scan_task = asyncio.create_task(
+            self._background_scan_loop(stop_event), name="dag-background-scan"
+        )
+        return self._scan_task

--- a/clients/python/src/agamemnon/orchestration/logging.py
+++ b/clients/python/src/agamemnon/orchestration/logging.py
@@ -1,0 +1,135 @@
+"""Structured JSON logging for Agamemnon using stdlib only."""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+import threading
+from datetime import datetime, timezone
+from typing import Any
+
+# Pre-computed baseline attributes of a LogRecord to detect extra fields.
+_BASELINE_ATTRS: frozenset[str] = frozenset(
+    logging.LogRecord("", 0, "", 0, "", (), None).__dict__
+)
+
+# Reserved top-level field names that would conflict with the log schema.
+_RESERVED_FIELDS = frozenset({"timestamp", "level", "logger", "message", "exception"})
+
+
+class JsonFormatter(logging.Formatter):
+    """Formats log records as single-line JSON objects."""
+
+    def __init__(
+        self, *args: Any, include_location: bool = False, **kwargs: Any
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self._include_location = include_location
+
+    def format(self, record: logging.LogRecord) -> str:
+        output: dict[str, Any] = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+
+        # Add location fields if requested.
+        if self._include_location:
+            output["pathname"] = record.pathname
+            output["lineno"] = record.lineno
+            output["funcName"] = record.funcName
+
+        # Promote extra fields injected by the caller.
+        for key, value in record.__dict__.items():
+            if key not in _BASELINE_ATTRS:
+                dest_key = f"ctx_{key}" if key in _RESERVED_FIELDS else key
+                output[dest_key] = value
+
+        if record.exc_info:
+            output["exception"] = self.formatException(record.exc_info)
+
+        return json.dumps(output, default=str)
+
+
+class KeystoneLogger:
+    """Thread-safe logger that binds context fields to every log record."""
+
+    def __init__(self, logger: logging.Logger, context: dict[str, Any]) -> None:
+        self._logger = logger
+        self._context: dict[str, Any] = dict(context)
+        self._lock = threading.Lock()
+
+    def _log(self, level: int, msg: str, **kwargs: Any) -> None:
+        with self._lock:
+            ctx = dict(self._context)
+        extra = {**kwargs, **ctx}
+        self._logger.log(level, msg, extra=extra)
+
+    def debug(self, msg: str, **kwargs: Any) -> None:
+        """Log a DEBUG message with optional context fields."""
+        self._log(logging.DEBUG, msg, **kwargs)
+
+    def info(self, msg: str, **kwargs: Any) -> None:
+        """Log an INFO message with optional context fields."""
+        self._log(logging.INFO, msg, **kwargs)
+
+    def warning(self, msg: str, **kwargs: Any) -> None:
+        """Log a WARNING message with optional context fields."""
+        self._log(logging.WARNING, msg, **kwargs)
+
+    def error(self, msg: str, **kwargs: Any) -> None:
+        """Log an ERROR message with optional context fields."""
+        self._log(logging.ERROR, msg, **kwargs)
+
+    def exception(self, msg: str, **kwargs: Any) -> None:
+        """Log an ERROR message with exception info."""
+        extra = {**kwargs}
+        with self._lock:
+            extra.update(self._context)
+        self._logger.exception(msg, extra=extra)
+
+    def bind(self, **extra: object) -> KeystoneLogger:
+        """Return a new KeystoneLogger with merged context fields.
+
+        The returned logger includes all existing context plus the given extra fields.
+        If a field name exists in both, the extra field takes precedence.
+        """
+        with self._lock:
+            merged_context = {**self._context, **extra}
+        return KeystoneLogger(self._logger, merged_context)
+
+
+def configure_logging(level: int = logging.INFO) -> None:
+    """Configure the root logger with JSON output on stderr.
+
+    Safe to call multiple times — will not add duplicate handlers.
+    """
+    root = logging.getLogger()
+    root.setLevel(level)
+
+    # Avoid adding a second StreamHandler if one already exists.
+    for handler in root.handlers:
+        if isinstance(handler, logging.StreamHandler) and handler.stream is sys.stderr:
+            handler.setLevel(level)
+            return
+
+    handler = logging.StreamHandler(sys.stderr)
+    handler.setLevel(level)
+    handler.setFormatter(JsonFormatter())
+    root.addHandler(handler)
+
+
+def get_logger(*, component: str = "", **context: Any) -> KeystoneLogger:
+    """Return a KeystoneLogger bound to the given component and context.
+
+    Args:
+        component: Appended to the ``keystone.`` logger name prefix.
+        **context: Key-value pairs pre-bound to every log record.
+
+    Returns:
+        A :class:`KeystoneLogger` wrapping ``logging.getLogger(name)``.
+    """
+    name = f"keystone.{component}" if component else "keystone"
+    return KeystoneLogger(logging.getLogger(name), context)

--- a/clients/python/src/agamemnon/orchestration/models.py
+++ b/clients/python/src/agamemnon/orchestration/models.py
@@ -1,17 +1,16 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import Any
 
 from pydantic import BaseModel, ConfigDict, model_validator
-
 
 TERMINAL_STATUSES: frozenset[str] = frozenset({"completed", "failed", "error", "cancelled"})
 
 
 def resolve_event_status(
     status: str | None,
-    data: dict | None,
+    data: dict[str, Any] | None,
     new_status: str | None,
 ) -> str | None:
     """Resolve effective status from three possible sources in priority order.
@@ -32,7 +31,7 @@ class Task:
     title: str
     status: str
     dependencies: list[str] = field(default_factory=list)
-    assigned_agent_id: Optional[str] = None
+    assigned_agent_id: str | None = None
 
 
 @dataclass
@@ -44,7 +43,7 @@ class Agent:
     session_status: str = "online"
     task_description: str = ""
     program: str = ""
-    current_task_id: Optional[str] = None
+    current_task_id: str | None = None
 
 
 class TaskEvent(BaseModel):
@@ -63,7 +62,7 @@ class TaskEvent(BaseModel):
 
     status: str | None = None
     newStatus: str | None = None  # noqa: N815 — matches camelCase JSON payload
-    data: dict | None = None
+    data: dict[str, Any] | None = None
     taskId: str | None = None  # noqa: N815
     teamId: str | None = None  # noqa: N815
     effective_status: str | None = None

--- a/clients/python/src/agamemnon/orchestration/models.py
+++ b/clients/python/src/agamemnon/orchestration/models.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, model_validator
+
+
+TERMINAL_STATUSES: frozenset[str] = frozenset({"completed", "failed", "error", "cancelled"})
+
+
+def resolve_event_status(
+    status: str | None,
+    data: dict | None,
+    new_status: str | None,
+) -> str | None:
+    """Resolve effective status from three possible sources in priority order.
+
+    Priority: status > data["status"] > new_status
+    """
+    resolved = status
+    if not resolved and data:
+        resolved = data.get("status")
+    if not resolved:
+        resolved = new_status
+    return resolved
+
+
+@dataclass
+class Task:
+    id: str
+    title: str
+    status: str
+    dependencies: list[str] = field(default_factory=list)
+    assigned_agent_id: Optional[str] = None
+
+
+@dataclass
+class Agent:
+    id: str
+    name: str
+    host: str = ""
+    status: str = "active"
+    session_status: str = "online"
+    task_description: str = ""
+    program: str = ""
+    current_task_id: Optional[str] = None
+
+
+class TaskEvent(BaseModel):
+    """Validated NATS task event payload.
+
+    Normalizes status from three possible locations:
+    1. Top-level ``status`` field
+    2. Nested ``data.status`` (Hermes format per issue #107)
+    3. ``newStatus`` field
+
+    All fields are optional — NATS payloads can be sparse or use different
+    schemas depending on the emitting component.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: str | None = None
+    newStatus: str | None = None  # noqa: N815 — matches camelCase JSON payload
+    data: dict | None = None
+    taskId: str | None = None  # noqa: N815
+    teamId: str | None = None  # noqa: N815
+    effective_status: str | None = None
+
+    @model_validator(mode="after")
+    def _resolve_effective_status(self) -> TaskEvent:
+        self.effective_status = resolve_event_status(self.status, self.data, self.newStatus)
+        return self

--- a/clients/python/src/agamemnon/orchestration/nats_listener.py
+++ b/clients/python/src/agamemnon/orchestration/nats_listener.py
@@ -9,7 +9,6 @@ from typing import Any, Protocol
 
 import nats.errors
 import nats.js.errors
-
 from pydantic import ValidationError
 
 from agamemnon.orchestration.models import TaskEvent
@@ -21,7 +20,7 @@ logger = logging.getLogger(__name__)
 class TaskClaimer(Protocol):
     """Protocol for objects that can handle advance_dag_tracked calls."""
 
-    def advance_dag_tracked(self, team_id: str) -> None:
+    def advance_dag_tracked(self, team_id: str) -> asyncio.Task[Any]:
         ...
 
 
@@ -233,7 +232,8 @@ class NATSListener:
         parts = subject.split(".")
         if len(parts) != NATSListener._SUBJECT_PART_COUNT:
             raise ValueError(
-                f"Expected {NATSListener._SUBJECT_PART_COUNT} subject parts, got {len(parts)}: {subject!r}"
+                f"Expected {NATSListener._SUBJECT_PART_COUNT} subject parts,"
+                f" got {len(parts)}: {subject!r}"
             )
         return parts[2], parts[3]  # team_id, task_id
 

--- a/clients/python/src/agamemnon/orchestration/nats_listener.py
+++ b/clients/python/src/agamemnon/orchestration/nats_listener.py
@@ -1,0 +1,242 @@
+"""NATS event listener with input validation and graceful shutdown support."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Any, Protocol
+
+import nats.errors
+import nats.js.errors
+
+from pydantic import ValidationError
+
+from agamemnon.orchestration.models import TaskEvent
+from agamemnon.orchestration.validation import validate_id
+
+logger = logging.getLogger(__name__)
+
+
+class TaskClaimer(Protocol):
+    """Protocol for objects that can handle advance_dag_tracked calls."""
+
+    def advance_dag_tracked(self, team_id: str) -> None:
+        ...
+
+
+class NATSListener:
+    """Listens for NATS task events and dispatches advance_dag calls.
+
+    Subjects follow the pattern ``hi.tasks.{team_id}.{task_id}.{event}``.
+    Both ``team_id`` and ``task_id`` are validated before dispatch to prevent
+    path traversal or injection from malformed NATS messages.
+
+    Event payloads are parsed through :class:`~agamemnon.orchestration.models.TaskEvent` for
+    type-safe, validated deserialization. Both flat (``{"status": "completed"}``)
+    and Hermes-nested (``{"data": {"status": "completed"}}``) formats are handled.
+
+    Once :meth:`begin_shutdown` is called, new events are logged and dropped
+    without being dispatched — allowing in-flight operations started before
+    shutdown to complete undisturbed.
+    """
+
+    _SUBJECT_PART_COUNT = 5
+
+    def __init__(self, task_claimer: TaskClaimer) -> None:
+        self._task_claimer = task_claimer
+        self._shutting_down: bool = False
+
+    @property
+    def shutting_down(self) -> bool:
+        """Return True if this listener is in shutdown mode."""
+        return self._shutting_down
+
+    def begin_shutdown(self) -> None:
+        """Stop accepting new NATS events.
+
+        After this call, :meth:`_on_task_event` will log and drop any incoming
+        events rather than dispatching them to advance_dag.
+        """
+        self._shutting_down = True
+        logger.info("nats_listener_shutdown_started")
+
+    async def start(
+        self,
+        nc: Any,
+        subject: str = "hi.tasks.>",
+        *,
+        stream: str = "homeric-tasks",
+        max_retries: int = 5,
+        retry_base_delay: float = 1.0,
+    ) -> None:
+        """Subscribe to a JetStream subject, retrying with backoff on stream-not-found.
+
+        Args:
+            nc: An active ``nats.aio.client.Client`` connection.
+            subject: The NATS subject pattern to subscribe to.
+            stream: The JetStream stream name (used in error messages).
+            max_retries: Number of retry attempts when the stream is not found.
+            retry_base_delay: Initial delay (seconds) before the first retry;
+                doubles on each subsequent attempt.
+
+        Raises:
+            ConnectionError: If the NATS server is unreachable or authentication fails.
+            RuntimeError: If the stream is not found after all retries are exhausted,
+                or if JetStream is not available on the server.
+        """
+        js = nc.jetstream()
+        last_exc: Exception | None = None
+        delay = retry_base_delay
+
+        for attempt in range(1, max_retries + 1):
+            try:
+                await js.subscribe(subject)
+                logger.info(
+                    "nats_listener_subscribed",
+                    extra={"subject": subject, "stream": stream},
+                )
+                return
+            except nats.js.errors.NotFoundError as exc:
+                last_exc = exc
+                logger.warning(
+                    "nats_stream_not_found",
+                    extra={
+                        "stream": stream,
+                        "subject": subject,
+                        "attempt": attempt,
+                        "max_retries": max_retries,
+                        "retry_delay_seconds": delay,
+                        "error": str(exc),
+                    },
+                )
+                if attempt < max_retries:
+                    await asyncio.sleep(delay)
+                    delay *= 2
+            except nats.errors.NoServersError as exc:
+                logger.error(
+                    "nats_no_servers",
+                    extra={"subject": subject, "stream": stream, "error": str(exc)},
+                )
+                raise ConnectionError(
+                    f"NATS server unreachable — cannot subscribe to '{subject}': {exc}"
+                ) from exc
+            except (
+                nats.errors.AuthorizationError,
+                nats.errors.InvalidUserCredentialsError,
+            ) as exc:
+                logger.error(
+                    "nats_auth_error",
+                    extra={"subject": subject, "stream": stream, "error": str(exc)},
+                )
+                raise ConnectionError(
+                    f"NATS authentication failed — cannot subscribe to '{subject}': {exc}"
+                ) from exc
+            except nats.js.errors.ServiceUnavailableError as exc:
+                logger.error(
+                    "nats_jetstream_unavailable",
+                    extra={"subject": subject, "stream": stream, "error": str(exc)},
+                )
+                raise RuntimeError(
+                    "JetStream is not enabled on the connected NATS server"
+                ) from exc
+
+        logger.error(
+            "nats_stream_not_found_fatal",
+            extra={
+                "stream": stream,
+                "subject": subject,
+                "attempts": max_retries,
+                "error": str(last_exc),
+            },
+        )
+        raise RuntimeError(
+            f"NATS stream for task events not found — ensure stream '{stream}' is "
+            f"configured (tried {max_retries} time(s)): {last_exc}"
+        ) from last_exc
+
+    async def _on_task_event(
+        self,
+        subject: str,
+        team_id: str,
+        task_id: str,
+        raw_payload: bytes | None = None,
+    ) -> None:
+        """Handle an incoming NATS task event, validating IDs and payload before dispatch.
+
+        Validates both ``team_id`` and ``task_id`` extracted from the NATS subject.
+        If a raw payload is provided, it is parsed through
+        :class:`~agamemnon.orchestration.models.TaskEvent` for type-safe deserialization.
+        Malformed IDs or invalid JSON produce a warning log and the event is dropped
+        without raising.
+
+        Args:
+            subject: The full NATS subject string (used for log context).
+            team_id: The team ID extracted from the subject parts.
+            task_id: The task ID extracted from the subject parts.
+            raw_payload: Optional raw message bytes to parse as a TaskEvent.
+        """
+        if self._shutting_down:
+            logger.info(
+                "nats_event_dropped_during_shutdown",
+                extra={"team_id": team_id, "subject": subject},
+            )
+            return
+
+        try:
+            validate_id(team_id, "team_id")
+            validate_id(task_id, "task_id")
+        except ValueError as exc:
+            logger.warning(
+                "nats_event_dropped_invalid_id",
+                extra={"subject": subject, "error": str(exc)},
+            )
+            return
+
+        event: TaskEvent | None = None
+        if raw_payload is not None:
+            try:
+                payload_dict: Any = json.loads(raw_payload.decode())
+            except Exception as exc:
+                logger.warning(
+                    "nats_event_dropped_invalid_json",
+                    extra={"subject": subject, "error": str(exc)},
+                )
+                return
+
+            try:
+                event = TaskEvent.model_validate(payload_dict)
+            except ValidationError as exc:
+                logger.warning(
+                    "nats_event_dropped_invalid_payload",
+                    extra={"subject": subject, "error": str(exc)},
+                )
+                return
+
+        logger.debug(
+            "nats_event_received",
+            extra={
+                "team_id": team_id,
+                "task_id": task_id,
+                "subject": subject,
+                "effective_status": event.effective_status if event else None,
+            },
+        )
+        self._task_claimer.advance_dag_tracked(team_id)
+
+    @staticmethod
+    def _parse_subject(subject: str) -> tuple[str, str]:
+        """Parse NATS subject 'hi.tasks.{team_id}.{task_id}.{event}' into (team_id, task_id).
+
+        Raises ValueError if the subject does not have the expected 5-part structure.
+        """
+        parts = subject.split(".")
+        if len(parts) != NATSListener._SUBJECT_PART_COUNT:
+            raise ValueError(
+                f"Expected {NATSListener._SUBJECT_PART_COUNT} subject parts, got {len(parts)}: {subject!r}"
+            )
+        return parts[2], parts[3]  # team_id, task_id
+
+    async def stop(self) -> None:
+        """Drain the NATS connection and release resources."""
+        logger.info("nats_listener_stopped")

--- a/clients/python/src/agamemnon/orchestration/task_claimer.py
+++ b/clients/python/src/agamemnon/orchestration/task_claimer.py
@@ -1,0 +1,182 @@
+"""Per-team concurrency guard for advance_dag task claiming."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Callable, Coroutine
+
+logger = logging.getLogger(__name__)
+
+
+class TaskClaimer:
+    """Claims ready tasks for a team by advancing its DAG.
+
+    Uses a per-team asyncio.Lock to prevent concurrent advance_dag calls for
+    the same team from racing each other. If a call arrives while one is already
+    in-flight for the same team, the new call is coalesced (skipped) rather than
+    queued, since the in-flight call will already observe the latest state.
+    """
+
+    def __init__(
+        self,
+        get_tasks: Callable[[str], Coroutine[Any, Any, list[dict[str, Any]]]],
+        claim_task: Callable[[str, str], Coroutine[Any, Any, bool]],
+    ) -> None:
+        """Initialize TaskClaimer.
+
+        Args:
+            get_tasks: Async callable that fetches tasks for a team_id.
+            claim_task: Async callable that attempts to claim a task by team_id
+                and task_id. Returns True if the claim succeeded.
+        """
+        self._get_tasks = get_tasks
+        self._claim_task = claim_task
+        self._team_locks: dict[str, asyncio.Lock] = {}
+        self._advancing: set[str] = set()
+        self._in_flight: set[asyncio.Task[Any]] = set()
+        # Issue #295: track coalesced (skipped) advance_dag calls per team
+        self._coalesced_count: dict[str, int] = {}
+
+    @property
+    def in_flight_count(self) -> int:
+        """Number of advance_dag_tracked tasks currently executing."""
+        return len(self._in_flight)
+
+    def get_coalesced_count(self, team_id: str) -> int:
+        """Return the number of coalesced (skipped) advance_dag calls for a team.
+
+        A call is coalesced when advance_dag is invoked while another call for
+        the same team is already in-flight.
+
+        Args:
+            team_id: The team whose coalesced count to retrieve.
+
+        Returns:
+            Number of coalesced calls recorded for this team (0 if none).
+        """
+        return self._coalesced_count.get(team_id, 0)
+
+    def get_metrics(self) -> dict[str, Any]:
+        """Return a snapshot of coalesced-call metrics for all teams.
+
+        Returns:
+            A dict mapping team_id to its coalesced call count.
+        """
+        return dict(self._coalesced_count)
+
+    def _get_team_lock(self, team_id: str) -> asyncio.Lock:
+        """Return the per-team lock, creating it lazily if needed."""
+        if team_id not in self._team_locks:
+            self._team_locks[team_id] = asyncio.Lock()
+        return self._team_locks[team_id]
+
+    def cleanup_idle_teams(self) -> list[str]:
+        """Remove per-team locks for teams that are not currently advancing.
+
+        Teams with an active advance_dag call in progress are kept. All other
+        teams have their lock entry removed from ``_team_locks``, preventing
+        unbounded growth as new team IDs are seen over time.
+
+        Returns:
+            List of team IDs whose locks were removed.
+        """
+        idle_teams = [t for t in self._team_locks if t not in self._advancing]
+        for team_id in idle_teams:
+            del self._team_locks[team_id]
+        if idle_teams:
+            logger.debug("cleanup_idle_teams: removed %d team locks", len(idle_teams))
+        return idle_teams
+
+    async def advance_dag(self, team_id: str) -> list[str]:
+        """Fetch ready tasks for team_id and claim them.
+
+        At most one advance_dag call executes per team at any time. If a call
+        arrives while another is already in-flight for the same team, the new
+        call is skipped (coalesced) and returns an empty list.
+
+        Args:
+            team_id: The team whose DAG should be advanced.
+
+        Returns:
+            List of task IDs that were successfully claimed, or an empty list
+            if this call was coalesced.
+        """
+        if team_id in self._advancing:
+            logger.info(
+                "advance_dag already in-flight for team %s -- skipping", team_id
+            )
+            self._coalesced_count[team_id] = self._coalesced_count.get(team_id, 0) + 1
+            return []
+
+        self._advancing.add(team_id)
+        try:
+            async with self._get_team_lock(team_id):
+                tasks = await self._get_tasks(team_id)
+                claimed: list[str] = []
+                for task in tasks:
+                    task_id: str = task["id"]
+                    if await self._claim_task(team_id, task_id):
+                        claimed.append(task_id)
+                return claimed
+        finally:
+            self._advancing.discard(team_id)
+
+    def advance_dag_tracked(self, team_id: str) -> asyncio.Task[Any]:
+        """Schedule advance_dag(team_id) as a tracked asyncio Task.
+
+        The returned Task is registered in _in_flight and removed when done.
+        Use drain() to wait for all in-flight tasks to complete.
+
+        Args:
+            team_id: The team whose DAG should be advanced.
+
+        Returns:
+            The asyncio.Task wrapping the advance_dag coroutine.
+        """
+        task: asyncio.Task[Any] = asyncio.get_event_loop().create_task(
+            self.advance_dag(team_id)
+        )
+        self._in_flight.add(task)
+        task.add_done_callback(self._in_flight.discard)
+        return task
+
+    async def drain(self, timeout: float) -> bool:
+        """Wait for all in-flight advance_dag_tracked tasks to complete.
+
+        Args:
+            timeout: Maximum seconds to wait before giving up.
+
+        Returns:
+            True if all tasks completed within the timeout, False otherwise.
+        """
+        if not self._in_flight:
+            return True
+        try:
+            await asyncio.wait_for(
+                asyncio.gather(*self._in_flight, return_exceptions=True),
+                timeout=timeout,
+            )
+            return True
+        except asyncio.TimeoutError:
+            logger.warning("drain_timeout", extra={"timeout": timeout})
+            return False
+
+    async def startup_scan(self, team_ids: list[str]) -> list[asyncio.Task[Any]]:
+        """Dispatch advance_dag_tracked for each team in team_ids.
+
+        This method is intended to be called at daemon startup to prime the
+        claim pipeline for all known teams. It schedules one tracked task per
+        team and returns the list of tasks so the caller can optionally await
+        them or pass them to drain().
+
+        Args:
+            team_ids: List of team IDs to scan on startup.
+
+        Returns:
+            List of asyncio.Task objects, one per team_id.
+        """
+        tasks: list[asyncio.Task[Any]] = []
+        for team_id in team_ids:
+            tasks.append(self.advance_dag_tracked(team_id))
+        return tasks

--- a/clients/python/src/agamemnon/orchestration/task_claimer.py
+++ b/clients/python/src/agamemnon/orchestration/task_claimer.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Any, Callable, Coroutine
+from collections.abc import Coroutine
+from typing import Any, Callable
 
 logger = logging.getLogger(__name__)
 

--- a/clients/python/src/agamemnon/orchestration/validation.py
+++ b/clients/python/src/agamemnon/orchestration/validation.py
@@ -1,0 +1,43 @@
+"""Input validation utilities for safe URL path construction."""
+
+from __future__ import annotations
+
+_MAX_ID_LENGTH = 256
+
+
+def validate_id(value: str, field_name: str) -> str:
+    """Validate an ID string for safe use in URL path segments.
+
+    Rejects empty strings, strings containing path separators (``/``, ``\\``,
+    ``..``), whitespace, control characters, and strings longer than 256
+    characters.
+
+    Args:
+        value: The ID string to validate.
+        field_name: Human-readable name of the field (used in error messages).
+
+    Returns:
+        The original ``value`` unchanged if it passes all checks.
+
+    Raises:
+        ValueError: If ``value`` fails any validation check.
+    """
+    if not value or not value.strip():
+        raise ValueError(f"{field_name} must not be empty or whitespace-only")
+
+    if len(value) > _MAX_ID_LENGTH:
+        raise ValueError(
+            f"{field_name} exceeds maximum length of {_MAX_ID_LENGTH} characters"
+        )
+
+    for ch in value:
+        if ch.isspace() or ord(ch) < 32:
+            raise ValueError(f"{field_name} contains invalid character: {ch!r}")
+
+    if "/" in value or "\\" in value:
+        raise ValueError(f"{field_name} contains path separator characters")
+
+    if ".." in value:
+        raise ValueError(f"{field_name} contains path traversal sequence '..'")
+
+    return value

--- a/clients/python/tests/orchestration/conftest.py
+++ b/clients/python/tests/orchestration/conftest.py
@@ -1,0 +1,32 @@
+"""Shared pytest fixtures and configuration for Agamemnon orchestration tests.
+
+asyncio_mode = "auto" is configured in pyproject.toml [tool.pytest.ini_options],
+so @pytest.mark.asyncio decorators are not required on individual async tests.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from tests.orchestration.helpers import make_agent, make_task
+
+__all__ = ["make_agent", "make_task"]
+
+
+@pytest.fixture
+def mock_http_client() -> MagicMock:
+    """Return a mock HTTP client with an async ``get`` method."""
+    http = MagicMock()
+    http.get = AsyncMock()
+    return http
+
+
+@pytest.fixture
+def mock_agamemnon_client() -> MagicMock:
+    """Return a MagicMock standing in for an AgamemnonClient."""
+    client = MagicMock()
+    client.get_tasks = AsyncMock(return_value=[])
+    client.claim_task = AsyncMock(return_value=True)
+    return client

--- a/clients/python/tests/orchestration/helpers.py
+++ b/clients/python/tests/orchestration/helpers.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from agamemnon.orchestration.models import Agent, Task
+
+
+def make_agent(
+    id: str = "agent-1",
+    name: str = "Agent 1",
+    host: str = "host-1",
+    status: str = "active",
+    session_status: str = "online",
+    task_description: str = "",
+    program: str = "",
+    current_task_id: Optional[str] = None,
+) -> Agent:
+    """Create an Agent test fixture with sensible defaults."""
+    return Agent(
+        id=id,
+        name=name,
+        host=host,
+        status=status,
+        session_status=session_status,
+        task_description=task_description,
+        program=program,
+        current_task_id=current_task_id,
+    )
+
+
+def make_task(
+    id: str = "task-1",
+    title: str = "Task 1",
+    status: str = "pending",
+    dependencies: Optional[list[str]] = None,
+    assigned_agent_id: Optional[str] = None,
+) -> Task:
+    """Create a Task test fixture with sensible defaults."""
+    return Task(
+        id=id,
+        title=title,
+        status=status,
+        dependencies=dependencies or [],
+        assigned_agent_id=assigned_agent_id,
+    )

--- a/clients/python/tests/orchestration/helpers.py
+++ b/clients/python/tests/orchestration/helpers.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Optional
-
 from agamemnon.orchestration.models import Agent, Task
 
 
@@ -13,7 +11,7 @@ def make_agent(
     session_status: str = "online",
     task_description: str = "",
     program: str = "",
-    current_task_id: Optional[str] = None,
+    current_task_id: str | None = None,
 ) -> Agent:
     """Create an Agent test fixture with sensible defaults."""
     return Agent(
@@ -32,8 +30,8 @@ def make_task(
     id: str = "task-1",
     title: str = "Task 1",
     status: str = "pending",
-    dependencies: Optional[list[str]] = None,
-    assigned_agent_id: Optional[str] = None,
+    dependencies: list[str] | None = None,
+    assigned_agent_id: str | None = None,
 ) -> Task:
     """Create a Task test fixture with sensible defaults."""
     return Task(

--- a/clients/python/tests/orchestration/test_dag_walker.py
+++ b/clients/python/tests/orchestration/test_dag_walker.py
@@ -1,0 +1,524 @@
+"""Tests for DAGWalker — cycle detection, ready tasks, available agents, and advance_dag."""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from agamemnon.orchestration.dag_walker import DAGWalker
+from tests.orchestration.helpers import make_agent, make_task
+
+
+class TestGetAvailableAgents:
+    def test_online_active_agent_available(self) -> None:
+        agent = make_agent()
+        walker = DAGWalker(tasks=[], agents=[agent])
+        assert agent in walker.get_available_agents()
+
+    def test_busy_agent_not_available(self) -> None:
+        agent = make_agent(current_task_id="some-task")
+        walker = DAGWalker(tasks=[], agents=[agent])
+        assert agent not in walker.get_available_agents()
+
+    def test_inactive_agent_not_available(self) -> None:
+        agent = make_agent(status="inactive")
+        walker = DAGWalker(tasks=[], agents=[agent])
+        assert agent not in walker.get_available_agents()
+
+    def test_offline_agent_not_available(self) -> None:
+        agent = make_agent(session_status="offline")
+        walker = DAGWalker(tasks=[], agents=[agent])
+        assert agent not in walker.get_available_agents()
+
+    def test_mixed_agents_only_idle_returned(self) -> None:
+        idle = make_agent(id="a1")
+        busy = make_agent(id="a2", current_task_id="t-99")
+        offline = make_agent(id="a3", session_status="offline")
+        walker = DAGWalker(tasks=[], agents=[idle, busy, offline])
+        result = walker.get_available_agents()
+        assert result == [idle]
+
+
+class TestGetReadyTasks:
+    def test_task_with_no_deps_is_ready(self) -> None:
+        task = make_task()
+        walker = DAGWalker(tasks=[task], agents=[])
+        assert task in walker.get_ready_tasks()
+
+    def test_task_with_completed_dep_is_ready(self) -> None:
+        dep = make_task(id="dep-1", status="completed")
+        task = make_task(id="task-2", dependencies=["dep-1"])
+        walker = DAGWalker(tasks=[dep, task], agents=[])
+        assert task in walker.get_ready_tasks()
+
+    def test_task_with_pending_dep_not_ready(self) -> None:
+        dep = make_task(id="dep-1", status="pending")
+        task = make_task(id="task-2", dependencies=["dep-1"])
+        walker = DAGWalker(tasks=[dep, task], agents=[])
+        assert task not in walker.get_ready_tasks()
+
+    def test_already_assigned_task_not_ready(self) -> None:
+        task = make_task(assigned_agent_id="agent-99")
+        walker = DAGWalker(tasks=[task], agents=[])
+        assert task not in walker.get_ready_tasks()
+
+
+class TestValidateNoCycles:
+    def test_empty_dag_is_acyclic(self) -> None:
+        walker = DAGWalker(tasks=[], agents=[])
+        assert walker.validate_no_cycles() is True
+
+    def test_single_task_no_deps_is_acyclic(self) -> None:
+        task = make_task(id="t1")
+        walker = DAGWalker(tasks=[task], agents=[])
+        assert walker.validate_no_cycles() is True
+
+    def test_linear_chain_is_acyclic(self) -> None:
+        # t1 -> t2 -> t3
+        t1 = make_task(id="t1")
+        t2 = make_task(id="t2", dependencies=["t1"])
+        t3 = make_task(id="t3", dependencies=["t2"])
+        walker = DAGWalker(tasks=[t1, t2, t3], agents=[])
+        assert walker.validate_no_cycles() is True
+
+    def test_diamond_dag_is_acyclic(self) -> None:
+        # t1 -> t2, t1 -> t3, t2 -> t4, t3 -> t4
+        t1 = make_task(id="t1")
+        t2 = make_task(id="t2", dependencies=["t1"])
+        t3 = make_task(id="t3", dependencies=["t1"])
+        t4 = make_task(id="t4", dependencies=["t2", "t3"])
+        walker = DAGWalker(tasks=[t1, t2, t3, t4], agents=[])
+        assert walker.validate_no_cycles() is True
+
+    def test_two_node_cycle_detected(self) -> None:
+        # t1 -> t2 -> t1
+        t1 = make_task(id="t1", dependencies=["t2"])
+        t2 = make_task(id="t2", dependencies=["t1"])
+        walker = DAGWalker(tasks=[t1, t2], agents=[])
+        assert walker.validate_no_cycles() is False
+
+    def test_three_node_cycle_detected(self) -> None:
+        # t1 -> t2 -> t3 -> t1
+        t1 = make_task(id="t1", dependencies=["t3"])
+        t2 = make_task(id="t2", dependencies=["t1"])
+        t3 = make_task(id="t3", dependencies=["t2"])
+        walker = DAGWalker(tasks=[t1, t2, t3], agents=[])
+        assert walker.validate_no_cycles() is False
+
+    def test_self_cycle_detected(self) -> None:
+        t1 = make_task(id="t1", dependencies=["t1"])
+        walker = DAGWalker(tasks=[t1], agents=[])
+        assert walker.validate_no_cycles() is False
+
+    def test_cycle_in_subgraph_detected(self) -> None:
+        # t1 is clean; t2 <-> t3 form a cycle
+        t1 = make_task(id="t1")
+        t2 = make_task(id="t2", dependencies=["t3"])
+        t3 = make_task(id="t3", dependencies=["t2"])
+        walker = DAGWalker(tasks=[t1, t2, t3], agents=[])
+        assert walker.validate_no_cycles() is False
+
+    def test_deep_chain_no_recursion_error(self) -> None:
+        """2000-node linear chain must not raise RecursionError (regression for #100)."""
+        n = 2000
+        tasks = [make_task(id="t0")]
+        for i in range(1, n):
+            tasks.append(make_task(id=f"t{i}", dependencies=[f"t{i - 1}"]))
+        walker = DAGWalker(tasks=tasks, agents=[])
+        assert walker.validate_no_cycles() is True
+
+    def test_external_dependency_raises(self) -> None:
+        """Dependencies referencing task IDs not in the graph raise ValueError (Issue #233)."""
+        t1 = make_task(id="t1", dependencies=["external-task-not-in-graph"])
+        walker = DAGWalker(tasks=[t1], agents=[])
+        with pytest.raises(ValueError, match="Unknown dependency"):
+            walker.validate_no_cycles()
+
+    def test_validate_no_cycles_reports_cycle_path(self) -> None:
+        """_find_cycle_path() returns the task IDs involved in the cycle (Issue #229)."""
+        # A -> B -> A forms a 2-node cycle
+        t_a = make_task(id="A", dependencies=["B"])
+        t_b = make_task(id="B", dependencies=["A"])
+        walker = DAGWalker(tasks=[t_a, t_b], agents=[])
+        cycle_path = walker._find_cycle_path()
+        assert len(cycle_path) >= 2
+        assert "A" in cycle_path
+        assert "B" in cycle_path
+
+
+class TestAdvanceDag:
+    async def test_assigns_ready_task_to_available_agent(self) -> None:
+        task = make_task()
+        agent = make_agent()
+        walker = DAGWalker(tasks=[task], agents=[agent])
+        assignments = await walker.advance_dag()
+        assert len(assignments) == 1
+        assert assignments[0] == (task, agent)
+        assert agent.current_task_id == task.id
+        assert task.assigned_agent_id == agent.id
+
+    async def test_multiple_assignments_use_different_agents(self) -> None:
+        task1 = make_task(id="t1")
+        task2 = make_task(id="t2")
+        agent1 = make_agent(id="a1")
+        agent2 = make_agent(id="a2")
+        walker = DAGWalker(tasks=[task1, task2], agents=[agent1, agent2])
+        assignments = await walker.advance_dag()
+        assert len(assignments) == 2
+        assigned_agents = {a.id for _, a in assignments}
+        assert assigned_agents == {"a1", "a2"}
+
+    async def test_busy_agent_not_double_assigned(self) -> None:
+        """A single idle agent with two ready tasks should only get one assignment."""
+        task1 = make_task(id="t1")
+        task2 = make_task(id="t2")
+        agent = make_agent(id="a1")
+        walker = DAGWalker(tasks=[task1, task2], agents=[agent])
+        assignments = await walker.advance_dag()
+        assert len(assignments) == 1
+        assert agent.current_task_id is not None
+
+    async def test_agent_marked_busy_immediately(self) -> None:
+        task1 = make_task(id="t1")
+        task2 = make_task(id="t2")
+        agent = make_agent(id="a1")
+        walker = DAGWalker(tasks=[task1, task2], agents=[agent])
+        await walker.advance_dag()
+        assert sum(1 for t in walker.tasks if t.assigned_agent_id is not None) == 1
+
+    async def test_no_available_agents_no_assignments(self) -> None:
+        task = make_task()
+        agent = make_agent(current_task_id="other-task")
+        walker = DAGWalker(tasks=[task], agents=[agent])
+        assignments = await walker.advance_dag()
+        assert assignments == []
+
+    async def test_no_ready_tasks_no_assignments(self) -> None:
+        dep = make_task(id="dep", status="in_progress")
+        task = make_task(id="t1", dependencies=["dep"])
+        agent = make_agent()
+        walker = DAGWalker(tasks=[dep, task], agents=[agent])
+        assignments = await walker.advance_dag()
+        assert assignments == []
+
+    async def test_advance_dag_calls_client_assign_task(self) -> None:
+        """advance_dag() must call client.assign_task(task_id, agent_id) when a client is set."""
+        task = make_task()
+        agent = make_agent()
+        mock_client = AsyncMock()
+        # Return the same agent list so the fresh-agent refresh (issue #196) is a no-op.
+        mock_client.get_agents = AsyncMock(return_value=[agent])
+        walker = DAGWalker(tasks=[task], agents=[agent], client=mock_client)
+
+        assignments = await walker.advance_dag()
+
+        assert len(assignments) == 1
+        mock_client.assign_task.assert_awaited_once_with(task.id, agent.id)
+
+    @pytest.mark.asyncio
+    async def test_advance_dag_no_client_no_api_call(self) -> None:
+        """advance_dag() must succeed and return assignments when no client is provided."""
+        task = make_task()
+        agent = make_agent()
+        walker = DAGWalker(tasks=[task], agents=[agent], client=None)
+
+        assignments = await walker.advance_dag()
+
+        assert len(assignments) == 1
+        assert assignments[0] == (task, agent)
+
+    @pytest.mark.asyncio
+    async def test_advance_dag_marks_agent_busy(self) -> None:
+        """advance_dag() must set agent.current_task_id after assignment."""
+        task = make_task()
+        agent = make_agent()
+        walker = DAGWalker(tasks=[task], agents=[agent])
+
+        await walker.advance_dag()
+
+        assert agent.current_task_id == task.id
+        assert task.assigned_agent_id == agent.id
+
+    @pytest.mark.asyncio
+    async def test_advance_dag_no_ready_tasks_returns_empty_with_client(self) -> None:
+        """advance_dag() must return [] and never call assign_task when no tasks are ready."""
+        dep = make_task(id="dep", status="in_progress")
+        task = make_task(id="t1", dependencies=["dep"])
+        agent = make_agent()
+        mock_client = AsyncMock()
+        walker = DAGWalker(tasks=[dep, task], agents=[agent], client=mock_client)
+
+        assignments = await walker.advance_dag()
+
+        assert assignments == []
+        mock_client.assign_task.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_advance_dag_client_called_for_each_assignment(self) -> None:
+        """assign_task() must be called once per task-agent pair when multiple assignments occur."""
+        task1 = make_task(id="t1")
+        task2 = make_task(id="t2")
+        agent1 = make_agent(id="a1")
+        agent2 = make_agent(id="a2")
+        mock_client = AsyncMock()
+        # Return the same agents so the fresh-agent refresh (issue #196) is a no-op.
+        mock_client.get_agents = AsyncMock(return_value=[agent1, agent2])
+        walker = DAGWalker(
+            tasks=[task1, task2], agents=[agent1, agent2], client=mock_client
+        )
+
+        assignments = await walker.advance_dag()
+
+        assert len(assignments) == 2
+        assert mock_client.assign_task.await_count == 2
+        awaited_calls = {call.args for call in mock_client.assign_task.await_args_list}
+        assert (task1.id, agent1.id) in awaited_calls or (
+            task1.id,
+            agent2.id,
+        ) in awaited_calls
+        assert (task2.id, agent1.id) in awaited_calls or (
+            task2.id,
+            agent2.id,
+        ) in awaited_calls
+
+    @pytest.mark.asyncio
+    async def test_advance_dag_raises_on_cycle(self) -> None:
+        """advance_dag() raises ValueError when the DAG contains a cycle (Issue #228)."""
+        t_a = make_task(id="A", dependencies=["B"])
+        t_b = make_task(id="B", dependencies=["A"])
+        agent = make_agent()
+        walker = DAGWalker(tasks=[t_a, t_b], agents=[agent])
+        with pytest.raises(ValueError, match="Cycle detected in task DAG"):
+            await walker.advance_dag()
+
+    @pytest.mark.asyncio
+    async def test_advance_dag_raises_on_unknown_dependency(self) -> None:
+        """advance_dag() raises ValueError when a task references an unknown dep ID (Issue #233)."""
+        task = make_task(id="t1", dependencies=["nonexistent-id"])
+        agent = make_agent()
+        walker = DAGWalker(tasks=[task], agents=[agent])
+        with pytest.raises(ValueError, match="Unknown dependency"):
+            await walker.advance_dag()
+
+
+class TestAdvanceDagFreshAgents:
+    """Tests for issue #196 — advance_dag() calls get_agents() for a fresh agent list."""
+
+    async def test_advance_dag_calls_get_agents_when_available(self) -> None:
+        """advance_dag() calls client.get_agents() and uses the returned list."""
+        task = make_task()
+        stale_agent = make_agent(id="stale", current_task_id="busy")
+        fresh_agent = make_agent(id="fresh")
+        mock_client = AsyncMock()
+        mock_client.get_agents = AsyncMock(return_value=[fresh_agent])
+        walker = DAGWalker(tasks=[task], agents=[stale_agent], client=mock_client)
+
+        assignments = await walker.advance_dag()
+
+        mock_client.get_agents.assert_awaited_once()
+        assert len(assignments) == 1
+        assert assignments[0][1].id == "fresh"
+
+    async def test_advance_dag_skips_get_agents_when_no_client(self) -> None:
+        """advance_dag() works without a client — uses self.agents unchanged."""
+        task = make_task()
+        agent = make_agent()
+        walker = DAGWalker(tasks=[task], agents=[agent], client=None)
+
+        assignments = await walker.advance_dag()
+
+        assert len(assignments) == 1
+        assert assignments[0][1] is agent
+
+    async def test_advance_dag_skips_get_agents_when_client_lacks_method(self) -> None:
+        """advance_dag() falls back to self.agents when client has no get_agents()."""
+        from unittest.mock import MagicMock
+
+        task = make_task()
+        agent = make_agent()
+        # Build a client that only has assign_task (an async callable) — no get_agents.
+        mock_client = MagicMock()
+        mock_client.assign_task = AsyncMock()
+        del mock_client.get_agents  # ensure hasattr returns False
+        walker = DAGWalker(tasks=[task], agents=[agent], client=mock_client)
+
+        assignments = await walker.advance_dag()
+
+        assert len(assignments) == 1
+        assert assignments[0][1] is agent
+
+    async def test_advance_dag_falls_back_on_get_agents_exception(self) -> None:
+        """If get_agents() raises, advance_dag() falls back to the cached list."""
+        task = make_task()
+        cached_agent = make_agent(id="cached")
+        mock_client = AsyncMock()
+        mock_client.get_agents = AsyncMock(side_effect=RuntimeError("service down"))
+        walker = DAGWalker(tasks=[task], agents=[cached_agent], client=mock_client)
+
+        assignments = await walker.advance_dag()
+
+        # Falls back to cached list — the cached agent was available
+        assert len(assignments) == 1
+        assert assignments[0][1].id == "cached"
+
+    async def test_advance_dag_ignores_none_from_get_agents(self) -> None:
+        """If get_agents() returns None, advance_dag() keeps the existing agent list."""
+        task = make_task()
+        cached_agent = make_agent(id="cached")
+        mock_client = AsyncMock()
+        mock_client.get_agents = AsyncMock(return_value=None)
+        walker = DAGWalker(tasks=[task], agents=[cached_agent], client=mock_client)
+
+        assignments = await walker.advance_dag()
+
+        assert len(assignments) == 1
+        assert assignments[0][1].id == "cached"
+
+
+class TestBackgroundScan:
+    """Tests for issue #98 — periodic background DAG scan safety net."""
+
+    async def test_start_background_scan_returns_task(self) -> None:
+        """start_background_scan() returns an asyncio.Task."""
+        walker = DAGWalker(tasks=[], agents=[], scan_interval=0.05)
+        stop_event = asyncio.Event()
+        task = walker.start_background_scan(stop_event)
+        assert isinstance(task, asyncio.Task)
+        stop_event.set()
+        await task
+
+    async def test_background_scan_calls_advance_dag(self) -> None:
+        """Background scan calls advance_dag() at least once per interval."""
+        ready_task = make_task()
+        agent = make_agent()
+        walker = DAGWalker(tasks=[ready_task], agents=[agent], scan_interval=0.02)
+
+        call_count = 0
+        original_advance = walker.advance_dag
+
+        async def counting_advance() -> list:
+            nonlocal call_count
+            call_count += 1
+            return await original_advance()
+
+        walker.advance_dag = counting_advance  # type: ignore[method-assign]
+
+        stop_event = asyncio.Event()
+        scan_task = walker.start_background_scan(stop_event)
+        await asyncio.sleep(0.07)  # allow ~3 intervals to fire
+        stop_event.set()
+        await scan_task
+
+        assert call_count >= 1
+
+    async def test_background_scan_survives_advance_dag_exception(self) -> None:
+        """A raised exception in advance_dag() must not terminate the scan loop."""
+        walker = DAGWalker(tasks=[], agents=[], scan_interval=0.02)
+        call_count = 0
+
+        async def failing_advance() -> list:
+            nonlocal call_count
+            call_count += 1
+            if call_count < 2:
+                raise RuntimeError("transient failure")
+            return []
+
+        walker.advance_dag = failing_advance  # type: ignore[method-assign]
+
+        stop_event = asyncio.Event()
+        scan_task = walker.start_background_scan(stop_event)
+        await asyncio.sleep(0.07)
+        stop_event.set()
+        await scan_task
+
+        assert call_count >= 2
+
+    async def test_background_scan_exits_immediately_on_stop(self) -> None:
+        """If stop_event is pre-set, the loop exits before calling advance_dag()."""
+        walker = DAGWalker(tasks=[], agents=[], scan_interval=60.0)
+        call_count = 0
+
+        async def counting_advance() -> list:
+            nonlocal call_count
+            call_count += 1
+            return []
+
+        walker.advance_dag = counting_advance  # type: ignore[method-assign]
+
+        stop_event = asyncio.Event()
+        stop_event.set()  # pre-set before starting
+        scan_task = walker.start_background_scan(stop_event)
+        await scan_task
+
+        assert call_count == 0
+
+    async def test_start_background_scan_stores_task_reference(self) -> None:
+        """start_background_scan() stores the task in self._scan_task."""
+        walker = DAGWalker(tasks=[], agents=[], scan_interval=0.05)
+        stop_event = asyncio.Event()
+        task = walker.start_background_scan(stop_event)
+        assert walker._scan_task is task
+        stop_event.set()
+        await task
+
+
+class TestFindCyclePath:
+    """Tests for _find_cycle_path() cycle detection with back-edge reconstruction."""
+
+    def test_find_cycle_path_returns_empty_for_acyclic_graph(self) -> None:
+        """_find_cycle_path() returns [] for an acyclic DAG."""
+        t1 = make_task(id="t1")
+        t2 = make_task(id="t2", dependencies=["t1"])
+        walker = DAGWalker(tasks=[t1, t2], agents=[])
+        assert walker._find_cycle_path() == []
+
+    def test_find_cycle_path_detects_immediate_back_edge(self) -> None:
+        """_find_cycle_path() detects immediate back-edge to GRAY neighbor (line 108-117)."""
+        # t1 -> t2, t2 -> t1 (immediate back-edge when processing t2's edges)
+        t1 = make_task(id="t1", dependencies=["t2"])
+        t2 = make_task(id="t2", dependencies=["t1"])
+        walker = DAGWalker(tasks=[t1, t2], agents=[])
+        cycle = walker._find_cycle_path()
+        assert len(cycle) >= 2
+        assert "t1" in cycle
+        assert "t2" in cycle
+
+    def test_find_cycle_path_detects_deferred_back_edge(self) -> None:
+        """_find_cycle_path() detects deferred back-edge when revisiting GRAY node (line 91-100)."""
+        # t1 -> t2, t2 -> t3, t3 -> t1 (back-edge found when popping t1 from stack)
+        t1 = make_task(id="t1", dependencies=["t3"])
+        t2 = make_task(id="t2", dependencies=["t1"])
+        t3 = make_task(id="t3", dependencies=["t2"])
+        walker = DAGWalker(tasks=[t1, t2, t3], agents=[])
+        cycle = walker._find_cycle_path()
+        assert len(cycle) >= 2
+        assert "t1" in cycle
+        assert "t2" in cycle
+        assert "t3" in cycle
+
+    def test_find_cycle_path_handles_black_node_skip(self) -> None:
+        """_find_cycle_path() skips BLACK (already visited) nodes (line 102-103)."""
+        # Complex graph: t1 -> t2, t1 -> t3, t2 -> t3, t3 -> t2 (cycle in t2 <-> t3)
+        t1 = make_task(id="t1")
+        t2 = make_task(id="t2", dependencies=["t3"])
+        t3 = make_task(id="t3", dependencies=["t2"])
+        walker = DAGWalker(tasks=[t1, t2, t3], agents=[])
+        cycle = walker._find_cycle_path()
+        # t1 is visited first (no cycle), then t2 <-> t3 is detected
+        assert "t2" in cycle
+        assert "t3" in cycle
+
+    def test_find_cycle_path_with_multiple_independent_components(self) -> None:
+        """_find_cycle_path() detects cycle in one component (line 75-77 loop)."""
+        # Component 1: t1 -> t2 (no cycle)
+        # Component 2: t3 -> t4 -> t3 (cycle)
+        t1 = make_task(id="t1")
+        t2 = make_task(id="t2", dependencies=["t1"])
+        t3 = make_task(id="t3", dependencies=["t4"])
+        t4 = make_task(id="t4", dependencies=["t3"])
+        walker = DAGWalker(tasks=[t1, t2, t3, t4], agents=[])
+        cycle = walker._find_cycle_path()
+        # Should find the cycle in component 2
+        assert "t3" in cycle
+        assert "t4" in cycle

--- a/clients/python/tests/orchestration/test_graceful_shutdown.py
+++ b/clients/python/tests/orchestration/test_graceful_shutdown.py
@@ -37,10 +37,11 @@ class SlowTaskClaimer(TaskClaimer):
         self.delay = delay
         self.calls: list[str] = []
 
-    async def advance_dag(self, team_id: str) -> None:
+    async def advance_dag(self, team_id: str) -> list[str]:
         self.calls.append(team_id)
         if self.delay > 0:
             await asyncio.sleep(self.delay)
+        return []
 
 
 # ---------------------------------------------------------------------------
@@ -89,7 +90,7 @@ class TestInflightTracking:
     async def test_inflight_removed_after_exception(self) -> None:
         claimer = make_claimer()
 
-        async def failing_advance_dag(team_id: str) -> None:
+        async def failing_advance_dag(team_id: str) -> list[str]:
             raise RuntimeError("simulated failure")
 
         claimer.advance_dag = failing_advance_dag  # type: ignore[method-assign]

--- a/clients/python/tests/orchestration/test_graceful_shutdown.py
+++ b/clients/python/tests/orchestration/test_graceful_shutdown.py
@@ -11,7 +11,6 @@ import pytest
 from agamemnon.orchestration.nats_listener import NATSListener
 from agamemnon.orchestration.task_claimer import TaskClaimer
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/clients/python/tests/orchestration/test_graceful_shutdown.py
+++ b/clients/python/tests/orchestration/test_graceful_shutdown.py
@@ -1,0 +1,305 @@
+"""Tests for graceful shutdown — draining in-flight advance_dag calls."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from agamemnon.orchestration.nats_listener import NATSListener
+from agamemnon.orchestration.task_claimer import TaskClaimer
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _noop_get_tasks(team_id: str) -> list[dict[str, Any]]:
+    return []
+
+
+async def _noop_claim_task(team_id: str, task_id: str) -> bool:
+    return False
+
+
+def make_claimer() -> TaskClaimer:
+    """Return a TaskClaimer with no-op callbacks for unit tests."""
+    return TaskClaimer(get_tasks=_noop_get_tasks, claim_task=_noop_claim_task)
+
+
+class SlowTaskClaimer(TaskClaimer):
+    """TaskClaimer whose advance_dag sleeps for a configurable duration."""
+
+    def __init__(self, delay: float = 0.0) -> None:
+        super().__init__(get_tasks=_noop_get_tasks, claim_task=_noop_claim_task)
+        self.delay = delay
+        self.calls: list[str] = []
+
+    async def advance_dag(self, team_id: str) -> None:
+        self.calls.append(team_id)
+        if self.delay > 0:
+            await asyncio.sleep(self.delay)
+
+
+# ---------------------------------------------------------------------------
+# TaskClaimer.drain — no in-flight tasks
+# ---------------------------------------------------------------------------
+
+
+class TestDrainEmpty:
+    async def test_drain_returns_true_immediately_when_no_inflight(self) -> None:
+        claimer = make_claimer()
+        result = await claimer.drain(timeout=5.0)
+        assert result is True
+
+    async def test_inflight_count_zero_initially(self) -> None:
+        claimer = make_claimer()
+        assert claimer.in_flight_count == 0
+
+
+# ---------------------------------------------------------------------------
+# TaskClaimer — tracking in-flight tasks
+# ---------------------------------------------------------------------------
+
+
+class TestInflightTracking:
+    async def test_inflight_count_increases_when_task_dispatched(self) -> None:
+        claimer = SlowTaskClaimer(delay=0.1)
+        task = claimer.advance_dag_tracked("team-1")
+        assert claimer.in_flight_count == 1
+        await task
+
+    async def test_inflight_count_decreases_after_task_completes(self) -> None:
+        claimer = SlowTaskClaimer(delay=0.0)
+        task = claimer.advance_dag_tracked("team-1")
+        await task
+        # Give the done callback a chance to fire.
+        await asyncio.sleep(0)
+        assert claimer.in_flight_count == 0
+
+    async def test_multiple_inflight_tracked(self) -> None:
+        claimer = SlowTaskClaimer(delay=0.1)
+        t1 = claimer.advance_dag_tracked("team-1")
+        t2 = claimer.advance_dag_tracked("team-2")
+        assert claimer.in_flight_count == 2
+        await asyncio.gather(t1, t2)
+
+    async def test_inflight_removed_after_exception(self) -> None:
+        claimer = make_claimer()
+
+        async def failing_advance_dag(team_id: str) -> None:
+            raise RuntimeError("simulated failure")
+
+        claimer.advance_dag = failing_advance_dag  # type: ignore[method-assign]
+        task = claimer.advance_dag_tracked("team-x")
+        with pytest.raises(RuntimeError):
+            await task
+        await asyncio.sleep(0)
+        assert claimer.in_flight_count == 0
+
+
+# ---------------------------------------------------------------------------
+# TaskClaimer.drain — in-flight tasks complete before timeout
+# ---------------------------------------------------------------------------
+
+
+class TestDrainCompletes:
+    async def test_inflight_advance_dag_completes_before_drain_returns(self) -> None:
+        """Core success criterion: drain() waits for in-flight work to finish."""
+        claimer = SlowTaskClaimer(delay=0.05)
+        claimer.advance_dag_tracked("team-1")
+        assert claimer.in_flight_count == 1
+
+        result = await claimer.drain(timeout=5.0)
+
+        assert result is True
+        assert claimer.in_flight_count == 0
+
+    async def test_multiple_inflight_all_complete_before_drain_returns(self) -> None:
+        claimer = SlowTaskClaimer(delay=0.05)
+        for team_id in ("team-1", "team-2", "team-3"):
+            claimer.advance_dag_tracked(team_id)
+        assert claimer.in_flight_count == 3
+
+        result = await claimer.drain(timeout=5.0)
+
+        assert result is True
+        assert claimer.in_flight_count == 0
+
+    async def test_advance_dag_called_with_correct_team_id(self) -> None:
+        claimer = SlowTaskClaimer(delay=0.0)
+        claimer.advance_dag_tracked("team-42")
+        await claimer.drain(timeout=5.0)
+        assert "team-42" in claimer.calls
+
+
+# ---------------------------------------------------------------------------
+# TaskClaimer.drain — timeout
+# ---------------------------------------------------------------------------
+
+
+class TestDrainTimeout:
+    @pytest.mark.timeout(30)
+    async def test_drain_timeout_returns_false(self) -> None:
+        """drain() returns False when in-flight tasks outlast the timeout."""
+        claimer = SlowTaskClaimer(delay=10.0)
+        task = claimer.advance_dag_tracked("team-slow")
+
+        result = await claimer.drain(timeout=0.05)
+
+        assert result is False
+        task.cancel()
+        try:
+            await task
+        except (asyncio.CancelledError, Exception):
+            pass
+
+    @pytest.mark.timeout(30)
+    async def test_drain_timeout_logs_warning(self) -> None:
+        claimer = SlowTaskClaimer(delay=10.0)
+        task = claimer.advance_dag_tracked("team-slow")
+
+        with patch.object(claimer, "_in_flight", claimer._in_flight):
+            with patch("agamemnon.orchestration.task_claimer.logger") as mock_logger:
+                result = await claimer.drain(timeout=0.05)
+                assert result is False
+                mock_logger.warning.assert_called_once()
+                call_kwargs = mock_logger.warning.call_args
+                assert call_kwargs[0][0] == "drain_timeout"
+
+        task.cancel()
+        try:
+            await task
+        except (asyncio.CancelledError, Exception):
+            pass
+
+
+# ---------------------------------------------------------------------------
+# NATSListener — shutting_down flag
+# ---------------------------------------------------------------------------
+
+
+class TestNATSListenerShutdown:
+    def test_shutting_down_false_initially(self) -> None:
+        claimer = make_claimer()
+        listener = NATSListener(claimer)
+        assert listener.shutting_down is False
+
+    def test_begin_shutdown_sets_flag(self) -> None:
+        claimer = make_claimer()
+        listener = NATSListener(claimer)
+        listener.begin_shutdown()
+        assert listener.shutting_down is True
+
+    async def test_new_events_dropped_after_begin_shutdown(self) -> None:
+        """After begin_shutdown(), _on_task_event must not call advance_dag."""
+        claimer = SlowTaskClaimer(delay=0.0)
+        listener = NATSListener(claimer)
+        listener.begin_shutdown()
+
+        await listener._on_task_event("hi.tasks.team-1.t1.assigned", "team-1", "t1")
+
+        assert claimer.in_flight_count == 0
+        assert claimer.calls == []
+
+    async def test_events_dispatched_before_shutdown(self) -> None:
+        claimer = SlowTaskClaimer(delay=0.0)
+        listener = NATSListener(claimer)
+
+        await listener._on_task_event("hi.tasks.team-1.t1.assigned", "team-1", "t1")
+        await asyncio.sleep(0.01)
+
+        assert "team-1" in claimer.calls
+
+    async def test_event_dropped_during_shutdown_logs_info(self) -> None:
+        claimer = make_claimer()
+        listener = NATSListener(claimer)
+        listener.begin_shutdown()
+
+        with patch("agamemnon.orchestration.nats_listener.logger") as mock_logger:
+            await listener._on_task_event(
+                "hi.tasks.team-dropped.t1.assigned", "team-dropped", "t1"
+            )
+            mock_logger.info.assert_called_once()
+            call_args = mock_logger.info.call_args
+            assert call_args[0][0] == "nats_event_dropped_during_shutdown"
+
+    async def test_inflight_before_shutdown_completes(self) -> None:
+        """Events in-flight at shutdown time must still complete."""
+        claimer = SlowTaskClaimer(delay=0.05)
+        listener = NATSListener(claimer)
+
+        # Dispatch an event before shutdown.
+        await listener._on_task_event("hi.tasks.team-1.t1.assigned", "team-1", "t1")
+        assert claimer.in_flight_count == 1
+
+        # Now signal shutdown.
+        listener.begin_shutdown()
+
+        # drain() must wait for the already-in-flight task.
+        result = await claimer.drain(timeout=5.0)
+        assert result is True
+        assert claimer.in_flight_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Integration: begin_shutdown → drain → stop sequence
+# ---------------------------------------------------------------------------
+
+
+class TestShutdownSequence:
+    async def test_full_shutdown_sequence_completes_inflight(self) -> None:
+        """Full sequence: begin_shutdown → drain → stop, all in-flight complete."""
+        claimer = SlowTaskClaimer(delay=0.05)
+        listener = NATSListener(claimer)
+
+        # Simulate events arriving before shutdown.
+        await listener._on_task_event("hi.tasks.team-a.t1.assigned", "team-a", "t1")
+        await listener._on_task_event("hi.tasks.team-b.t1.assigned", "team-b", "t1")
+
+        # Shutdown starts.
+        listener.begin_shutdown()
+
+        # New events are dropped.
+        await listener._on_task_event("hi.tasks.team-c.t1.assigned", "team-c", "t1")
+
+        # Drain in-flight ops.
+        drained = await claimer.drain(timeout=5.0)
+        assert drained is True
+
+        # NATS drain.
+        await listener.stop()
+
+        assert claimer.in_flight_count == 0
+        assert "team-c" not in claimer.calls
+
+    @pytest.mark.timeout(30)
+    async def test_stop_called_even_when_drain_times_out(self) -> None:
+        """listener.stop() must be called even if drain times out."""
+        claimer = SlowTaskClaimer(delay=10.0)
+        listener = NATSListener(claimer)
+        stop_called = False
+
+        async def _stop() -> None:
+            nonlocal stop_called
+            stop_called = True
+
+        listener.stop = _stop  # type: ignore[method-assign]
+
+        task = claimer.advance_dag_tracked("team-slow")
+        listener.begin_shutdown()
+
+        drained = await claimer.drain(timeout=0.05)
+        assert drained is False
+
+        await listener.stop()
+        assert stop_called is True
+
+        task.cancel()
+        try:
+            await task
+        except (asyncio.CancelledError, Exception):
+            pass

--- a/clients/python/tests/orchestration/test_logging.py
+++ b/clients/python/tests/orchestration/test_logging.py
@@ -10,14 +10,12 @@ from datetime import datetime
 from io import StringIO
 from unittest.mock import patch
 
-
 from agamemnon.orchestration.logging import (
     JsonFormatter,
     KeystoneLogger,
     configure_logging,
     get_logger,
 )
-
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/clients/python/tests/orchestration/test_logging.py
+++ b/clients/python/tests/orchestration/test_logging.py
@@ -1,0 +1,370 @@
+"""Tests for agamemnon/orchestration/logging.py."""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+import threading
+from datetime import datetime
+from io import StringIO
+from unittest.mock import patch
+
+
+from agamemnon.orchestration.logging import (
+    JsonFormatter,
+    KeystoneLogger,
+    configure_logging,
+    get_logger,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_record(
+    msg: str = "hello",
+    level: int = logging.INFO,
+    name: str = "test",
+    args: tuple = (),
+    **extra: object,
+) -> logging.LogRecord:
+    record = logging.LogRecord(name, level, "", 0, msg, args, None)
+    for key, value in extra.items():
+        setattr(record, key, value)
+    return record
+
+
+def _format(record: logging.LogRecord) -> dict:
+    return json.loads(JsonFormatter().format(record))
+
+
+# ---------------------------------------------------------------------------
+# TestJsonFormatter
+# ---------------------------------------------------------------------------
+
+
+class TestJsonFormatter:
+    def test_output_is_valid_json(self) -> None:
+        raw = JsonFormatter().format(_make_record())
+        assert json.loads(raw) is not None
+
+    def test_required_fields_present(self) -> None:
+        data = _format(_make_record(name="keystone.test"))
+        assert "timestamp" in data
+        assert "level" in data
+        assert "logger" in data
+        assert "message" in data
+
+    def test_logger_name_matches_record(self) -> None:
+        data = _format(_make_record(name="keystone.daemon"))
+        assert data["logger"] == "keystone.daemon"
+
+    def test_level_matches_record(self) -> None:
+        data = _format(_make_record(level=logging.WARNING))
+        assert data["level"] == "WARNING"
+
+    def test_extra_fields_promoted_to_top_level(self) -> None:
+        data = _format(_make_record(team_id="t1", task_id="task-99", agent_id="a3"))
+        assert data["team_id"] == "t1"
+        assert data["task_id"] == "task-99"
+        assert data["agent_id"] == "a3"
+
+    def test_uses_get_message_not_msg(self) -> None:
+        record = _make_record("hello %s", args=("world",))
+        data = _format(record)
+        assert data["message"] == "hello world"
+
+    def test_timestamp_is_iso8601_utc(self) -> None:
+        data = _format(_make_record())
+        ts = datetime.fromisoformat(data["timestamp"])
+        assert ts.tzinfo is not None
+        assert ts.utcoffset().total_seconds() == 0  # type: ignore[union-attr]
+
+    def test_reserved_field_collision_prefixed(self) -> None:
+        data = _format(_make_record(level_custom=5))  # 'level' is reserved
+        # level_custom is NOT reserved, so it appears as-is
+        assert "level_custom" in data
+        # Verify actual collision: inject a field named 'level'
+        record = _make_record()
+        setattr(record, "level", "INJECTED")
+        out = _format(record)
+        assert out.get("ctx_level") == "INJECTED"
+        assert out["level"] != "INJECTED"
+
+    def test_non_serializable_value_uses_str_fallback(self) -> None:
+        class Unserializable:
+            def __repr__(self) -> str:
+                return "<Unserializable>"
+
+        data = _format(_make_record(custom=Unserializable()))
+        assert "custom" in data
+
+    def test_exc_info_adds_exception_field(self) -> None:
+        try:
+            raise ValueError("boom")
+        except ValueError:
+            record = logging.LogRecord("test", logging.ERROR, "", 0, "err", (), sys.exc_info())
+        data = _format(record)
+        assert "exception" in data
+        assert "ValueError" in data["exception"]
+
+    def test_include_location_adds_pathname_lineno_funcname(self) -> None:
+        """JsonFormatter with include_location=True must include location fields (line 40-42)."""
+        record = _make_record(name="test")
+        record.pathname = "/path/to/file.py"
+        record.lineno = 42
+        record.funcName = "test_func"
+
+        formatter = JsonFormatter(include_location=True)
+        data = json.loads(formatter.format(record))
+
+        assert data["pathname"] == "/path/to/file.py"
+        assert data["lineno"] == 42
+        assert data["funcName"] == "test_func"
+
+    def test_exclude_location_by_default(self) -> None:
+        """JsonFormatter without include_location must exclude location fields."""
+        record = _make_record(name="test")
+        record.pathname = "/path/to/file.py"
+        record.lineno = 42
+        record.funcName = "test_func"
+
+        formatter = JsonFormatter(include_location=False)
+        data = json.loads(formatter.format(record))
+
+        assert "pathname" not in data
+        assert "lineno" not in data
+        assert "funcName" not in data
+
+
+# ---------------------------------------------------------------------------
+# TestGetLogger
+# ---------------------------------------------------------------------------
+
+
+class TestGetLogger:
+    def test_returns_keystone_logger(self) -> None:
+        lg = get_logger(component="test")
+        assert isinstance(lg, KeystoneLogger)
+
+    def test_component_sets_logger_name(self) -> None:
+        lg = get_logger(component="daemon")
+        assert lg._logger.name == "keystone.daemon"
+
+    def test_no_component_uses_keystone_name(self) -> None:
+        lg = get_logger()
+        assert lg._logger.name == "keystone"
+
+    def test_context_bound_at_construction(self) -> None:
+        records: list[logging.LogRecord] = []
+
+        class CapturingHandler(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                records.append(record)
+
+        handler = CapturingHandler()
+        lg = get_logger(component="ctx_test", team_id="team-42")
+        lg._logger.addHandler(handler)
+        lg._logger.setLevel(logging.DEBUG)
+        lg._logger.propagate = False
+
+        lg.info("event")
+        assert len(records) == 1
+        assert records[0].__dict__.get("team_id") == "team-42"
+
+        # Cleanup
+        lg._logger.removeHandler(handler)
+        lg._logger.propagate = True
+
+
+# ---------------------------------------------------------------------------
+# TestKeystoneLoggerAdapter
+# ---------------------------------------------------------------------------
+
+
+class TestKeystoneLoggerAdapter:
+    def _capturing_logger(self, component: str) -> tuple[KeystoneLogger, list[logging.LogRecord]]:
+        records: list[logging.LogRecord] = []
+
+        class Cap(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                records.append(record)
+
+        cap = Cap()
+        lg = get_logger(component=component)
+        lg._logger.addHandler(cap)
+        lg._logger.setLevel(logging.DEBUG)
+        lg._logger.propagate = False
+        return lg, records
+
+    def test_process_does_not_mutate_caller_extra(self) -> None:
+        lg, records = self._capturing_logger("no_mutate")
+        lg.info("first", foo="bar")
+        lg.info("second", foo="baz")
+        assert records[0].__dict__["foo"] == "bar"
+        assert records[1].__dict__["foo"] == "baz"
+        assert len(records) == 2
+        lg._logger.handlers.clear()
+
+    def test_per_call_extra_merged_with_context(self) -> None:
+        lg = get_logger(component="merge_test", team_id="t1")
+        records: list[logging.LogRecord] = []
+
+        class Cap(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                records.append(record)
+
+        cap = Cap()
+        lg._logger.addHandler(cap)
+        lg._logger.setLevel(logging.DEBUG)
+        lg._logger.propagate = False
+
+        lg.info("event", task_id="task-1")
+        assert records[0].__dict__["team_id"] == "t1"
+        assert records[0].__dict__["task_id"] == "task-1"
+        lg._logger.handlers.clear()
+
+    def test_thread_safe_context_read(self) -> None:
+        lg = get_logger(component="threadsafe", team_id="t1")
+        records: list[logging.LogRecord] = []
+        errors: list[Exception] = []
+        lock = threading.Lock()
+
+        class Cap(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                with lock:
+                    records.append(record)
+
+        cap = Cap()
+        lg._logger.addHandler(cap)
+        lg._logger.setLevel(logging.DEBUG)
+        lg._logger.propagate = False
+
+        def worker() -> None:
+            try:
+                for _ in range(10):
+                    lg.info("ping", task_id="x")
+            except Exception as exc:
+                with lock:
+                    errors.append(exc)
+
+        threads = [threading.Thread(target=worker) for _ in range(5)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors
+        assert len(records) == 50
+        lg._logger.handlers.clear()
+
+    def test_debug_method_logs_at_debug_level(self) -> None:
+        """KeystoneLogger.debug() must log at DEBUG level (line 72)."""
+        lg, records = self._capturing_logger("debug_test")
+        lg.debug("debug_msg", key="value")
+        assert len(records) == 1
+        assert records[0].levelno == logging.DEBUG
+        assert records[0].getMessage() == "debug_msg"
+        lg._logger.handlers.clear()
+
+    def test_warning_method_logs_at_warning_level(self) -> None:
+        """KeystoneLogger.warning() must log at WARNING level (line 80)."""
+        lg, records = self._capturing_logger("warning_test")
+        lg.warning("warn_msg", key="value")
+        assert len(records) == 1
+        assert records[0].levelno == logging.WARNING
+        assert records[0].getMessage() == "warn_msg"
+        lg._logger.handlers.clear()
+
+    def test_error_method_logs_at_error_level(self) -> None:
+        """KeystoneLogger.error() must log at ERROR level (line 84)."""
+        lg, records = self._capturing_logger("error_test")
+        lg.error("error_msg", key="value")
+        assert len(records) == 1
+        assert records[0].levelno == logging.ERROR
+        assert records[0].getMessage() == "error_msg"
+        lg._logger.handlers.clear()
+
+    def test_bind_creates_new_logger_with_merged_context(self) -> None:
+        """KeystoneLogger.bind() returns a new logger with merged context (line 99-101)."""
+        lg1 = get_logger(component="bind_test", team_id="t1")
+        lg2 = lg1.bind(task_id="task-1", agent_id="a1")
+
+        # lg1 should still have only team_id
+        assert lg1._context == {"team_id": "t1"}
+        # lg2 should have merged context
+        assert lg2._context == {"team_id": "t1", "task_id": "task-1", "agent_id": "a1"}
+
+    def test_bind_overrides_existing_fields(self) -> None:
+        """KeystoneLogger.bind() overrides existing fields in context."""
+        lg1 = get_logger(component="bind_override", team_id="t1", task_id="old-task")
+        lg2 = lg1.bind(task_id="new-task")
+
+        assert lg1._context["task_id"] == "old-task"
+        assert lg2._context["task_id"] == "new-task"
+        assert lg2._context["team_id"] == "t1"
+
+    def test_bind_does_not_mutate_original(self) -> None:
+        """KeystoneLogger.bind() must not mutate the original logger's context."""
+        lg1 = get_logger(component="bind_immutable", team_id="t1")
+        original_context = dict(lg1._context)
+
+        lg2 = lg1.bind(task_id="task-1")
+
+        # Original should be unchanged
+        assert lg1._context == original_context
+        # New one should have the binding
+        assert "task_id" in lg2._context
+
+
+# ---------------------------------------------------------------------------
+# TestConfigureLogging
+# ---------------------------------------------------------------------------
+
+
+class TestConfigureLogging:
+    def setup_method(self) -> None:
+        # Clear root handlers before each test.
+        root = logging.getLogger()
+        root.handlers = [
+            h
+            for h in root.handlers
+            if not (isinstance(h, logging.StreamHandler) and h.stream is sys.stderr)
+        ]
+
+    def test_no_duplicate_handlers_on_repeated_calls(self) -> None:
+        configure_logging()
+        configure_logging()
+        root = logging.getLogger()
+        stderr_handlers = [
+            h
+            for h in root.handlers
+            if isinstance(h, logging.StreamHandler) and h.stream is sys.stderr
+        ]
+        assert len(stderr_handlers) == 1
+
+    def test_log_level_respected_debug(self) -> None:
+        buf = StringIO()
+        with patch("sys.stderr", buf):
+            configure_logging(level=logging.DEBUG)
+            logging.getLogger("keystone.level_test").debug("dbg_msg")
+        assert "dbg_msg" in buf.getvalue()
+
+    def test_log_level_respected_warning_filters_debug(self) -> None:
+        buf = StringIO()
+        with patch("sys.stderr", buf):
+            configure_logging(level=logging.WARNING)
+            logging.getLogger("keystone.level_test2").debug("should_not_appear")
+        assert "should_not_appear" not in buf.getvalue()
+
+    def test_output_goes_to_stderr(self) -> None:
+        root = logging.getLogger()
+        configure_logging()
+        handler = next(
+            h for h in root.handlers
+            if isinstance(h, logging.StreamHandler) and h.stream is sys.stderr
+        )
+        assert handler.stream is sys.stderr

--- a/clients/python/tests/orchestration/test_nats_listener.py
+++ b/clients/python/tests/orchestration/test_nats_listener.py
@@ -1,0 +1,234 @@
+"""Tests for NATSListener: ID validation in _on_task_event and start() error handling."""
+from __future__ import annotations
+
+import json
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+import nats.errors
+import nats.js.errors
+
+from agamemnon.orchestration.nats_listener import NATSListener
+
+
+def _make_listener() -> tuple[NATSListener, MagicMock]:
+    claimer = MagicMock()
+    claimer.advance_dag_tracked = MagicMock()
+    listener = NATSListener(claimer)
+    return listener, claimer
+
+
+class TestOnTaskEventValidIds:
+    async def test_valid_ids_dispatches(self) -> None:
+        listener, claimer = _make_listener()
+        await listener._on_task_event("hi.tasks.team-1.task-42.completed", "team-1", "task-42")
+        claimer.advance_dag_tracked.assert_called_once_with("team-1")
+
+    async def test_valid_uuid_ids_dispatches(self) -> None:
+        listener, claimer = _make_listener()
+        team = "550e8400-e29b-41d4-a716-446655440000"
+        task = "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+        await listener._on_task_event(f"hi.tasks.{team}.{task}.completed", team, task)
+        claimer.advance_dag_tracked.assert_called_once_with(team)
+
+
+class TestOnTaskEventInvalidIds:
+    async def test_empty_team_id_dropped(self) -> None:
+        listener, claimer = _make_listener()
+        await listener._on_task_event("hi.tasks...task-1.completed", "", "task-1")
+        claimer.advance_dag_tracked.assert_not_called()
+
+    async def test_slash_in_team_id_dropped(self) -> None:
+        listener, claimer = _make_listener()
+        await listener._on_task_event("hi.tasks.../admin.task-1.completed", "../admin", "task-1")
+        claimer.advance_dag_tracked.assert_not_called()
+
+    async def test_empty_task_id_dropped(self) -> None:
+        listener, claimer = _make_listener()
+        await listener._on_task_event("hi.tasks.team-1..completed", "team-1", "")
+        claimer.advance_dag_tracked.assert_not_called()
+
+    async def test_path_traversal_task_id_dropped(self) -> None:
+        listener, claimer = _make_listener()
+        await listener._on_task_event("hi.tasks.team-1.../etc.completed", "team-1", "../etc")
+        claimer.advance_dag_tracked.assert_not_called()
+
+    async def test_overlong_team_id_dropped(self) -> None:
+        listener, claimer = _make_listener()
+        bad_team = "a" * 257
+        await listener._on_task_event("hi.tasks.AAA.task-1.completed", bad_team, "task-1")
+        claimer.advance_dag_tracked.assert_not_called()
+
+
+class TestParseSubject:
+    def test_valid_subject_extracts_team_and_task(self) -> None:
+        result = NATSListener._parse_subject("hi.tasks.team-1.task-2.completed")
+        assert result == ("team-1", "task-2")
+
+    def test_short_subject_raises_value_error(self) -> None:
+        with pytest.raises(ValueError):
+            NATSListener._parse_subject("hi.tasks.team-1.task-2")
+
+    def test_long_subject_raises_value_error(self) -> None:
+        with pytest.raises(ValueError):
+            NATSListener._parse_subject("hi.tasks.team-1.task-2.completed.extra")
+
+    def test_empty_subject_raises(self) -> None:
+        with pytest.raises(ValueError):
+            NATSListener._parse_subject("")
+
+
+class TestOnTaskEventShutdown:
+    async def test_event_dropped_during_shutdown(self) -> None:
+        listener, claimer = _make_listener()
+        listener.begin_shutdown()
+        await listener._on_task_event("hi.tasks.team-1.task-1.completed", "team-1", "task-1")
+        claimer.advance_dag_tracked.assert_not_called()
+
+    async def test_shutdown_checked_before_validation(self) -> None:
+        listener, claimer = _make_listener()
+        listener.begin_shutdown()
+        # Even with invalid IDs, no error raised — shutdown takes priority
+        await listener._on_task_event("bad", "", "")
+        claimer.advance_dag_tracked.assert_not_called()
+
+
+class TestOnTaskEventRawPayload:
+    @pytest.mark.asyncio
+    async def test_valid_json_payload_dispatches(self) -> None:
+        listener, claimer = _make_listener()
+        payload = json.dumps({"status": "completed"}).encode()
+        await listener._on_task_event(
+            "hi.tasks.team-1.task-42.completed", "team-1", "task-42", raw_payload=payload
+        )
+        claimer.advance_dag_tracked.assert_called_once_with("team-1")
+
+    @pytest.mark.asyncio
+    async def test_invalid_json_payload_drops_event(self) -> None:
+        listener, claimer = _make_listener()
+        await listener._on_task_event(
+            "hi.tasks.team-1.task-42.completed",
+            "team-1",
+            "task-42",
+            raw_payload=b"not-valid-json",
+        )
+        claimer.advance_dag_tracked.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_payload_missing_status_still_dispatches(self) -> None:
+        listener, claimer = _make_listener()
+        payload = json.dumps({}).encode()
+        await listener._on_task_event(
+            "hi.tasks.team-1.task-42.completed", "team-1", "task-42", raw_payload=payload
+        )
+        claimer.advance_dag_tracked.assert_called_once_with("team-1")
+
+    @pytest.mark.asyncio
+    async def test_nested_data_status_resolves_effective_status(self) -> None:
+        listener, claimer = _make_listener()
+        payload = json.dumps({"data": {"status": "completed"}}).encode()
+        await listener._on_task_event(
+            "hi.tasks.team-1.task-42.completed", "team-1", "task-42", raw_payload=payload
+        )
+        claimer.advance_dag_tracked.assert_called_once_with("team-1")
+
+    @pytest.mark.asyncio
+    async def test_none_payload_dispatches_without_parsing(self) -> None:
+        listener, claimer = _make_listener()
+        await listener._on_task_event(
+            "hi.tasks.team-1.task-42.completed", "team-1", "task-42", raw_payload=None
+        )
+        claimer.advance_dag_tracked.assert_called_once_with("team-1")
+
+
+# ---------------------------------------------------------------------------
+# Helpers for start() tests
+# ---------------------------------------------------------------------------
+
+def _make_mock_nc(subscribe_side_effect: object = None) -> MagicMock:
+    """Return a mock NATS client whose jetstream().subscribe() behaves as specified."""
+    nc = MagicMock()
+    js = MagicMock()
+    nc.jetstream.return_value = js
+    if subscribe_side_effect is None:
+        js.subscribe = AsyncMock(return_value=MagicMock())
+    else:
+        js.subscribe = AsyncMock(side_effect=subscribe_side_effect)
+    return nc
+
+
+class TestStartSubscribeSuccess:
+    async def test_subscribe_success_returns(self) -> None:
+        listener, _ = _make_listener()
+        nc = _make_mock_nc()
+        await listener.start(nc, "hi.tasks.>", stream="homeric-tasks")
+        nc.jetstream().subscribe.assert_awaited_once()
+
+    async def test_subscribe_success_uses_subject(self) -> None:
+        listener, _ = _make_listener()
+        nc = _make_mock_nc()
+        await listener.start(nc, "hi.tasks.team-1.>", stream="homeric-tasks")
+        nc.jetstream().subscribe.assert_awaited_once_with("hi.tasks.team-1.>")
+
+
+class TestStartStreamNotFound:
+    async def test_stream_not_found_raises_runtime_error(self) -> None:
+        listener, _ = _make_listener()
+        nc = _make_mock_nc(subscribe_side_effect=nats.js.errors.NotFoundError())
+        with pytest.raises(RuntimeError, match="homeric-tasks"):
+            await listener.start(
+                nc, "hi.tasks.>", stream="homeric-tasks", max_retries=1, retry_base_delay=0.0
+            )
+
+    async def test_stream_not_found_retries_up_to_max(self) -> None:
+        listener, _ = _make_listener()
+        nc = _make_mock_nc(subscribe_side_effect=nats.js.errors.NotFoundError())
+        with pytest.raises(RuntimeError):
+            await listener.start(nc, "hi.tasks.>", max_retries=3, retry_base_delay=0.0)
+        assert nc.jetstream().subscribe.await_count == 3
+
+    async def test_stream_not_found_succeeds_on_retry(self) -> None:
+        listener, _ = _make_listener()
+        nc = MagicMock()
+        js = MagicMock()
+        nc.jetstream.return_value = js
+        js.subscribe = AsyncMock(
+            side_effect=[
+                nats.js.errors.NotFoundError(),
+                nats.js.errors.NotFoundError(),
+                MagicMock(),
+            ]
+        )
+        await listener.start(nc, "hi.tasks.>", max_retries=3, retry_base_delay=0.0)
+        assert js.subscribe.await_count == 3
+
+    async def test_error_message_includes_stream_name(self) -> None:
+        listener, _ = _make_listener()
+        nc = _make_mock_nc(subscribe_side_effect=nats.js.errors.NotFoundError())
+        with pytest.raises(RuntimeError, match="my-custom-stream"):
+            await listener.start(
+                nc, "hi.tasks.>", stream="my-custom-stream", max_retries=1, retry_base_delay=0.0
+            )
+
+
+class TestStartConnectionErrors:
+    async def test_no_servers_raises_connection_error(self) -> None:
+        listener, _ = _make_listener()
+        nc = _make_mock_nc(subscribe_side_effect=nats.errors.NoServersError())
+        with pytest.raises(ConnectionError, match="unreachable"):
+            await listener.start(nc, "hi.tasks.>")
+
+    async def test_auth_error_raises_connection_error(self) -> None:
+        listener, _ = _make_listener()
+        nc = _make_mock_nc(subscribe_side_effect=nats.errors.AuthorizationError())
+        with pytest.raises(ConnectionError, match="authentication"):
+            await listener.start(nc, "hi.tasks.>")
+
+    async def test_jetstream_unavailable_raises_runtime_error(self) -> None:
+        listener, _ = _make_listener()
+        nc = _make_mock_nc(
+            subscribe_side_effect=nats.js.errors.ServiceUnavailableError()
+        )
+        with pytest.raises(RuntimeError, match="JetStream"):
+            await listener.start(nc, "hi.tasks.>")

--- a/clients/python/tests/orchestration/test_nats_listener.py
+++ b/clients/python/tests/orchestration/test_nats_listener.py
@@ -2,12 +2,11 @@
 from __future__ import annotations
 
 import json
-
-import pytest
 from unittest.mock import AsyncMock, MagicMock
 
 import nats.errors
 import nats.js.errors
+import pytest
 
 from agamemnon.orchestration.nats_listener import NATSListener
 

--- a/clients/python/tests/orchestration/test_task_claimer.py
+++ b/clients/python/tests/orchestration/test_task_claimer.py
@@ -7,7 +7,6 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-
 from agamemnon.orchestration.task_claimer import TaskClaimer
 
 

--- a/clients/python/tests/orchestration/test_task_claimer.py
+++ b/clients/python/tests/orchestration/test_task_claimer.py
@@ -1,0 +1,351 @@
+"""Tests for TaskClaimer concurrency guard."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+from agamemnon.orchestration.task_claimer import TaskClaimer
+
+
+def _make_claimer(
+    tasks_by_team: dict[str, list[dict]] | None = None,
+    claim_result: bool = True,
+) -> tuple[TaskClaimer, AsyncMock, AsyncMock]:
+    tasks_by_team = tasks_by_team or {}
+
+    async def get_tasks(team_id: str) -> list[dict]:
+        return tasks_by_team.get(team_id, [])
+
+    get_tasks_mock = AsyncMock(side_effect=get_tasks)
+    claim_mock = AsyncMock(return_value=claim_result)
+    claimer = TaskClaimer(get_tasks=get_tasks_mock, claim_task=claim_mock)
+    return claimer, get_tasks_mock, claim_mock
+
+
+async def test_advance_dag_claims_ready_tasks() -> None:
+    tasks = [{"id": "t1"}, {"id": "t2"}]
+    claimer, get_tasks_mock, claim_mock = _make_claimer({"team-A": tasks})
+
+    result = await claimer.advance_dag("team-A")
+
+    assert result == ["t1", "t2"]
+    get_tasks_mock.assert_awaited_once_with("team-A")
+    assert claim_mock.await_count == 2
+    claim_mock.assert_any_await("team-A", "t1")
+    claim_mock.assert_any_await("team-A", "t2")
+
+
+async def test_advance_dag_empty_team_returns_empty() -> None:
+    claimer, get_tasks_mock, claim_mock = _make_claimer()
+
+    result = await claimer.advance_dag("team-empty")
+
+    assert result == []
+    get_tasks_mock.assert_awaited_once_with("team-empty")
+    claim_mock.assert_not_awaited()
+
+
+async def test_advance_dag_partial_claim_failures() -> None:
+    tasks = [{"id": "t1"}, {"id": "t2"}]
+
+    async def get_tasks(team_id: str) -> list[dict]:
+        return tasks
+
+    get_tasks_mock = AsyncMock(side_effect=get_tasks)
+    # First claim succeeds, second fails
+    claim_mock = AsyncMock(side_effect=[True, False])
+    claimer = TaskClaimer(get_tasks=get_tasks_mock, claim_task=claim_mock)
+
+    result = await claimer.advance_dag("team-A")
+
+    assert result == ["t1"]
+
+
+async def test_concurrent_advance_dag_coalesced() -> None:
+    """Second advance_dag for same team is skipped while first is in-flight."""
+    first_call_started = asyncio.Event()
+    first_call_proceed = asyncio.Event()
+
+    async def slow_get_tasks(team_id: str) -> list[dict]:
+        first_call_started.set()
+        await first_call_proceed.wait()
+        return [{"id": "t1"}]
+
+    get_tasks_mock = AsyncMock(side_effect=slow_get_tasks)
+    claim_mock = AsyncMock(return_value=True)
+    claimer = TaskClaimer(get_tasks=get_tasks_mock, claim_task=claim_mock)
+
+    async def first_call() -> list[str]:
+        return await claimer.advance_dag("team-X")
+
+    async def second_call() -> list[str]:
+        # Wait until first call is inside get_tasks (in-flight), then try
+        await first_call_started.wait()
+        result = await claimer.advance_dag("team-X")
+        # Now ungate the first call so the gather can complete
+        first_call_proceed.set()
+        return result
+
+    result1, result2 = await asyncio.gather(first_call(), second_call())
+
+    # First call completes normally; second was coalesced
+    assert result1 == ["t1"]
+    assert result2 == []
+    # get_tasks called only once - second call was skipped before calling it
+    assert get_tasks_mock.await_count == 1
+
+
+async def test_concurrent_advance_dag_different_teams_parallel() -> None:
+    """Concurrent calls for different teams both proceed independently."""
+    tasks = {"team-A": [{"id": "a1"}], "team-B": [{"id": "b1"}]}
+    claimer, get_tasks_mock, claim_mock = _make_claimer(tasks)
+
+    result_a, result_b = await asyncio.gather(
+        claimer.advance_dag("team-A"),
+        claimer.advance_dag("team-B"),
+    )
+
+    assert sorted(result_a) == ["a1"]
+    assert sorted(result_b) == ["b1"]
+    assert get_tasks_mock.await_count == 2
+
+
+async def test_advance_dag_lock_released_on_error() -> None:
+    """Lock and _advancing set are cleaned up even when get_tasks raises."""
+    call_count = 0
+
+    async def flaky_get_tasks(team_id: str) -> list[dict]:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise RuntimeError("transient failure")
+        return [{"id": "t1"}]
+
+    get_tasks_mock = AsyncMock(side_effect=flaky_get_tasks)
+    claim_mock = AsyncMock(return_value=True)
+    claimer = TaskClaimer(get_tasks=get_tasks_mock, claim_task=claim_mock)
+
+    with pytest.raises(RuntimeError, match="transient failure"):
+        await claimer.advance_dag("team-Z")
+
+    # Second call must not deadlock and must succeed
+    result = await claimer.advance_dag("team-Z")
+    assert result == ["t1"]
+    assert get_tasks_mock.await_count == 2
+
+
+async def test_sequential_calls_same_team_both_execute() -> None:
+    """Sequential (non-concurrent) calls for the same team both run normally."""
+    tasks = [{"id": "t1"}]
+    claimer, get_tasks_mock, claim_mock = _make_claimer({"team-A": tasks})
+
+    result1 = await claimer.advance_dag("team-A")
+    result2 = await claimer.advance_dag("team-A")
+
+    assert result1 == ["t1"]
+    assert result2 == ["t1"]
+    assert get_tasks_mock.await_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Issue #295 — coalesced count metrics
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_coalesced_count_increments_when_skipped() -> None:
+    """get_coalesced_count increments each time an advance_dag call is skipped."""
+    first_call_started = asyncio.Event()
+    first_call_proceed = asyncio.Event()
+
+    async def slow_get_tasks(team_id: str) -> list[dict]:
+        first_call_started.set()
+        await first_call_proceed.wait()
+        return []
+
+    get_tasks_mock = AsyncMock(side_effect=slow_get_tasks)
+    claim_mock = AsyncMock(return_value=True)
+    claimer = TaskClaimer(get_tasks=get_tasks_mock, claim_task=claim_mock)
+
+    async def first_call() -> list[str]:
+        return await claimer.advance_dag("team-X")
+
+    async def second_call() -> list[str]:
+        await first_call_started.wait()
+        result = await claimer.advance_dag("team-X")
+        first_call_proceed.set()
+        return result
+
+    await asyncio.gather(first_call(), second_call())
+
+    assert claimer.get_coalesced_count("team-X") == 1
+
+
+@pytest.mark.asyncio
+async def test_coalesced_count_zero_when_not_skipped() -> None:
+    """get_coalesced_count is 0 for a team that was never coalesced."""
+    claimer, _, _ = _make_claimer()
+    assert claimer.get_coalesced_count("team-never-seen") == 0
+
+
+@pytest.mark.asyncio
+async def test_get_metrics_returns_all_coalesced_teams() -> None:
+    """get_metrics returns a dict with entries for every coalesced team."""
+    first_started: dict[str, asyncio.Event] = {
+        "team-A": asyncio.Event(),
+        "team-B": asyncio.Event(),
+    }
+    proceed: dict[str, asyncio.Event] = {
+        "team-A": asyncio.Event(),
+        "team-B": asyncio.Event(),
+    }
+
+    async def slow_get_tasks(team_id: str) -> list[dict]:
+        first_started[team_id].set()
+        await proceed[team_id].wait()
+        return []
+
+    get_tasks_mock = AsyncMock(side_effect=slow_get_tasks)
+    claim_mock = AsyncMock(return_value=True)
+    claimer = TaskClaimer(get_tasks=get_tasks_mock, claim_task=claim_mock)
+
+    async def do_coalesce(team_id: str) -> None:
+        async def first() -> None:
+            await claimer.advance_dag(team_id)
+
+        async def second() -> None:
+            await first_started[team_id].wait()
+            await claimer.advance_dag(team_id)
+            proceed[team_id].set()
+
+        await asyncio.gather(first(), second())
+
+    await asyncio.gather(do_coalesce("team-A"), do_coalesce("team-B"))
+
+    metrics = claimer.get_metrics()
+    assert metrics.get("team-A", 0) == 1
+    assert metrics.get("team-B", 0) == 1
+
+
+# ---------------------------------------------------------------------------
+# Issue #296 — cleanup_idle_teams
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cleanup_idle_teams_removes_idle_locks() -> None:
+    """cleanup_idle_teams removes team locks that are not currently advancing."""
+    claimer, _, _ = _make_claimer()
+
+    # Trigger lazy lock creation for two teams by calling advance_dag
+    await claimer.advance_dag("team-A")
+    await claimer.advance_dag("team-B")
+
+    assert "team-A" in claimer._team_locks
+    assert "team-B" in claimer._team_locks
+
+    removed = claimer.cleanup_idle_teams()
+
+    assert "team-A" not in claimer._team_locks
+    assert "team-B" not in claimer._team_locks
+    assert set(removed) == {"team-A", "team-B"}
+
+
+@pytest.mark.asyncio
+async def test_cleanup_idle_teams_keeps_active_team() -> None:
+    """cleanup_idle_teams does not remove a lock for a team currently advancing."""
+    first_started = asyncio.Event()
+    proceed = asyncio.Event()
+
+    async def slow_get_tasks(team_id: str) -> list[dict]:
+        first_started.set()
+        await proceed.wait()
+        return []
+
+    claimer = TaskClaimer(
+        get_tasks=AsyncMock(side_effect=slow_get_tasks),
+        claim_task=AsyncMock(return_value=True),
+    )
+
+    advance_task = asyncio.get_event_loop().create_task(claimer.advance_dag("team-X"))
+    await first_started.wait()
+
+    # While team-X is actively advancing, cleanup should not remove it
+    removed = claimer.cleanup_idle_teams()
+    assert "team-X" not in removed
+    assert "team-X" in claimer._team_locks
+
+    proceed.set()
+    await advance_task
+
+
+@pytest.mark.asyncio
+async def test_cleanup_idle_teams_empty_is_noop() -> None:
+    """cleanup_idle_teams on a fresh claimer returns an empty list."""
+    claimer, _, _ = _make_claimer()
+    removed = claimer.cleanup_idle_teams()
+    assert removed == []
+
+
+# ---------------------------------------------------------------------------
+# Issue #300 — startup_scan
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_startup_scan_dispatches_advance_for_each_team() -> None:
+    """startup_scan schedules advance_dag_tracked for every supplied team_id."""
+    teams = {"team-A": [{"id": "a1"}], "team-B": [{"id": "b1"}]}
+    claimer, get_tasks_mock, claim_mock = _make_claimer(teams)
+
+    dispatched_tasks = await claimer.startup_scan(["team-A", "team-B"])
+
+    # All tasks should be asyncio.Task instances
+    assert len(dispatched_tasks) == 2
+    for t in dispatched_tasks:
+        assert isinstance(t, asyncio.Task)
+
+    # Let them all complete
+    await asyncio.gather(*dispatched_tasks)
+
+    # Both teams should have been fetched
+    assert get_tasks_mock.await_count == 2
+    called_teams = {c.args[0] for c in get_tasks_mock.call_args_list}
+    assert called_teams == {"team-A", "team-B"}
+
+
+@pytest.mark.asyncio
+async def test_startup_scan_empty_list_returns_no_tasks() -> None:
+    """startup_scan with an empty list produces no tasks."""
+    claimer, get_tasks_mock, _ = _make_claimer()
+
+    dispatched_tasks = await claimer.startup_scan([])
+
+    assert dispatched_tasks == []
+    get_tasks_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_startup_scan_tasks_are_tracked_in_flight() -> None:
+    """Tasks returned by startup_scan appear in the in_flight_count until done."""
+    proceed = asyncio.Event()
+
+    async def slow_get_tasks(team_id: str) -> list[dict]:
+        await proceed.wait()
+        return []
+
+    claimer = TaskClaimer(
+        get_tasks=AsyncMock(side_effect=slow_get_tasks),
+        claim_task=AsyncMock(return_value=True),
+    )
+
+    dispatched_tasks = await claimer.startup_scan(["team-A", "team-B"])
+    assert claimer.in_flight_count == 2
+
+    proceed.set()
+    await asyncio.gather(*dispatched_tasks)
+    assert claimer.in_flight_count == 0

--- a/clients/python/tests/orchestration/test_task_event.py
+++ b/clients/python/tests/orchestration/test_task_event.py
@@ -87,7 +87,9 @@ class TestTaskEventMissingFields:
             TaskEvent.model_validate({"status": "done", "unknownField": "ignored"})
 
     def test_task_id_and_team_id_populated(self) -> None:
-        event = TaskEvent.model_validate({"taskId": "t-42", "teamId": "team-1", "status": "completed"})
+        event = TaskEvent.model_validate(
+            {"taskId": "t-42", "teamId": "team-1", "status": "completed"}
+        )
         assert event.taskId == "t-42"
         assert event.teamId == "team-1"
         assert event.effective_status == "completed"

--- a/clients/python/tests/orchestration/test_task_event.py
+++ b/clients/python/tests/orchestration/test_task_event.py
@@ -1,0 +1,143 @@
+"""Unit tests for TaskEvent Pydantic model validation and status normalization."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from agamemnon.orchestration.models import TaskEvent, resolve_event_status
+
+
+class TestTaskEventFlatStatus:
+    """TaskEvent resolves effective_status from top-level status field."""
+
+    def test_flat_status_resolved(self) -> None:
+        event = TaskEvent.model_validate({"status": "completed"})
+        assert event.effective_status == "completed"
+
+    def test_flat_status_preserves_value(self) -> None:
+        event = TaskEvent.model_validate({"status": "failed"})
+        assert event.status == "failed"
+        assert event.effective_status == "failed"
+
+    @pytest.mark.parametrize("status", ["completed", "failed", "error", "cancelled", "running"])
+    def test_various_flat_statuses(self, status: str) -> None:
+        event = TaskEvent.model_validate({"status": status})
+        assert event.effective_status == status
+
+
+class TestTaskEventNestedStatus:
+    """TaskEvent resolves effective_status from data.status (Hermes format, issue #107)."""
+
+    def test_nested_data_status_resolved(self) -> None:
+        event = TaskEvent.model_validate({"data": {"status": "completed"}})
+        assert event.effective_status == "completed"
+
+    def test_nested_status_when_top_level_absent(self) -> None:
+        event = TaskEvent.model_validate({"data": {"status": "running", "extra": "value"}})
+        assert event.effective_status == "running"
+
+    def test_top_level_status_takes_precedence_over_nested(self) -> None:
+        event = TaskEvent.model_validate({"status": "completed", "data": {"status": "running"}})
+        assert event.effective_status == "completed"
+
+    def test_data_without_status_key(self) -> None:
+        event = TaskEvent.model_validate({"data": {"other": "value"}})
+        assert event.effective_status is None
+
+    def test_data_none_skipped(self) -> None:
+        event = TaskEvent.model_validate({"data": None})
+        assert event.effective_status is None
+
+
+class TestTaskEventNewStatus:
+    """TaskEvent resolves effective_status from newStatus field as fallback."""
+
+    def test_new_status_resolved_when_status_absent(self) -> None:
+        event = TaskEvent.model_validate({"newStatus": "completed"})
+        assert event.effective_status == "completed"
+
+    def test_status_takes_precedence_over_new_status(self) -> None:
+        event = TaskEvent.model_validate({"status": "failed", "newStatus": "completed"})
+        assert event.effective_status == "failed"
+
+    def test_nested_status_takes_precedence_over_new_status(self) -> None:
+        event = TaskEvent.model_validate({"data": {"status": "running"}, "newStatus": "completed"})
+        assert event.effective_status == "running"
+
+    def test_new_status_fallback_when_flat_and_nested_absent(self) -> None:
+        event = TaskEvent.model_validate({"newStatus": "cancelled", "taskId": "t-1"})
+        assert event.effective_status == "cancelled"
+
+
+class TestTaskEventMissingFields:
+    """TaskEvent handles sparse payloads gracefully — all fields optional."""
+
+    def test_empty_payload_is_valid(self) -> None:
+        event = TaskEvent.model_validate({})
+        assert event.effective_status is None
+        assert event.status is None
+        assert event.newStatus is None
+        assert event.data is None
+        assert event.taskId is None
+        assert event.teamId is None
+
+    def test_unknown_fields_ignored(self) -> None:
+        with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+            TaskEvent.model_validate({"status": "done", "unknownField": "ignored"})
+
+    def test_task_id_and_team_id_populated(self) -> None:
+        event = TaskEvent.model_validate({"taskId": "t-42", "teamId": "team-1", "status": "completed"})
+        assert event.taskId == "t-42"
+        assert event.teamId == "team-1"
+        assert event.effective_status == "completed"
+
+
+class TestTaskEventResolutionPriority:
+    """Verify the three-way resolution priority: status > data.status > newStatus."""
+
+    def test_all_three_present_top_level_wins(self) -> None:
+        event = TaskEvent.model_validate({
+            "status": "completed",
+            "data": {"status": "running"},
+            "newStatus": "failed",
+        })
+        assert event.effective_status == "completed"
+
+    def test_nested_beats_new_status(self) -> None:
+        event = TaskEvent.model_validate({
+            "data": {"status": "running"},
+            "newStatus": "failed",
+        })
+        assert event.effective_status == "running"
+
+    def test_empty_status_string_falls_through_to_nested(self) -> None:
+        event = TaskEvent.model_validate({"status": "", "data": {"status": "running"}})
+        assert event.effective_status == "running"
+
+    def test_empty_status_string_falls_through_to_new_status(self) -> None:
+        event = TaskEvent.model_validate({"status": "", "newStatus": "completed"})
+        assert event.effective_status == "completed"
+
+    def test_none_status_falls_through(self) -> None:
+        event = TaskEvent.model_validate({"status": None, "newStatus": "completed"})
+        assert event.effective_status == "completed"
+
+
+class TestResolveEventStatus:
+    """Unit tests for the standalone resolve_event_status utility function."""
+
+    def test_status_returned_when_set(self) -> None:
+        assert resolve_event_status("done", None, None) == "done"
+
+    def test_data_status_used_when_status_absent(self) -> None:
+        assert resolve_event_status(None, {"status": "done"}, None) == "done"
+
+    def test_new_status_used_as_final_fallback(self) -> None:
+        assert resolve_event_status(None, None, "done") == "done"
+
+    def test_status_takes_priority_over_data_and_new_status(self) -> None:
+        assert resolve_event_status("top", {"status": "nested"}, "new") == "top"
+
+    def test_all_none_returns_none(self) -> None:
+        assert resolve_event_status(None, None, None) is None

--- a/clients/python/tests/orchestration/test_validation.py
+++ b/clients/python/tests/orchestration/test_validation.py
@@ -1,0 +1,96 @@
+"""Unit tests for validate_id() in agamemnon.orchestration.validation."""
+
+from __future__ import annotations
+
+import pytest
+
+from agamemnon.orchestration.validation import validate_id
+
+
+class TestValidateIdAccepts:
+    """validate_id() should return the value unchanged for valid inputs."""
+
+    @pytest.mark.parametrize("value", [
+        "550e8400-e29b-41d4-a716-446655440000",  # standard UUID
+        "team-1",
+        "abc123",
+        "T",
+        "team.alpha",
+        "a" * 256,  # exactly at max length
+    ])
+    def test_valid_ids_pass(self, value: str) -> None:
+        assert validate_id(value, "team_id") == value
+
+    def test_returns_original_string(self) -> None:
+        val = "my-team-42"
+        assert validate_id(val, "team_id") is val
+
+
+class TestValidateIdRejects:
+    """validate_id() should raise ValueError for invalid inputs."""
+
+    def test_empty_string(self) -> None:
+        with pytest.raises(ValueError, match="empty"):
+            validate_id("", "team_id")
+
+    def test_whitespace_only(self) -> None:
+        with pytest.raises(ValueError, match="whitespace"):
+            validate_id("   ", "task_id")
+
+    def test_contains_forward_slash(self) -> None:
+        with pytest.raises(ValueError, match="path separator"):
+            validate_id("team/evil", "team_id")
+
+    def test_contains_backslash(self) -> None:
+        with pytest.raises(ValueError, match="path separator"):
+            validate_id("team\\evil", "team_id")
+
+    def test_path_traversal_with_slash(self) -> None:
+        with pytest.raises(ValueError):
+            validate_id("../admin", "team_id")
+
+    def test_path_traversal_dotdot_no_slash(self) -> None:
+        with pytest.raises(ValueError, match="path traversal"):
+            validate_id("..admin", "team_id")
+
+    def test_path_traversal_embedded(self) -> None:
+        with pytest.raises(ValueError, match="path traversal"):
+            validate_id("team..id", "team_id")
+
+    def test_contains_newline(self) -> None:
+        with pytest.raises(ValueError, match="invalid character"):
+            validate_id("team\nid", "team_id")
+
+    def test_contains_tab(self) -> None:
+        with pytest.raises(ValueError, match="invalid character"):
+            validate_id("team\tid", "team_id")
+
+    def test_contains_null_byte(self) -> None:
+        with pytest.raises(ValueError, match="invalid character"):
+            validate_id("team\x00id", "task_id")
+
+    def test_contains_control_character(self) -> None:
+        with pytest.raises(ValueError, match="invalid character"):
+            validate_id("team\x1fid", "task_id")
+
+    def test_exceeds_max_length(self) -> None:
+        with pytest.raises(ValueError, match="exceeds maximum length"):
+            validate_id("a" * 257, "team_id")
+
+    def test_error_message_includes_field_name(self) -> None:
+        with pytest.raises(ValueError, match="my_field"):
+            validate_id("", "my_field")
+
+
+class TestValidateIdFieldName:
+    """field_name is included in all error messages."""
+
+    @pytest.mark.parametrize("bad_value,field_name", [
+        ("", "team_id"),
+        ("../x", "task_id"),
+        ("x/y", "some_field"),
+        ("a" * 300, "record_id"),
+    ])
+    def test_field_name_in_error(self, bad_value: str, field_name: str) -> None:
+        with pytest.raises(ValueError, match=field_name):
+            validate_id(bad_value, field_name)

--- a/clients/python/tests/orchestration/test_version_bounds.py
+++ b/clients/python/tests/orchestration/test_version_bounds.py
@@ -1,9 +1,9 @@
 """Regression test: all pypi dependencies in pixi.toml must have bounded version specs."""
 
-import tomllib
 from pathlib import Path
 
 import pytest
+import tomllib
 
 PIXI_TOML = Path(__file__).resolve().parents[2] / "pixi.toml"
 

--- a/clients/python/tests/orchestration/test_version_bounds.py
+++ b/clients/python/tests/orchestration/test_version_bounds.py
@@ -1,0 +1,57 @@
+"""Regression test: all pypi dependencies in pixi.toml must have bounded version specs."""
+
+import tomllib
+from pathlib import Path
+
+import pytest
+
+PIXI_TOML = Path(__file__).resolve().parents[2] / "pixi.toml"
+
+
+def _load_pypi_deps() -> list[tuple[str, str, str]]:
+    """Yield (section, package, spec) for all pypi-dependencies."""
+    with open(PIXI_TOML, "rb") as f:
+        data = tomllib.load(f)
+
+    results: list[tuple[str, str, str]] = []
+
+    for pkg, spec in data.get("pypi-dependencies", {}).items():
+        if isinstance(spec, dict):
+            continue
+        results.append(("pypi-dependencies", pkg, spec))
+
+    dev_deps = data.get("feature", {}).get("dev", {}).get("pypi-dependencies", {})
+    for pkg, spec in dev_deps.items():
+        if isinstance(spec, dict):
+            continue
+        results.append(("feature.dev.pypi-dependencies", pkg, spec))
+
+    return results
+
+
+ALL_DEPS = _load_pypi_deps()
+
+
+@pytest.mark.parametrize(
+    "section,pkg,spec",
+    ALL_DEPS,
+    ids=[f"{s}::{p}" for s, p, _ in ALL_DEPS],
+)
+def test_has_upper_bound(section: str, pkg: str, spec: str) -> None:
+    """Every pypi dependency must declare a major-version upper bound."""
+    assert "<" in spec, (
+        f'{section} :: {pkg} = "{spec}" is missing an upper bound (<). '
+        "All pypi dependencies must have a major-version upper bound."
+    )
+
+
+@pytest.mark.parametrize(
+    "section,pkg,spec",
+    ALL_DEPS,
+    ids=[f"{s}::{p}" for s, p, _ in ALL_DEPS],
+)
+def test_no_wildcard(section: str, pkg: str, spec: str) -> None:
+    """Wildcard version specifiers are not allowed for pypi dependencies."""
+    assert spec.strip() != "*", (
+        f'{section} :: {pkg} = "*" — wildcard specifiers are not allowed.'
+    )


### PR DESCRIPTION
## Summary

- Copies 12 Python test files from `ProjectKeystone/tests/` into `clients/python/tests/orchestration/`
- Creates `clients/python/src/agamemnon/orchestration/` source package with migrated modules (`models`, `validation`, `logging`, `dag_walker`, `task_claimer`, `nats_listener`, `daemon`, `config`)
- Updates all import paths from `keystone.*` → `agamemnon.orchestration.*`
- Adds `nats-py>=2.6,<3` runtime dependency to `pyproject.toml` and `pixi.toml`
- Updates `pyproject.toml`: `pythonpath`, extended `coverage.run.source`, extended `hatch` packages, extended `mypy` packages

## Test plan

- [x] `pixi run python -m pytest tests/orchestration/ -v` → **210 passed, 0 failed**
- [x] `pixi run python -m pytest tests/ -v` → **288 passed, 0 failed** (no regressions in existing client tests)
- [x] `test_version_bounds.py` reads `clients/python/pixi.toml` at `parents[2]` and validates all deps have upper bounds

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)