### PR TITLE
feat(orchestration): rename env vars KEYSTONE_* → AGAMEMNON_* with deprecation shim

### DIFF
--- a/.github/workflows/python-client.yml
+++ b/.github/workflows/python-client.yml
@@ -39,6 +39,23 @@ jobs:
       - name: Run ruff
         run: pixi run --manifest-path clients/python/pixi.toml lint
 
+      - name: Track deprecated KEYSTONE_* env var names
+        run: |
+          count=$(grep -rn --include="*.py" \
+            "KEYSTONE_LOG_LEVEL\|KEYSTONE_POLL_INTERVAL\|KEYSTONE_SHUTDOWN_TIMEOUT" \
+            clients/python/src \
+            | grep -v '^\s*#' \
+            | wc -l)
+          if [ "$count" -gt 0 ]; then
+            echo "::warning::Found $count reference(s) to deprecated KEYSTONE_* env vars in src/ - should be 0 before shim removal"
+            grep -rn --include="*.py" \
+              "KEYSTONE_LOG_LEVEL\|KEYSTONE_POLL_INTERVAL\|KEYSTONE_SHUTDOWN_TIMEOUT" \
+              clients/python/src \
+              | grep -v '^\s*#' || true
+          else
+            echo "PASSED: No deprecated KEYSTONE_* references found in src/"
+          fi
+
   typecheck:
     name: Type Check
     runs-on: ubuntu-24.04

--- a/clients/python/src/agamemnon_client/__init__.py
+++ b/clients/python/src/agamemnon_client/__init__.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from importlib.metadata import PackageNotFoundError, version
 
 from agamemnon_client.client import AgamemnonClient as AgamemnonClient
+from agamemnon_client.config import Settings as Settings
+from agamemnon_client.config import load_settings as load_settings
 from agamemnon_client.errors import AgamemnonAPIError as AgamemnonAPIError
 from agamemnon_client.errors import AgamemnonConnectionError as AgamemnonConnectionError
 from agamemnon_client.errors import AgamemnonError as AgamemnonError
@@ -51,4 +53,6 @@ __all__ = [
     "FailureSpec",
     "InjectionResult",
     "ChaosEntry",
+    "Settings",
+    "load_settings",
 ]

--- a/clients/python/src/agamemnon_client/config.py
+++ b/clients/python/src/agamemnon_client/config.py
@@ -1,0 +1,45 @@
+"""Orchestration-layer settings loaded from environment variables."""
+
+from __future__ import annotations
+
+import os
+import warnings
+from dataclasses import dataclass
+
+
+@dataclass
+class Settings:
+    """Runtime settings for the Agamemnon orchestration layer."""
+
+    log_level: str
+    poll_interval: float
+    shutdown_timeout: float
+
+
+def _get_with_fallback(new_name: str, old_name: str, default: str) -> str:
+    """Return the value of *new_name*, falling back to *old_name* with a deprecation warning."""
+    if new_name in os.environ:
+        return os.environ[new_name]
+    if old_name in os.environ:
+        warnings.warn(
+            f"{old_name} is deprecated; use {new_name} instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return os.environ[old_name]
+    return default
+
+
+def load_settings() -> Settings:
+    """Load orchestration settings from environment variables."""
+    return Settings(
+        log_level=_get_with_fallback("AGAMEMNON_LOG_LEVEL", "KEYSTONE_LOG_LEVEL", "INFO"),
+        poll_interval=float(
+            _get_with_fallback("AGAMEMNON_POLL_INTERVAL", "KEYSTONE_POLL_INTERVAL", "1.0")
+        ),
+        shutdown_timeout=float(
+            _get_with_fallback(
+                "AGAMEMNON_SHUTDOWN_TIMEOUT", "KEYSTONE_SHUTDOWN_TIMEOUT", "30.0"
+            )
+        ),
+    )

--- a/clients/python/tests/test_config.py
+++ b/clients/python/tests/test_config.py
@@ -1,0 +1,155 @@
+"""Tests for agamemnon_client.config — Settings and load_settings."""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+from agamemnon_client.config import Settings, load_settings
+
+
+class TestLoadSettingsDefaults:
+    def test_defaults(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("AGAMEMNON_LOG_LEVEL", raising=False)
+        monkeypatch.delenv("AGAMEMNON_POLL_INTERVAL", raising=False)
+        monkeypatch.delenv("AGAMEMNON_SHUTDOWN_TIMEOUT", raising=False)
+        monkeypatch.delenv("KEYSTONE_LOG_LEVEL", raising=False)
+        monkeypatch.delenv("KEYSTONE_POLL_INTERVAL", raising=False)
+        monkeypatch.delenv("KEYSTONE_SHUTDOWN_TIMEOUT", raising=False)
+
+        s = load_settings()
+
+        assert s.log_level == "INFO"
+        assert s.poll_interval == 1.0
+        assert s.shutdown_timeout == 30.0
+
+    def test_return_type(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("AGAMEMNON_LOG_LEVEL", raising=False)
+        monkeypatch.delenv("AGAMEMNON_POLL_INTERVAL", raising=False)
+        monkeypatch.delenv("AGAMEMNON_SHUTDOWN_TIMEOUT", raising=False)
+        monkeypatch.delenv("KEYSTONE_LOG_LEVEL", raising=False)
+        monkeypatch.delenv("KEYSTONE_POLL_INTERVAL", raising=False)
+        monkeypatch.delenv("KEYSTONE_SHUTDOWN_TIMEOUT", raising=False)
+
+        s = load_settings()
+
+        assert isinstance(s, Settings)
+        assert isinstance(s.poll_interval, float)
+        assert isinstance(s.shutdown_timeout, float)
+
+
+class TestLoadSettingsNewNames:
+    def test_agamemnon_log_level(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AGAMEMNON_LOG_LEVEL", "DEBUG")
+        monkeypatch.delenv("KEYSTONE_LOG_LEVEL", raising=False)
+
+        s = load_settings()
+
+        assert s.log_level == "DEBUG"
+
+    def test_agamemnon_poll_interval(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AGAMEMNON_POLL_INTERVAL", "2.5")
+        monkeypatch.delenv("KEYSTONE_POLL_INTERVAL", raising=False)
+
+        s = load_settings()
+
+        assert s.poll_interval == 2.5
+
+    def test_agamemnon_shutdown_timeout(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AGAMEMNON_SHUTDOWN_TIMEOUT", "60.0")
+        monkeypatch.delenv("KEYSTONE_SHUTDOWN_TIMEOUT", raising=False)
+
+        s = load_settings()
+
+        assert s.shutdown_timeout == 60.0
+
+    def test_all_agamemnon_vars_no_warning(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AGAMEMNON_LOG_LEVEL", "WARNING")
+        monkeypatch.setenv("AGAMEMNON_POLL_INTERVAL", "0.5")
+        monkeypatch.setenv("AGAMEMNON_SHUTDOWN_TIMEOUT", "10.0")
+        monkeypatch.delenv("KEYSTONE_LOG_LEVEL", raising=False)
+        monkeypatch.delenv("KEYSTONE_POLL_INTERVAL", raising=False)
+        monkeypatch.delenv("KEYSTONE_SHUTDOWN_TIMEOUT", raising=False)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            s = load_settings()
+
+        assert s.log_level == "WARNING"
+        assert s.poll_interval == 0.5
+        assert s.shutdown_timeout == 10.0
+
+
+class TestLoadSettingsOldNames:
+    def test_keystone_log_level_warns(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("AGAMEMNON_LOG_LEVEL", raising=False)
+        monkeypatch.setenv("KEYSTONE_LOG_LEVEL", "ERROR")
+
+        with pytest.warns(DeprecationWarning, match="KEYSTONE_LOG_LEVEL is deprecated"):
+            s = load_settings()
+
+        assert s.log_level == "ERROR"
+
+    def test_keystone_poll_interval_warns(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("AGAMEMNON_POLL_INTERVAL", raising=False)
+        monkeypatch.setenv("KEYSTONE_POLL_INTERVAL", "5.0")
+
+        with pytest.warns(DeprecationWarning, match="KEYSTONE_POLL_INTERVAL is deprecated"):
+            s = load_settings()
+
+        assert s.poll_interval == 5.0
+
+    def test_keystone_shutdown_timeout_warns(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("AGAMEMNON_SHUTDOWN_TIMEOUT", raising=False)
+        monkeypatch.setenv("KEYSTONE_SHUTDOWN_TIMEOUT", "45.0")
+
+        with pytest.warns(DeprecationWarning, match="KEYSTONE_SHUTDOWN_TIMEOUT is deprecated"):
+            s = load_settings()
+
+        assert s.shutdown_timeout == 45.0
+
+    def test_deprecation_warning_message_includes_new_name(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("AGAMEMNON_LOG_LEVEL", raising=False)
+        monkeypatch.setenv("KEYSTONE_LOG_LEVEL", "DEBUG")
+
+        with pytest.warns(DeprecationWarning, match="AGAMEMNON_LOG_LEVEL"):
+            load_settings()
+
+
+class TestLoadSettingsPrecedence:
+    def test_agamemnon_takes_precedence_over_keystone(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("AGAMEMNON_LOG_LEVEL", "CRITICAL")
+        monkeypatch.setenv("KEYSTONE_LOG_LEVEL", "DEBUG")
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            s = load_settings()
+
+        assert s.log_level == "CRITICAL"
+
+    def test_agamemnon_poll_interval_precedence(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AGAMEMNON_POLL_INTERVAL", "3.0")
+        monkeypatch.setenv("KEYSTONE_POLL_INTERVAL", "99.0")
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            s = load_settings()
+
+        assert s.poll_interval == 3.0
+
+    def test_agamemnon_shutdown_timeout_precedence(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("AGAMEMNON_SHUTDOWN_TIMEOUT", "15.0")
+        monkeypatch.setenv("KEYSTONE_SHUTDOWN_TIMEOUT", "99.0")
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            s = load_settings()
+
+        assert s.shutdown_timeout == 15.0


### PR DESCRIPTION
## Summary

- Add `clients/python/src/agamemnon_client/config.py` with `Settings` dataclass and `load_settings()` that reads `AGAMEMNON_LOG_LEVEL`, `AGAMEMNON_POLL_INTERVAL`, and `AGAMEMNON_SHUTDOWN_TIMEOUT` first, falling back to `KEYSTONE_*` equivalents with `DeprecationWarning`
- Export `Settings` and `load_settings` from the package public API (`__init__.py`)
- Add 13 unit tests in `tests/test_config.py` covering defaults, new names (no warning), old names (warning + message content), and precedence (new over old)
- Add non-blocking CI lint step to track residual `KEYSTONE_*` references in `src/`

## Test plan

- [x] `pixi run test` — 91 tests pass, 99.3% coverage (≥96% threshold)
- [x] `pixi run lint` — ruff clean
- [x] `pixi run typecheck` — mypy strict, no issues across all 5 source files
- [x] Old `KEYSTONE_*` names still work (no breaking change for one release)
- [x] `AGAMEMNON_*` takes precedence when both are set; no warning emitted

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)