### PR TITLE
docs(api): add OpenAPI 3.1 spec and API reference documentation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,3 +26,12 @@ repos:
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
+
+  - repo: local
+    hooks:
+      - id: validate-openapi
+        name: Validate OpenAPI spec
+        language: script
+        entry: scripts/validate-openapi.sh
+        files: ^docs/api/openapi\.yaml$
+        pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -35,6 +35,20 @@ Agamemnon publishes and subscribes to the following NATS subjects:
 Local intra-host transport uses BlazingMQ + C++20 MessageBus. Cross-host transport uses
 NATS JetStream via nats.c v3.9.1 over Tailscale.
 
+## API Documentation
+
+The REST API exposes 25 endpoints across agents, teams, tasks, workflows, and chaos injection.
+
+- **[docs/api/README.md](docs/api/README.md)** — Human-readable endpoint reference with request/response tables
+- **[docs/api/openapi.yaml](docs/api/openapi.yaml)** — OpenAPI 3.1 specification (machine-readable)
+- **[docs/api/nats-events.md](docs/api/nats-events.md)** — NATS subject reference for all published/subscribed events
+
+Validate the spec locally:
+
+```bash
+just docs-validate
+```
+
 ## Prerequisites
 
 | Tool | Minimum Version | Notes |
@@ -46,7 +60,7 @@ NATS JetStream via nats.c v3.9.1 over Tailscale.
 | OpenSSL | 3.0 | Runtime: `libssl3`; build: `libssl-dev` |
 | pixi | any | Recommended; provides a reproducible dev environment |
 
-## Quick Start
+## Building
 
 ```bash
 git clone https://github.com/HomericIntelligence/ProjectAgamemnon.git

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,0 +1,171 @@
+# ProjectAgamemnon API Reference
+
+Full machine-readable spec: [`openapi.yaml`](openapi.yaml) (OpenAPI 3.1)
+
+**Base URL:** `http://localhost:8080` (override port with `PORT` env var)
+
+**Authentication:** None — Phase 1 is unauthenticated. All endpoints are open.
+
+---
+
+## Endpoint Summary
+
+### Health
+
+| Method | Path | Summary | Response |
+|--------|------|---------|----------|
+| GET | `/health` | Root health check | `{"status":"ok","service":"ProjectAgamemnon"}` |
+| GET | `/v1/health` | Versioned health check | `{"status":"ok"}` |
+| GET | `/v1/version` | Service version | `{"version":"0.1.0","name":"ProjectAgamemnon"}` |
+
+---
+
+### Agents
+
+| Method | Path | Summary | Request Body | Response |
+|--------|------|---------|-------------|----------|
+| GET | `/v1/agents` | List all agents | — | `{"agents":[...]}` |
+| POST | `/v1/agents` | Create agent | `AgentCreate` | 201 `{"id":"...","agent":{...}}` |
+| POST | `/v1/agents/docker` | Create Docker agent | `AgentCreate` | 201 `{"id":"...","agent":{...}}` |
+| GET | `/v1/agents/by-name/{name}` | Get agent by name | — | `{"agent":{...}}` |
+| GET | `/v1/agents/{id}` | Get agent by ID | — | `{"agent":{...}}` |
+| PATCH | `/v1/agents/{id}` | Partially update agent | `AgentPatch` | `{"agent":{...}}` |
+| DELETE | `/v1/agents/{id}` | Delete agent | — | `{"deleted":"<id>"}` |
+| POST | `/v1/agents/{id}/start` | Set agent online | — | `{"status":"online","id":"..."}` |
+| POST | `/v1/agents/{id}/stop` | Set agent offline | — | `{"status":"offline","id":"..."}` |
+
+**Agent object fields:**
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `id` | string (UUID) | Assigned at creation; immutable |
+| `name` | string | Default `"unnamed"` |
+| `label` | string | Optional label |
+| `program` | string | Executable path |
+| `workingDirectory` | string | Working directory for the process |
+| `programArgs` | string[] | CLI arguments |
+| `taskDescription` | string | Human-readable task description |
+| `tags` | string[] | Arbitrary tags |
+| `owner` | string | Owning entity |
+| `role` | string | Default `"worker"` |
+| `host` | string | Default `"local"`; `"docker"` for Docker agents |
+| `status` | `online`\|`offline` | Always `"offline"` at creation |
+| `createdAt` | ISO 8601 UTC | Assigned at creation; immutable |
+
+**Route registration note:** `POST /v1/agents/docker` and `GET /v1/agents/by-name/{name}` and
+`POST /v1/agents/{id}/start` / `POST /v1/agents/{id}/stop` are registered in cpp-httplib
+*before* the generic `POST /v1/agents` and `GET /v1/agents/{id}` routes to avoid prefix
+collision.
+
+---
+
+### Teams
+
+| Method | Path | Summary | Request Body | Response |
+|--------|------|---------|-------------|----------|
+| GET | `/v1/teams` | List all teams | — | `{"teams":[...]}` |
+| POST | `/v1/teams` | Create team | `TeamCreate` | 201 `{"team":{...}}` |
+| GET | `/v1/teams/{id}` | Get team by ID | — | `{"team":{...}}` |
+| PUT | `/v1/teams/{id}` | Update team fields | `TeamUpdate` | `{"team":{...}}` |
+| DELETE | `/v1/teams/{id}` | Delete team | — | `{"deleted":"<id>"}` |
+
+**Team object fields:**
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `id` | string (UUID) | Assigned at creation; immutable |
+| `name` | string | Default `"unnamed-team"` |
+| `agentIds` | string[] | Agent UUIDs; also accepted as `agent_ids` on input |
+| `createdAt` | ISO 8601 UTC | Assigned at creation; immutable |
+
+---
+
+### Tasks
+
+| Method | Path | Summary | Request Body | Response |
+|--------|------|---------|-------------|----------|
+| GET | `/v1/tasks` | List all tasks (all teams) | — | `{"tasks":[...]}` |
+| GET | `/v1/teams/{team_id}/tasks` | List tasks for a team | — | `{"tasks":[...]}` |
+| POST | `/v1/teams/{team_id}/tasks` | Create task | `TaskCreate` | 201 `{"task":{...}}` |
+| GET | `/v1/teams/{team_id}/tasks/{task_id}` | Get task by ID | — | `{"task":{...}}` |
+| PUT | `/v1/teams/{team_id}/tasks/{task_id}` | Update task (full merge) | `TaskUpdate` | `{"task":{...}}` |
+| PATCH | `/v1/teams/{team_id}/tasks/{task_id}` | Partially update task | `TaskUpdate` | `{"task":{...}}` |
+
+**Task object fields:**
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `id` | string (UUID) | Assigned at creation; immutable |
+| `teamId` | string | Set from URL path; immutable |
+| `subject` | string | Short title |
+| `description` | string | Long-form description |
+| `assigneeAgentId` | string | Assigned agent UUID; empty if unassigned |
+| `blockedBy` | string[] | Task IDs blocking this task |
+| `type` | string | Default `"general"`; used as myrmidon queue key |
+| `status` | string | `pending`\|`in_progress`\|`completed`\|`failed`; always `"pending"` at creation |
+| `createdAt` | ISO 8601 UTC | Assigned at creation; immutable |
+| `completedAt` | ISO 8601 UTC \| null | Auto-set when `status` → `"completed"` |
+
+**PUT vs PATCH:** Both use identical merge semantics server-side. PUT is used by Telemachy
+(the myrmidon completion protocol); PATCH is available for partial updates.
+
+**Myrmidon dispatch:** On task creation, Agamemnon publishes to
+`hi.myrmidon.{type}.{task_id}` so a myrmidon can pull the work. The myrmidon later
+publishes to `hi.tasks.{team_id}.{task_id}.completed`, which Agamemnon subscribes to and
+auto-marks the task completed.
+
+---
+
+### Workflows
+
+| Method | Path | Summary | Response |
+|--------|------|---------|----------|
+| GET | `/v1/workflows` | List workflows | `{"workflows":[]}` |
+
+> **Not implemented.** Always returns an empty array. Placeholder for future workflow support.
+
+---
+
+### Chaos
+
+| Method | Path | Summary | Request Body | Response |
+|--------|------|---------|-------------|----------|
+| GET | `/v1/chaos` | List active faults | — | `{"faults":[...]}` |
+| POST | `/v1/chaos/{type}` | Inject fault | — | 201 `{"fault":{...}}` |
+| DELETE | `/v1/chaos/{id}` | Remove fault | — | `{"deleted":"<id>"}` |
+
+**Fault object fields:**
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `id` | string (UUID) | Assigned at creation |
+| `type` | string | Fault type from path (e.g. `latency`, `drop`, `corrupt`) |
+| `active` | boolean | Always `true` when created |
+| `createdAt` | ISO 8601 UTC | |
+
+---
+
+## Error Responses
+
+All error responses use the same shape:
+
+```json
+{"error": "<human-readable message>"}
+```
+
+| Status | Condition |
+|--------|-----------|
+| 400 | Invalid JSON body |
+| 404 | Resource not found (`"<resource> not found"`) |
+
+---
+
+## Known Gaps
+
+- **No authentication** — Phase 1 intentionally unauthenticated
+- **No pagination** — all list endpoints return unbounded arrays
+- **No filtering** — no query parameter filtering on list endpoints
+- **Workflows stub** — `GET /v1/workflows` always returns `[]`
+- **In-memory only** — all state is lost on server restart; GitHub Issues/Projects
+  backing store is planned for Phase 2
+- **No TLS** — internal mesh traffic over Tailscale only

--- a/docs/api/nats-events.md
+++ b/docs/api/nats-events.md
@@ -1,0 +1,89 @@
+# NATS Event Reference
+
+Agamemnon publishes to NATS on every mutating operation. Subjects follow the
+`hi.*` namespace. Odysseus subscribes to `hi.tasks.>` and `hi.pipeline.>`;
+myrmidons pull from `hi.myrmidon.{type}.>`.
+
+All payloads are JSON-encoded strings.
+
+---
+
+## Published Events (Agamemnon → NATS)
+
+| Endpoint | NATS Subject | Trigger | Payload |
+|----------|-------------|---------|---------|
+| `POST /v1/agents` | `hi.agents.{host}.{name}.created` | Always | Full `{"id":..., "agent":{...}}` response |
+| `POST /v1/agents/docker` | `hi.agents.{host}.{name}.created` | Always | Full `{"id":..., "agent":{...}}` response |
+| `POST /v1/agents/{id}/start` | `hi.agents.{host}.{name}.updated` | Always | `{"status":"online","id":"..."}` |
+| `POST /v1/agents/{id}/stop` | `hi.agents.{host}.{name}.updated` | Always | `{"status":"offline","id":"..."}` |
+| `PATCH /v1/agents/{id}` | `hi.agents.{host}.{name}.updated` | Always | Full agent object |
+| `DELETE /v1/agents/{id}` | `hi.agents.{host}.{name}.deleted` | Always | `{"id":"<deleted-id>"}` |
+| `POST /v1/teams` | `hi.agents.team.created` | Always | Full `{"team":{...}}` response |
+| `PUT /v1/teams/{id}` | `hi.agents.team.updated` | Always | Full `{"team":{...}}` response |
+| `DELETE /v1/teams/{id}` | `hi.agents.team.deleted` | Always | `{"id":"<deleted-id>"}` |
+| `POST /v1/teams/{team_id}/tasks` | `hi.tasks.created` | Always | Full `{"task":{...}}` response |
+| `POST /v1/teams/{team_id}/tasks` | `hi.myrmidon.{type}.{task_id}` | Always | Myrmidon work payload (see below) |
+| `PUT /v1/teams/{team_id}/tasks/{task_id}` | `hi.tasks.{team_id}.{task_id}.updated` | Always | Full `{"task":{...}}` response |
+| `PATCH /v1/teams/{team_id}/tasks/{task_id}` | `hi.tasks.{team_id}.{task_id}.updated` | Always | Full `{"task":{...}}` response |
+| `POST /v1/chaos/{type}` | `hi.agents.chaos.injected` | Always | Full `{"fault":{...}}` response |
+| `DELETE /v1/chaos/{id}` | `hi.agents.chaos.removed` | Always | `{"id":"<deleted-id>"}` |
+
+### Conditional log events
+
+| Endpoint | NATS Subject | Trigger | Payload |
+|----------|-------------|---------|---------|
+| `POST /v1/agents` | `hi.logs.agamemnon.agent_created` | Always | Log envelope with `agent_id`, `name`, `type`, `host` |
+| `POST /v1/agents/docker` | `hi.logs.agamemnon.agent_created` | Always | Log envelope with `agent_id`, `name`, `type`, `host` |
+| `POST /v1/teams/{team_id}/tasks` | `hi.logs.agamemnon.task_dispatched` | Always | Log envelope with `task_id`, `team_id`, `type`, `subject` |
+| `PUT /v1/teams/{team_id}/tasks/{task_id}` | `hi.logs.agamemnon.task_completed` | Only when `status == "completed"` | Log envelope with `task_id`, `team_id`, `type`, `assignee` |
+| `PATCH /v1/teams/{team_id}/tasks/{task_id}` | `hi.logs.agamemnon.task_completed` | Only when `status == "completed"` | Log envelope with `task_id`, `team_id`, `type`, `assignee` |
+
+---
+
+## Subscribed Events (NATS → Agamemnon)
+
+Agamemnon also subscribes to one subject to receive myrmidon completions:
+
+| Subject | Publisher | Action |
+|---------|-----------|--------|
+| `hi.tasks.*.*.completed` | Myrmidons | Calls `store.mark_task_completed(task_id)` — sets `status=completed` and `completedAt=now()` |
+
+The myrmidon payload is expected to contain either `task_id` at the top level or nested
+under a `data` key:
+
+```json
+{"task_id": "<uuid>"}
+// or
+{"data": {"task_id": "<uuid>"}}
+```
+
+---
+
+## Myrmidon Work Payload
+
+When a task is created, Agamemnon dispatches to `hi.myrmidon.{type}.{task_id}`:
+
+```json
+{
+  "task_id": "<uuid>",
+  "team_id": "<uuid>",
+  "subject": "<task subject>",
+  "description": "<task description>",
+  "type": "<task type>",
+  "assignee": "<assigneeAgentId>"
+}
+```
+
+The NATS stream for myrmidon subjects uses `MaxAckPending=1` (pull-based, one-at-a-time).
+
+---
+
+## Subject Namespace Reference
+
+| Prefix | Description |
+|--------|-------------|
+| `hi.agents.>` | Agent lifecycle events and team events |
+| `hi.tasks.>` | Task state updates (Odysseus subscribes here) |
+| `hi.pipeline.>` | Pipeline state updates (Odysseus subscribes here) |
+| `hi.myrmidon.{type}.>` | Work queues — PULL consumers, myrmidons pull from here |
+| `hi.logs.agamemnon.>` | Structured log events from Agamemnon |

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1,0 +1,1181 @@
+openapi: "3.1.0"
+
+info:
+  title: ProjectAgamemnon API
+  version: "0.1.0"
+  description: |
+    REST API for ProjectAgamemnon — the planning, coordination, and agentic orchestration
+    service for the HomericIntelligence distributed agent mesh.
+
+    **Authentication:** Phase 1 has no authentication. All endpoints are unauthenticated.
+    Authentication will be added in a future phase.
+
+    **Transport:** Internal mesh traffic only (no TLS). Intended to be reached over Tailscale
+    (100.x.x.x) or localhost.
+
+    **NATS side-effects:** Mutating endpoints publish events to NATS subjects. See the
+    `x-nats-events` extension field on each operation and `docs/api/nats-events.md` for the
+    full reference.
+
+servers:
+  - url: http://localhost:8080
+    description: Local development (default port; override with PORT env var)
+
+tags:
+  - name: health
+    description: Health and version checks
+  - name: agents
+    description: Agent lifecycle management
+  - name: teams
+    description: Team management
+  - name: tasks
+    description: Task management (scoped to teams)
+  - name: workflows
+    description: Workflow management (placeholder — not yet implemented)
+  - name: chaos
+    description: Chaos fault injection (for ProjectCharybdis integration)
+
+paths:
+
+  # ── Health / version ──────────────────────────────────────────────────────────
+
+  /health:
+    get:
+      operationId: getHealth
+      tags: [health]
+      summary: Root health check
+      description: Unauthenticated liveness probe. Returns service name.
+      responses:
+        "200":
+          description: Service is alive
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RootHealth"
+              example:
+                status: ok
+                service: ProjectAgamemnon
+
+  /v1/health:
+    get:
+      operationId: getV1Health
+      tags: [health]
+      summary: Versioned health check
+      description: Preferred liveness probe for v1 clients.
+      responses:
+        "200":
+          description: Service is alive
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Health"
+              example:
+                status: ok
+
+  /v1/version:
+    get:
+      operationId: getVersion
+      tags: [health]
+      summary: Service version
+      responses:
+        "200":
+          description: Current service version
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Version"
+              example:
+                version: "0.1.0"
+                name: ProjectAgamemnon
+
+  # ── Agents ────────────────────────────────────────────────────────────────────
+
+  /v1/agents:
+    get:
+      operationId: listAgents
+      tags: [agents]
+      summary: List all agents
+      responses:
+        "200":
+          description: Array of all registered agents
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AgentList"
+
+    post:
+      operationId: createAgent
+      tags: [agents]
+      summary: Create a generic agent
+      description: |
+        Creates a new agent and stores it in-memory. The agent's initial `status` is always
+        `offline` regardless of what is supplied in the request body.
+
+        Publishes to NATS: `hi.agents.{host}.{name}.created`
+      x-nats-events:
+        - subject: "hi.agents.{host}.{name}.created"
+          trigger: always
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AgentCreate"
+            example:
+              name: my-agent
+              role: worker
+              host: local
+      responses:
+        "201":
+          description: Agent created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AgentCreateResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+
+  /v1/agents/docker:
+    post:
+      operationId: createDockerAgent
+      tags: [agents]
+      summary: Create a Docker agent
+      description: |
+        Functionally identical to `POST /v1/agents` but semantically typed for Docker-hosted
+        agents. Expects `host` and `image` fields in the body.
+
+        **Registration order:** This route is registered in cpp-httplib *before* the generic
+        `POST /v1/agents`, so requests to `/v1/agents/docker` are correctly routed here rather
+        than matching a generic handler.
+
+        Publishes to NATS: `hi.agents.{host}.{name}.created`
+      x-nats-events:
+        - subject: "hi.agents.{host}.{name}.created"
+          trigger: always
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AgentCreate"
+            example:
+              name: docker-worker
+              host: docker
+              program: python
+              programArgs: [worker.py]
+      responses:
+        "201":
+          description: Docker agent created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AgentCreateResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+
+  /v1/agents/by-name/{name}:
+    get:
+      operationId: getAgentByName
+      tags: [agents]
+      summary: Get agent by name
+      description: |
+        Looks up an agent by its `name` field. Returns 404 if no agent has that name.
+
+        **Registration order:** Registered before the generic `GET /v1/agents/{id}` route in
+        cpp-httplib, so `/v1/agents/by-name/foo` is not misrouted.
+      parameters:
+        - $ref: "#/components/parameters/AgentName"
+      responses:
+        "200":
+          description: Agent found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AgentWrapper"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /v1/agents/{id}:
+    get:
+      operationId: getAgent
+      tags: [agents]
+      summary: Get agent by ID
+      parameters:
+        - $ref: "#/components/parameters/AgentId"
+      responses:
+        "200":
+          description: Agent found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AgentWrapper"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+    patch:
+      operationId: updateAgent
+      tags: [agents]
+      summary: Partially update agent fields
+      description: |
+        Merges the supplied fields into the stored agent. The `id` and `createdAt` fields are
+        immutable and are silently ignored if present in the body.
+
+        Publishes to NATS: `hi.agents.{host}.{name}.updated`
+      x-nats-events:
+        - subject: "hi.agents.{host}.{name}.updated"
+          trigger: always
+      parameters:
+        - $ref: "#/components/parameters/AgentId"
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AgentPatch"
+      responses:
+        "200":
+          description: Agent updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AgentWrapper"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+    delete:
+      operationId: deleteAgent
+      tags: [agents]
+      summary: Delete agent
+      description: |
+        Removes the agent from the in-memory store.
+
+        Publishes to NATS: `hi.agents.{host}.{name}.deleted`
+      x-nats-events:
+        - subject: "hi.agents.{host}.{name}.deleted"
+          trigger: always
+      parameters:
+        - $ref: "#/components/parameters/AgentId"
+      responses:
+        "200":
+          description: Agent deleted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Deleted"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /v1/agents/{id}/start:
+    post:
+      operationId: startAgent
+      tags: [agents]
+      summary: Start agent
+      description: |
+        Sets the agent's `status` to `online`.
+
+        Publishes to NATS: `hi.agents.{host}.{name}.updated`
+      x-nats-events:
+        - subject: "hi.agents.{host}.{name}.updated"
+          trigger: always
+      parameters:
+        - $ref: "#/components/parameters/AgentId"
+      responses:
+        "200":
+          description: Agent started
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AgentStatusResponse"
+              example:
+                status: online
+                id: "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /v1/agents/{id}/stop:
+    post:
+      operationId: stopAgent
+      tags: [agents]
+      summary: Stop agent
+      description: |
+        Sets the agent's `status` to `offline`.
+
+        Publishes to NATS: `hi.agents.{host}.{name}.updated`
+      x-nats-events:
+        - subject: "hi.agents.{host}.{name}.updated"
+          trigger: always
+      parameters:
+        - $ref: "#/components/parameters/AgentId"
+      responses:
+        "200":
+          description: Agent stopped
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AgentStatusResponse"
+              example:
+                status: offline
+                id: "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  # ── Teams ─────────────────────────────────────────────────────────────────────
+
+  /v1/teams:
+    get:
+      operationId: listTeams
+      tags: [teams]
+      summary: List all teams
+      responses:
+        "200":
+          description: Array of all teams
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TeamList"
+
+    post:
+      operationId: createTeam
+      tags: [teams]
+      summary: Create a team
+      description: |
+        Publishes to NATS: `hi.agents.team.created`
+      x-nats-events:
+        - subject: "hi.agents.team.created"
+          trigger: always
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TeamCreate"
+            example:
+              name: alpha-team
+              agentIds:
+                - "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+      responses:
+        "201":
+          description: Team created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TeamWrapper"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+
+  /v1/teams/{id}:
+    get:
+      operationId: getTeam
+      tags: [teams]
+      summary: Get team by ID
+      parameters:
+        - $ref: "#/components/parameters/TeamId"
+      responses:
+        "200":
+          description: Team found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TeamWrapper"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+    put:
+      operationId: updateTeam
+      tags: [teams]
+      summary: Replace team fields
+      description: |
+        Updates `name` and/or `agentIds` on the team. Accepts both `agentIds` (camelCase) and
+        `agent_ids` (snake_case) for the agent list field; the stored value is always `agentIds`.
+
+        Only `name` and `agentIds` are updatable; other fields are ignored.
+
+        Publishes to NATS: `hi.agents.team.updated`
+      x-nats-events:
+        - subject: "hi.agents.team.updated"
+          trigger: always
+      parameters:
+        - $ref: "#/components/parameters/TeamId"
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TeamUpdate"
+      responses:
+        "200":
+          description: Team updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TeamWrapper"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+    delete:
+      operationId: deleteTeam
+      tags: [teams]
+      summary: Delete team
+      description: |
+        Publishes to NATS: `hi.agents.team.deleted`
+      x-nats-events:
+        - subject: "hi.agents.team.deleted"
+          trigger: always
+      parameters:
+        - $ref: "#/components/parameters/TeamId"
+      responses:
+        "200":
+          description: Team deleted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Deleted"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  # ── Tasks ─────────────────────────────────────────────────────────────────────
+
+  /v1/tasks:
+    get:
+      operationId: listAllTasks
+      tags: [tasks]
+      summary: List all tasks across all teams
+      responses:
+        "200":
+          description: Array of all tasks
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TaskList"
+
+  /v1/teams/{team_id}/tasks:
+    get:
+      operationId: listTeamTasks
+      tags: [tasks]
+      summary: List tasks for a team
+      parameters:
+        - $ref: "#/components/parameters/TeamIdPath"
+      responses:
+        "200":
+          description: Array of tasks belonging to this team
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TaskList"
+
+    post:
+      operationId: createTask
+      tags: [tasks]
+      summary: Create a task
+      description: |
+        Creates a new task scoped to the team. The task's initial `status` is always `pending`
+        and `completedAt` is always `null`.
+
+        After creation two NATS publishes occur:
+        1. `hi.tasks.created` — full task payload
+        2. `hi.myrmidon.{type}.{task_id}` — dispatches work to myrmidon pull queue
+      x-nats-events:
+        - subject: "hi.tasks.created"
+          trigger: always
+        - subject: "hi.myrmidon.{type}.{task_id}"
+          trigger: always
+          description: Dispatches task to the myrmidon work queue (PULL consumer, MaxAckPending=1)
+      parameters:
+        - $ref: "#/components/parameters/TeamIdPath"
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TaskCreate"
+            example:
+              subject: Implement login endpoint
+              description: Add POST /auth/login with JWT response
+              type: implementation
+              assigneeAgentId: "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+      responses:
+        "201":
+          description: Task created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TaskWrapper"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+
+  /v1/teams/{team_id}/tasks/{task_id}:
+    get:
+      operationId: getTask
+      tags: [tasks]
+      summary: Get task by ID
+      parameters:
+        - $ref: "#/components/parameters/TeamIdPath"
+        - $ref: "#/components/parameters/TaskIdPath"
+      responses:
+        "200":
+          description: Task found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TaskWrapper"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+    put:
+      operationId: updateTaskFull
+      tags: [tasks]
+      summary: Update task (full merge)
+      description: |
+        Merges all supplied fields into the stored task. The `id`, `teamId`, and `createdAt`
+        fields are immutable and silently ignored.
+
+        If `status` is set to `completed` and `completedAt` is currently `null`, `completedAt`
+        is automatically set to the current UTC timestamp.
+
+        **Used by Telemachy** (the myrmidon completion protocol) to report task results.
+
+        Publishes to NATS: `hi.tasks.{team_id}.{task_id}.updated`
+        If `status == "completed"`, also logs to: `hi.logs.agamemnon.task_completed`
+      x-nats-events:
+        - subject: "hi.tasks.{team_id}.{task_id}.updated"
+          trigger: always
+        - subject: "hi.logs.agamemnon.task_completed"
+          trigger: "when status == completed"
+      parameters:
+        - $ref: "#/components/parameters/TeamIdPath"
+        - $ref: "#/components/parameters/TaskIdPath"
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TaskUpdate"
+            example:
+              status: completed
+      responses:
+        "200":
+          description: Task updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TaskWrapper"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+    patch:
+      operationId: patchTask
+      tags: [tasks]
+      summary: Partially update task fields
+      description: |
+        Identical merge semantics to `PUT /v1/teams/{team_id}/tasks/{task_id}`. The HTTP method
+        distinction (PUT vs PATCH) is preserved for semantic clarity but the server-side
+        implementation is the same.
+
+        Publishes to NATS: `hi.tasks.{team_id}.{task_id}.updated`
+        If `status == "completed"`, also logs to: `hi.logs.agamemnon.task_completed`
+      x-nats-events:
+        - subject: "hi.tasks.{team_id}.{task_id}.updated"
+          trigger: always
+        - subject: "hi.logs.agamemnon.task_completed"
+          trigger: "when status == completed"
+      parameters:
+        - $ref: "#/components/parameters/TeamIdPath"
+        - $ref: "#/components/parameters/TaskIdPath"
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TaskUpdate"
+      responses:
+        "200":
+          description: Task updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TaskWrapper"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  # ── Workflows ─────────────────────────────────────────────────────────────────
+
+  /v1/workflows:
+    get:
+      operationId: listWorkflows
+      tags: [workflows]
+      summary: List workflows (stub)
+      description: |
+        **Not yet implemented.** Returns an empty array. This endpoint is a placeholder for
+        future workflow orchestration support.
+      x-not-implemented: true
+      responses:
+        "200":
+          description: Empty workflow list (stub response)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowList"
+              example:
+                workflows: []
+
+  # ── Chaos ─────────────────────────────────────────────────────────────────────
+
+  /v1/chaos:
+    get:
+      operationId: listFaults
+      tags: [chaos]
+      summary: List active chaos faults
+      responses:
+        "200":
+          description: Array of active faults
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FaultList"
+
+  /v1/chaos/{type}:
+    post:
+      operationId: injectFault
+      tags: [chaos]
+      summary: Inject a chaos fault
+      description: |
+        Creates a new fault of the given type. The fault is immediately active.
+
+        Publishes to NATS: `hi.agents.chaos.injected`
+      x-nats-events:
+        - subject: "hi.agents.chaos.injected"
+          trigger: always
+      parameters:
+        - $ref: "#/components/parameters/FaultType"
+      responses:
+        "201":
+          description: Fault injected
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FaultWrapper"
+
+  /v1/chaos/{id}:
+    delete:
+      operationId: removeFault
+      tags: [chaos]
+      summary: Remove a chaos fault
+      description: |
+        Removes the fault by ID, deactivating it.
+
+        Publishes to NATS: `hi.agents.chaos.removed`
+      x-nats-events:
+        - subject: "hi.agents.chaos.removed"
+          trigger: always
+      parameters:
+        - $ref: "#/components/parameters/FaultId"
+      responses:
+        "200":
+          description: Fault removed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Deleted"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+# ── Components ────────────────────────────────────────────────────────────────
+
+components:
+
+  parameters:
+    AgentId:
+      name: id
+      in: path
+      required: true
+      schema:
+        type: string
+      description: Agent UUID
+
+    AgentName:
+      name: name
+      in: path
+      required: true
+      schema:
+        type: string
+      description: Agent name (exact match)
+
+    TeamId:
+      name: id
+      in: path
+      required: true
+      schema:
+        type: string
+      description: Team UUID
+
+    TeamIdPath:
+      name: team_id
+      in: path
+      required: true
+      schema:
+        type: string
+      description: Team UUID
+
+    TaskIdPath:
+      name: task_id
+      in: path
+      required: true
+      schema:
+        type: string
+      description: Task UUID
+
+    FaultType:
+      name: type
+      in: path
+      required: true
+      schema:
+        type: string
+      description: Fault type identifier (e.g. `latency`, `drop`, `corrupt`)
+
+    FaultId:
+      name: id
+      in: path
+      required: true
+      schema:
+        type: string
+      description: Fault UUID
+
+  responses:
+    BadRequest:
+      description: Invalid JSON body or missing required field
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+          example:
+            error: "invalid JSON: ..."
+
+    NotFound:
+      description: Resource not found
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+          example:
+            error: "agent not found"
+
+  schemas:
+
+    # ── Health ──────────────────────────────────────────────────────────────
+
+    RootHealth:
+      type: object
+      required: [status, service]
+      properties:
+        status:
+          type: string
+          enum: [ok]
+        service:
+          type: string
+          example: ProjectAgamemnon
+
+    Health:
+      type: object
+      required: [status]
+      properties:
+        status:
+          type: string
+          enum: [ok]
+
+    Version:
+      type: object
+      required: [version, name]
+      properties:
+        version:
+          type: string
+          example: "0.1.0"
+        name:
+          type: string
+          example: ProjectAgamemnon
+
+    # ── Shared ──────────────────────────────────────────────────────────────
+
+    Error:
+      type: object
+      required: [error]
+      properties:
+        error:
+          type: string
+
+    Deleted:
+      type: object
+      required: [deleted]
+      properties:
+        deleted:
+          type: string
+          description: ID of the deleted resource
+
+    # ── Agents ──────────────────────────────────────────────────────────────
+
+    Agent:
+      type: object
+      required: [id, name, status, createdAt]
+      properties:
+        id:
+          type: string
+          description: UUID v4 assigned at creation
+        name:
+          type: string
+          default: unnamed
+        label:
+          type: string
+          default: ""
+        program:
+          type: string
+          description: Executable path or command
+          default: ""
+        workingDirectory:
+          type: string
+          default: ""
+        programArgs:
+          type: array
+          items:
+            type: string
+          default: []
+        taskDescription:
+          type: string
+          default: ""
+        tags:
+          type: array
+          items:
+            type: string
+          default: []
+        owner:
+          type: string
+          default: ""
+        role:
+          type: string
+          default: worker
+        host:
+          type: string
+          description: "Host identifier; `docker` for Docker agents"
+          default: local
+        status:
+          type: string
+          enum: [online, offline]
+          description: Set to `offline` at creation; changed by /start and /stop
+        createdAt:
+          type: string
+          format: date-time
+          description: ISO 8601 UTC timestamp
+
+    AgentCreate:
+      type: object
+      properties:
+        name:
+          type: string
+          default: unnamed
+        label:
+          type: string
+        program:
+          type: string
+        workingDirectory:
+          type: string
+        programArgs:
+          type: array
+          items:
+            type: string
+        taskDescription:
+          type: string
+        tags:
+          type: array
+          items:
+            type: string
+        owner:
+          type: string
+        role:
+          type: string
+          default: worker
+        host:
+          type: string
+          default: local
+
+    AgentPatch:
+      type: object
+      description: Any Agent fields except `id` and `createdAt`
+      properties:
+        name:
+          type: string
+        label:
+          type: string
+        program:
+          type: string
+        workingDirectory:
+          type: string
+        programArgs:
+          type: array
+          items:
+            type: string
+        taskDescription:
+          type: string
+        tags:
+          type: array
+          items:
+            type: string
+        owner:
+          type: string
+        role:
+          type: string
+        host:
+          type: string
+        status:
+          type: string
+          enum: [online, offline]
+
+    AgentWrapper:
+      type: object
+      required: [agent]
+      properties:
+        agent:
+          $ref: "#/components/schemas/Agent"
+
+    AgentCreateResponse:
+      type: object
+      required: [id, agent]
+      properties:
+        id:
+          type: string
+          description: UUID of the created agent
+        agent:
+          $ref: "#/components/schemas/Agent"
+
+    AgentStatusResponse:
+      type: object
+      required: [status, id]
+      properties:
+        status:
+          type: string
+          enum: [online, offline]
+        id:
+          type: string
+
+    AgentList:
+      type: object
+      required: [agents]
+      properties:
+        agents:
+          type: array
+          items:
+            $ref: "#/components/schemas/Agent"
+
+    # ── Teams ───────────────────────────────────────────────────────────────
+
+    Team:
+      type: object
+      required: [id, name, agentIds, createdAt]
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+          default: unnamed-team
+        agentIds:
+          type: array
+          items:
+            type: string
+          description: UUIDs of agents assigned to this team
+          default: []
+        createdAt:
+          type: string
+          format: date-time
+
+    TeamCreate:
+      type: object
+      properties:
+        name:
+          type: string
+          default: unnamed-team
+        agentIds:
+          type: array
+          items:
+            type: string
+          description: Also accepted as `agent_ids` (snake_case alias)
+        agent_ids:
+          type: array
+          items:
+            type: string
+          description: Snake_case alias for `agentIds`
+
+    TeamUpdate:
+      type: object
+      properties:
+        name:
+          type: string
+        agentIds:
+          type: array
+          items:
+            type: string
+          description: Also accepted as `agent_ids`
+        agent_ids:
+          type: array
+          items:
+            type: string
+
+    TeamWrapper:
+      type: object
+      required: [team]
+      properties:
+        team:
+          $ref: "#/components/schemas/Team"
+
+    TeamList:
+      type: object
+      required: [teams]
+      properties:
+        teams:
+          type: array
+          items:
+            $ref: "#/components/schemas/Team"
+
+    # ── Tasks ───────────────────────────────────────────────────────────────
+
+    Task:
+      type: object
+      required: [id, teamId, subject, status, createdAt]
+      properties:
+        id:
+          type: string
+        teamId:
+          type: string
+        subject:
+          type: string
+          default: ""
+        description:
+          type: string
+          default: ""
+        assigneeAgentId:
+          type: string
+          description: UUID of the assigned agent (empty string if unassigned)
+          default: ""
+        blockedBy:
+          type: array
+          items:
+            type: string
+          description: Task IDs this task is blocked by
+          default: []
+        type:
+          type: string
+          description: Task type; used to route to myrmidon work queue (`hi.myrmidon.{type}.{id}`)
+          default: general
+        status:
+          type: string
+          enum: [pending, in_progress, completed, failed]
+          default: pending
+        createdAt:
+          type: string
+          format: date-time
+        completedAt:
+          type: ["string", "null"]
+          format: date-time
+          description: Set automatically when `status` transitions to `completed`
+
+    TaskCreate:
+      type: object
+      properties:
+        subject:
+          type: string
+        description:
+          type: string
+        assigneeAgentId:
+          type: string
+        blockedBy:
+          type: array
+          items:
+            type: string
+        type:
+          type: string
+          default: general
+
+    TaskUpdate:
+      type: object
+      description: Any Task fields except `id`, `teamId`, and `createdAt`
+      properties:
+        subject:
+          type: string
+        description:
+          type: string
+        assigneeAgentId:
+          type: string
+        blockedBy:
+          type: array
+          items:
+            type: string
+        type:
+          type: string
+        status:
+          type: string
+          enum: [pending, in_progress, completed, failed]
+
+    TaskWrapper:
+      type: object
+      required: [task]
+      properties:
+        task:
+          $ref: "#/components/schemas/Task"
+
+    TaskList:
+      type: object
+      required: [tasks]
+      properties:
+        tasks:
+          type: array
+          items:
+            $ref: "#/components/schemas/Task"
+
+    # ── Workflows ───────────────────────────────────────────────────────────
+
+    WorkflowList:
+      type: object
+      required: [workflows]
+      properties:
+        workflows:
+          type: array
+          items: {}
+          description: Always empty in Phase 1
+
+    # ── Chaos ───────────────────────────────────────────────────────────────
+
+    Fault:
+      type: object
+      required: [id, type, active, createdAt]
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+          description: Fault type (e.g. `latency`, `drop`, `corrupt`)
+        active:
+          type: boolean
+          default: true
+        createdAt:
+          type: string
+          format: date-time
+
+    FaultWrapper:
+      type: object
+      required: [fault]
+      properties:
+        fault:
+          $ref: "#/components/schemas/Fault"
+
+    FaultList:
+      type: object
+      required: [faults]
+      properties:
+        faults:
+          type: array
+          items:
+            $ref: "#/components/schemas/Fault"

--- a/justfile
+++ b/justfile
@@ -32,5 +32,8 @@ coverage:
 clean:
   rm -rf build install
 
+docs-validate:
+  ./scripts/validate-openapi.sh
+
 ci:
   cmake --preset ci && cmake --build --preset ci && ctest --preset ci

--- a/scripts/validate-openapi.sh
+++ b/scripts/validate-openapi.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Validates docs/api/openapi.yaml with @stoplight/spectral-cli.
+# Requires: npx (Node.js >= 18) or a globally installed spectral binary.
+# Exit codes: 0 = valid, non-zero = validation errors.
+set -euo pipefail
+
+SPEC="${1:-docs/api/openapi.yaml}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SPEC_PATH="${REPO_ROOT}/${SPEC}"
+
+if [[ ! -f "${SPEC_PATH}" ]]; then
+  echo "ERROR: spec not found at ${SPEC_PATH}" >&2
+  exit 1
+fi
+
+if command -v spectral &>/dev/null; then
+  spectral lint --ruleset @stoplight/spectral-openapi "${SPEC_PATH}"
+else
+  npx --yes @stoplight/spectral-cli@latest lint --ruleset @stoplight/spectral-openapi "${SPEC_PATH}"
+fi


### PR DESCRIPTION
## Summary

- Adds `docs/api/openapi.yaml` — OpenAPI 3.1 spec covering all 25 endpoints in `routes.cpp` with full request/response schemas, path parameters, `x-nats-events` extensions, and documented gaps
- Adds `docs/api/README.md` — human-readable endpoint reference with method/path/body/response tables for all 6 endpoint groups; includes Known Gaps section
- Adds `docs/api/nats-events.md` — NATS subject reference mapping every mutating endpoint to published subjects plus the myrmidon subscription (`hi.tasks.*.*.completed`)
- Adds `scripts/validate-openapi.sh` — validates the spec via `@stoplight/spectral-cli`; falls back to `npx` if `spectral` not on PATH
- Adds `just docs-validate` recipe to `justfile`
- Adds pre-commit local hook to validate `docs/api/openapi.yaml` on changes
- Updates `README.md` with an API Documentation section linking to all three docs

## Test plan

- [ ] `just docs-validate` runs `spectral lint` against `docs/api/openapi.yaml` without errors
- [ ] Cross-check every row in `docs/api/README.md` against `src/routes.cpp` — no endpoint missing
- [ ] `PUT /v1/teams/{id}/tasks/{task_id}` description mentions full-merge semantics and Telemachy usage
- [ ] `GET /v1/workflows` is marked `x-not-implemented: true` and described as a stub
- [ ] No-auth gap documented in `openapi.yaml` `info.description` and `docs/api/README.md#known-gaps`
- [ ] NATS subject `hi.myrmidon.{type}.{task_id}` documented in both `openapi.yaml` and `nats-events.md`

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)