### PR TITLE
fix(docs): sync nats.c version in CLAUDE.md to match CMakeLists.txt

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ All inter-component communication flows **through ProjectKeystone** (invisible t
 Components publish/subscribe to logical subjects — Keystone routes transparently:
 
 - Local (intra-host): BlazingMQ + C++20 MessageBus
-- Cross-host: NATS JetStream via nats.c v3.12.0 over Tailscale
+- Cross-host: NATS JetStream via nats.c v3.9.1 over Tailscale
 
 Relevant NATS subjects Agamemnon uses:
 


### PR DESCRIPTION
## Summary

- CLAUDE.md (line 30) documented `nats.c v3.12.0` but `CMakeLists.txt` (line 33) pins `GIT_TAG v3.9.1`
- Updated CLAUDE.md to reflect the actual pinned version (`v3.9.1`)

## Test plan

- [ ] No code changes — documentation-only fix
- [ ] Verify CLAUDE.md line 30 now reads `nats.c v3.9.1`
- [ ] Verify CMakeLists.txt line 33 still reads `GIT_TAG v3.9.1`

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)