### PR TITLE
fix(routes): use kVersion/kProjectName constants in /v1/version endpoint

### DIFF
--- a/src/routes.cpp
+++ b/src/routes.cpp
@@ -2,6 +2,7 @@
 
 #include "projectagamemnon/nats_client.hpp"
 #include "projectagamemnon/store.hpp"
+#include "projectagamemnon/version.hpp"
 
 // cpp-httplib — single-header, no SSL needed for internal mesh traffic
 #define CPPHTTPLIB_NO_EXCEPTIONS
@@ -65,7 +66,7 @@ void register_routes(httplib::Server& server, Store& store, NatsClient& nats) {
   });
 
   server.Get("/v1/version", [](const httplib::Request&, httplib::Response& res) {
-    reply_json(res, 200, {{"version", "0.1.0"}, {"name", "ProjectAgamemnon"}});
+    reply_json(res, 200, {{"version", std::string(kVersion)}, {"name", std::string(kProjectName)}});
   });
 
   // ── Agents ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Replace hardcoded `"0.1.0"` and `"ProjectAgamemnon"` string literals in the `/v1/version` handler with `kVersion` and `kProjectName` from `version.hpp`
- Add `#include "projectagamemnon/version.hpp"` to `src/routes.cpp`

This eliminates the DRY violation where the version string was defined in `version.hpp` (and `CMakeLists.txt`) but duplicated verbatim in `routes.cpp`.

## Test plan

- [ ] Build passes: `pixi run cmake --build --preset debug`
- [ ] All existing tests pass: `pixi run ctest --preset debug` (2/2 passed)
- [ ] No new test needed — the existing `VersionTest` suite validates `kVersion`/`kProjectName` values

Closes #47

🤖 Generated with [Claude Code](https://claude.ai/claude-code)