### PR TITLE
fix(server): safe PORT env var parsing — replace std::stoi with std::from_chars

### DIFF
--- a/include/projectagamemnon/port_parse.hpp
+++ b/include/projectagamemnon/port_parse.hpp
@@ -1,0 +1,23 @@
+#pragma once
+#include <charconv>
+#include <cstring>
+#include <optional>
+
+namespace projectagamemnon {
+
+struct PortParseResult {
+    std::optional<int> port;
+    const char* error = nullptr;  // non-owning string literal
+};
+
+inline PortParseResult parse_port(const char* str) {
+    if (!str || !*str) return {std::nullopt, "empty"};
+    int parsed = 0;
+    const auto* end = str + std::strlen(str);
+    auto [ptr, ec] = std::from_chars(str, end, parsed);
+    if (ec != std::errc{} || ptr != end) return {std::nullopt, "not a valid integer"};
+    if (parsed < 1 || parsed > 65535) return {std::nullopt, "out of range [1,65535]"};
+    return {parsed, nullptr};
+}
+
+}  // namespace projectagamemnon

--- a/include/projectagamemnon/port_parse.hpp
+++ b/include/projectagamemnon/port_parse.hpp
@@ -6,18 +6,18 @@
 namespace projectagamemnon {
 
 struct PortParseResult {
-    std::optional<int> port;
-    const char* error = nullptr;  // non-owning string literal
+  std::optional<int> port;
+  const char* error = nullptr;  // non-owning string literal
 };
 
 inline PortParseResult parse_port(const char* str) {
-    if (!str || !*str) return {std::nullopt, "empty"};
-    int parsed = 0;
-    const auto* end = str + std::strlen(str);
-    auto [ptr, ec] = std::from_chars(str, end, parsed);
-    if (ec != std::errc{} || ptr != end) return {std::nullopt, "not a valid integer"};
-    if (parsed < 1 || parsed > 65535) return {std::nullopt, "out of range [1,65535]"};
-    return {parsed, nullptr};
+  if (!str || !*str) return {std::nullopt, "empty"};
+  int parsed = 0;
+  const auto* end = str + std::strlen(str);
+  auto [ptr, ec] = std::from_chars(str, end, parsed);
+  if (ec != std::errc{} || ptr != end) return {std::nullopt, "not a valid integer"};
+  if (parsed < 1 || parsed > 65535) return {std::nullopt, "out of range [1,65535]"};
+  return {parsed, nullptr};
 }
 
 }  // namespace projectagamemnon

--- a/src/server_main.cpp
+++ b/src/server_main.cpp
@@ -65,8 +65,8 @@ int main() {
   if (port_env) {
     auto result = projectagamemnon::parse_port(port_env);
     if (!result.port.has_value()) {
-      std::cerr << "[agamemnon] WARNING: PORT=\"" << port_env
-                << "\" is invalid (" << result.error << "), defaulting to " << port << "\n";
+      std::cerr << "[agamemnon] WARNING: PORT=\"" << port_env << "\" is invalid (" << result.error
+                << "), defaulting to " << port << "\n";
     } else {
       port = result.port.value();
     }

--- a/src/server_main.cpp
+++ b/src/server_main.cpp
@@ -1,4 +1,5 @@
 #include "projectagamemnon/nats_client.hpp"
+#include "projectagamemnon/port_parse.hpp"
 #include "projectagamemnon/routes.hpp"
 #include "projectagamemnon/store.hpp"
 #include "projectagamemnon/version.hpp"
@@ -60,7 +61,16 @@ int main() {
   projectagamemnon::register_routes(server, store, nats);
 
   const char* port_env = std::getenv("PORT");
-  int port = port_env ? std::stoi(port_env) : 8080;
+  int port = 8080;
+  if (port_env) {
+    auto result = projectagamemnon::parse_port(port_env);
+    if (!result.port.has_value()) {
+      std::cerr << "[agamemnon] WARNING: PORT=\"" << port_env
+                << "\" is invalid (" << result.error << "), defaulting to " << port << "\n";
+    } else {
+      port = result.port.value();
+    }
+  }
 
   std::cout << "[agamemnon] listening on 0.0.0.0:" << port << "\n";
   server.listen("0.0.0.0", port);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,7 +5,8 @@ find_package(nlohmann_json REQUIRED)
 
 add_executable(${PROJECT_NAME}_tests
   src/test_main.cpp
-  src/test_store.cpp)
+  src/test_store.cpp
+  src/test_parse_port.cpp)
 
 target_compile_features(${PROJECT_NAME}_tests PRIVATE cxx_std_20)
 set_target_properties(${PROJECT_NAME}_tests PROPERTIES CXX_EXTENSIONS OFF)

--- a/test/src/test_parse_port.cpp
+++ b/test/src/test_parse_port.cpp
@@ -1,0 +1,51 @@
+#include "projectagamemnon/port_parse.hpp"
+
+#include <gtest/gtest.h>
+
+namespace projectagamemnon::test {
+
+TEST(ParsePortTest, ValidPorts) {
+    EXPECT_EQ(parse_port("8080").port.value(), 8080);
+    EXPECT_EQ(parse_port("1").port.value(), 1);
+    EXPECT_EQ(parse_port("65535").port.value(), 65535);
+    EXPECT_EQ(parse_port("443").port.value(), 443);
+    EXPECT_EQ(parse_port("9090").port.value(), 9090);
+}
+
+TEST(ParsePortTest, NonNumericReturnsNullopt) {
+    auto r = parse_port("abc");
+    EXPECT_FALSE(r.port.has_value());
+    EXPECT_STREQ(r.error, "not a valid integer");
+}
+
+TEST(ParsePortTest, PartialNumericReturnsNullopt) {
+    auto r = parse_port("80abc");
+    EXPECT_FALSE(r.port.has_value());
+    EXPECT_STREQ(r.error, "not a valid integer");
+}
+
+TEST(ParsePortTest, ZeroIsOutOfRange) {
+    auto r = parse_port("0");
+    EXPECT_FALSE(r.port.has_value());
+    EXPECT_STREQ(r.error, "out of range [1,65535]");
+}
+
+TEST(ParsePortTest, OutOfRangeValues) {
+    EXPECT_FALSE(parse_port("65536").port.has_value());
+    EXPECT_FALSE(parse_port("99999").port.has_value());
+    EXPECT_STREQ(parse_port("99999").error, "out of range [1,65535]");
+}
+
+TEST(ParsePortTest, NullptrReturnsNullopt) {
+    auto r = parse_port(nullptr);
+    EXPECT_FALSE(r.port.has_value());
+    EXPECT_STREQ(r.error, "empty");
+}
+
+TEST(ParsePortTest, EmptyStringReturnsNullopt) {
+    auto r = parse_port("");
+    EXPECT_FALSE(r.port.has_value());
+    EXPECT_STREQ(r.error, "empty");
+}
+
+}  // namespace projectagamemnon::test

--- a/test/src/test_parse_port.cpp
+++ b/test/src/test_parse_port.cpp
@@ -5,47 +5,47 @@
 namespace projectagamemnon::test {
 
 TEST(ParsePortTest, ValidPorts) {
-    EXPECT_EQ(parse_port("8080").port.value(), 8080);
-    EXPECT_EQ(parse_port("1").port.value(), 1);
-    EXPECT_EQ(parse_port("65535").port.value(), 65535);
-    EXPECT_EQ(parse_port("443").port.value(), 443);
-    EXPECT_EQ(parse_port("9090").port.value(), 9090);
+  EXPECT_EQ(parse_port("8080").port.value(), 8080);
+  EXPECT_EQ(parse_port("1").port.value(), 1);
+  EXPECT_EQ(parse_port("65535").port.value(), 65535);
+  EXPECT_EQ(parse_port("443").port.value(), 443);
+  EXPECT_EQ(parse_port("9090").port.value(), 9090);
 }
 
 TEST(ParsePortTest, NonNumericReturnsNullopt) {
-    auto r = parse_port("abc");
-    EXPECT_FALSE(r.port.has_value());
-    EXPECT_STREQ(r.error, "not a valid integer");
+  auto r = parse_port("abc");
+  EXPECT_FALSE(r.port.has_value());
+  EXPECT_STREQ(r.error, "not a valid integer");
 }
 
 TEST(ParsePortTest, PartialNumericReturnsNullopt) {
-    auto r = parse_port("80abc");
-    EXPECT_FALSE(r.port.has_value());
-    EXPECT_STREQ(r.error, "not a valid integer");
+  auto r = parse_port("80abc");
+  EXPECT_FALSE(r.port.has_value());
+  EXPECT_STREQ(r.error, "not a valid integer");
 }
 
 TEST(ParsePortTest, ZeroIsOutOfRange) {
-    auto r = parse_port("0");
-    EXPECT_FALSE(r.port.has_value());
-    EXPECT_STREQ(r.error, "out of range [1,65535]");
+  auto r = parse_port("0");
+  EXPECT_FALSE(r.port.has_value());
+  EXPECT_STREQ(r.error, "out of range [1,65535]");
 }
 
 TEST(ParsePortTest, OutOfRangeValues) {
-    EXPECT_FALSE(parse_port("65536").port.has_value());
-    EXPECT_FALSE(parse_port("99999").port.has_value());
-    EXPECT_STREQ(parse_port("99999").error, "out of range [1,65535]");
+  EXPECT_FALSE(parse_port("65536").port.has_value());
+  EXPECT_FALSE(parse_port("99999").port.has_value());
+  EXPECT_STREQ(parse_port("99999").error, "out of range [1,65535]");
 }
 
 TEST(ParsePortTest, NullptrReturnsNullopt) {
-    auto r = parse_port(nullptr);
-    EXPECT_FALSE(r.port.has_value());
-    EXPECT_STREQ(r.error, "empty");
+  auto r = parse_port(nullptr);
+  EXPECT_FALSE(r.port.has_value());
+  EXPECT_STREQ(r.error, "empty");
 }
 
 TEST(ParsePortTest, EmptyStringReturnsNullopt) {
-    auto r = parse_port("");
-    EXPECT_FALSE(r.port.has_value());
-    EXPECT_STREQ(r.error, "empty");
+  auto r = parse_port("");
+  EXPECT_FALSE(r.port.has_value());
+  EXPECT_STREQ(r.error, "empty");
 }
 
 }  // namespace projectagamemnon::test


### PR DESCRIPTION
## Summary

- Replaces bare `std::stoi(port_env)` at `src/server_main.cpp:63` with `parse_port()`, a helper using `std::from_chars` (no exceptions, C++17 error-code path)
- `parse_port()` validates the value is a non-empty integer in the valid TCP range `[1, 65535]`; on any failure it returns a `std::nullopt` with a literal error reason
- On failure, `server_main.cpp` logs `[agamemnon] WARNING: PORT="..." is invalid (...), defaulting to 8080` to stderr — matching the existing NATS fallback warning pattern
- New header `include/projectagamemnon/port_parse.hpp` keeps the logic pure and testable without spawning a process
- Consistent with the `CPPHTTPLIB_NO_EXCEPTIONS` philosophy already in the file

Closes #50

## Test plan

- [x] `ParsePortTest.ValidPorts` — ports 1, 443, 8080, 9090, 65535 parse correctly
- [x] `ParsePortTest.NonNumericReturnsNullopt` — `"abc"` → nullopt with `"not a valid integer"`
- [x] `ParsePortTest.PartialNumericReturnsNullopt` — `"80abc"` → nullopt (full-consume check)
- [x] `ParsePortTest.ZeroIsOutOfRange` — `"0"` → nullopt with `"out of range [1,65535]"`
- [x] `ParsePortTest.OutOfRangeValues` — `"65536"`, `"99999"` → nullopt
- [x] `ParsePortTest.NullptrReturnsNullopt` — `nullptr` → nullopt with `"empty"`
- [x] `ParsePortTest.EmptyStringReturnsNullopt` — `""` → nullopt with `"empty"`
- [x] All 9 tests pass (2 pre-existing version tests + 7 new parse_port tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)