### PR TITLE
refactor(nats): use unique_ptr+release() for CallbackContext ownership transfer

### DIFF
--- a/src/nats_client.cpp
+++ b/src/nats_client.cpp
@@ -3,6 +3,7 @@
 // NOLINTNEXTLINE(misc-include-cleaner) — nats.h brings in its own transitive includes
 #include <chrono>
 #include <iostream>
+#include <memory>
 #include <string>
 
 #include "nats.h"
@@ -172,16 +173,17 @@ extern "C" void nats_msg_handler(natsConnection* /*nc*/, natsSubscription* /*sub
 bool NatsClient::subscribe(const std::string& subject, MessageCallback cb) {
   if (!connected_ || !conn_) return false;
 
-  // Heap-allocate the context; it lives for the lifetime of the subscription.
-  // For this server the subscription lives for the lifetime of the process.
-  auto* ctx = new CallbackContext{std::move(cb)};  // NOLINT(cppcoreguidelines-owning-memory)
+  // Ownership transfers to the C library on successful subscribe; the callback
+  // deletes the context when the subscription fires or is destroyed.
+  auto ctx = std::make_unique<CallbackContext>(CallbackContext{std::move(cb)});
+  CallbackContext* raw = ctx.release();  // NOLINT(cppcoreguidelines-owning-memory) — ownership transfer to nats.c C API
 
   natsSubscription* sub = nullptr;
   natsStatus s =
-      natsConnection_Subscribe(&sub, to_conn(conn_), subject.c_str(), nats_msg_handler, ctx);
+      natsConnection_Subscribe(&sub, to_conn(conn_), subject.c_str(), nats_msg_handler, raw);
   if (s != NATS_OK) {
     std::cerr << "[nats] subscribe error on " << subject << ": " << natsStatus_GetText(s) << "\n";
-    delete ctx;  // NOLINT(cppcoreguidelines-owning-memory)
+    delete raw;  // NOLINT(cppcoreguidelines-owning-memory) — reclaiming from failed C API transfer
     return false;
   }
   return true;

--- a/src/nats_client.cpp
+++ b/src/nats_client.cpp
@@ -176,7 +176,8 @@ bool NatsClient::subscribe(const std::string& subject, MessageCallback cb) {
   // Ownership transfers to the C library on successful subscribe; the callback
   // deletes the context when the subscription fires or is destroyed.
   auto ctx = std::make_unique<CallbackContext>(CallbackContext{std::move(cb)});
-  CallbackContext* raw = ctx.release();  // NOLINT(cppcoreguidelines-owning-memory) — ownership transfer to nats.c C API
+  CallbackContext* raw = ctx.release();  // NOLINT(cppcoreguidelines-owning-memory) — ownership
+                                         // transfer to nats.c C API
 
   natsSubscription* sub = nullptr;
   natsStatus s =


### PR DESCRIPTION
## Summary

- Replace raw `new CallbackContext{...}` / `delete ctx` in `NatsClient::subscribe()` with `std::make_unique` + explicit `.release()` to communicate intentional ownership transfer to the nats.c C API
- Capture the raw pointer before `release()` so the error path can still reclaim it on failed `natsConnection_Subscribe`
- Narrow both `NOLINT` suppressions with inline explanations clarifying the reason for each owning-pointer site
- Add explicit `#include <memory>` (was previously only transitively available)

Behavior is unchanged — this is a clarity-only refactor.

## Test plan

- [ ] Build passes: `pixi run cmake --build --preset debug` (pre-existing `version_info.cpp` clang-tidy sysroot issue is unrelated to this change)
- [ ] `nats_client.cpp` compiles cleanly with no new warnings or errors
- [ ] Code review: ownership transfer is now self-documenting via `make_unique` + `release()`

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)