### PR TITLE
feat(test): add C++ integration test suite with 'integration' ctest label

### DIFF
--- a/include/projectagamemnon/fake_nats_publisher.hpp
+++ b/include/projectagamemnon/fake_nats_publisher.hpp
@@ -1,11 +1,12 @@
 #pragma once
 
+#include "projectagamemnon/nats_publisher.hpp"
+
 #include <string>
 #include <utility>
 #include <vector>
 
 #include "nlohmann/json.hpp"
-#include "projectagamemnon/nats_publisher.hpp"
 
 namespace projectagamemnon {
 

--- a/include/projectagamemnon/fake_nats_publisher.hpp
+++ b/include/projectagamemnon/fake_nats_publisher.hpp
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "nlohmann/json.hpp"
+#include "projectagamemnon/nats_publisher.hpp"
+
+namespace projectagamemnon {
+
+/// Header-only test double that records every publish() call.
+/// Thread-safety is not required — integration tests run single-threaded
+/// per fixture setup.
+class FakeNatsPublisher : public NatsPublisher {
+ public:
+  struct Call {
+    std::string subject;
+    std::string payload;
+  };
+
+  bool publish(const std::string& subject, const std::string& payload) override {
+    calls.push_back({subject, payload});
+    return true;
+  }
+
+  void publish_log(const std::string& subject, const std::string& /*level*/,
+                   const std::string& /*message*/, const nlohmann::json& /*metadata*/) override {
+    log_calls.push_back(subject);
+  }
+
+  bool has_subject(const std::string& subject) const {
+    for (const auto& c : calls) {
+      if (c.subject == subject) return true;
+    }
+    return false;
+  }
+
+  bool has_subject_prefix(const std::string& prefix) const {
+    for (const auto& c : calls) {
+      if (c.subject.rfind(prefix, 0) == 0) return true;
+    }
+    return false;
+  }
+
+  void clear() {
+    calls.clear();
+    log_calls.clear();
+  }
+
+  std::vector<Call> calls;
+  std::vector<std::string> log_calls;
+};
+
+}  // namespace projectagamemnon

--- a/include/projectagamemnon/nats_client.hpp
+++ b/include/projectagamemnon/nats_client.hpp
@@ -7,6 +7,7 @@
 #include <string>
 
 #include "nlohmann/json.hpp"
+#include "projectagamemnon/nats_publisher.hpp"
 
 namespace projectagamemnon {
 
@@ -20,7 +21,7 @@ namespace projectagamemnon {
 /// Designed for graceful degradation: if the NATS server is unavailable,
 /// connect() returns false and is_connected() returns false.  All publish /
 /// subscribe calls are no-ops when not connected.
-class NatsClient {
+class NatsClient : public NatsPublisher {
  public:
   static constexpr int kMaxRetries = 3;
   static constexpr int kBaseRetryMs = 50;
@@ -58,7 +59,7 @@ class NatsClient {
   /// Publish a structured log event to hi.logs.agamemnon.<event> (ADR-005).
   /// Fire-and-forget: NATS failures are logged but do not propagate.
   void publish_log(const std::string& subject, const std::string& level, const std::string& message,
-                   const nlohmann::json& metadata);
+                   const nlohmann::json& metadata) override;
 
   /// Access the dead-letter queue (for drain/clear endpoints).
   DeadLetterQueue& dead_letter_queue() { return dlq_; }

--- a/include/projectagamemnon/nats_client.hpp
+++ b/include/projectagamemnon/nats_client.hpp
@@ -2,6 +2,7 @@
 
 #include "projectagamemnon/circuit_breaker.hpp"
 #include "projectagamemnon/dead_letter_queue.hpp"
+#include "projectagamemnon/nats_publisher.hpp"
 
 #include <functional>
 #include <string>

--- a/include/projectagamemnon/nats_client.hpp
+++ b/include/projectagamemnon/nats_client.hpp
@@ -7,7 +7,6 @@
 #include <string>
 
 #include "nlohmann/json.hpp"
-#include "projectagamemnon/nats_publisher.hpp"
 
 namespace projectagamemnon {
 

--- a/include/projectagamemnon/nats_publisher.hpp
+++ b/include/projectagamemnon/nats_publisher.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <string>
+
+#include "nlohmann/json.hpp"
+
+namespace projectagamemnon {
+
+/// Abstract interface for NATS publishing.  Allows tests to inject a fake
+/// publisher without requiring a live NATS connection.
+class NatsPublisher {
+ public:
+  virtual ~NatsPublisher() = default;
+
+  virtual bool publish(const std::string& subject, const std::string& payload) = 0;
+
+  virtual void publish_log(const std::string& subject, const std::string& level,
+                           const std::string& message, const nlohmann::json& metadata) = 0;
+};
+
+}  // namespace projectagamemnon

--- a/include/projectagamemnon/routes.hpp
+++ b/include/projectagamemnon/routes.hpp
@@ -8,14 +8,16 @@ class Server;
 namespace projectagamemnon {
 
 class Store;
-class NatsClient;
+class NatsPublisher;
 class RateLimiter;
 class AuthMiddleware;
 
 /// Register all /v1/ route handlers on the given server.
-/// Store, NatsClient, RateLimiter, and AuthMiddleware are passed by reference;
-/// they must outlive the server (they are owned by main).
-void register_routes(httplib::Server& server, Store& store, NatsClient& nats,
+/// Store, NatsPublisher, RateLimiter, and AuthMiddleware are passed by
+/// reference; they must outlive the server (they are owned by main).
+/// In production, pass a NatsClient (which derives from NatsPublisher).
+/// In tests, pass a FakeNatsPublisher for call recording.
+void register_routes(httplib::Server& server, Store& store, NatsPublisher& nats,
                      RateLimiter& rate_limiter, AuthMiddleware& auth);
 
 }  // namespace projectagamemnon

--- a/src/routes.cpp
+++ b/src/routes.cpp
@@ -1,7 +1,7 @@
 #include "projectagamemnon/routes.hpp"
 
 #include "projectagamemnon/auth.hpp"
-#include "projectagamemnon/nats_client.hpp"
+#include "projectagamemnon/nats_client.hpp"  // NatsClient derives NatsPublisher; needed for dynamic_cast
 #include "projectagamemnon/nats_publisher.hpp"
 #include "projectagamemnon/rate_limiter.hpp"
 #include "projectagamemnon/store.hpp"
@@ -166,18 +166,18 @@ std::optional<PaginationParams> parse_pagination(const httplib::Request& req,
 
 // ── Route registration ────────────────────────────────────────────────────────
 
-// NOTE: We capture Store* and NatsClient* (raw pointers, not references) to
+// NOTE: We capture Store* and NatsPublisher* (raw pointers, not references) to
 // avoid dangling-reference UB when the lambda outlives register_routes' stack.
 // Both store and nats are owned by main() and outlive the server.
 
-void register_routes(httplib::Server& server, Store& store, NatsClient& nats,
+void register_routes(httplib::Server& server, Store& store, NatsPublisher& nats,
                      RateLimiter& rate_limiter, AuthMiddleware& auth) {
   Store* sp = &store;
-  NatsClient* np = &nats;
-  // nc aliases np for use in lambdas that check NatsClient-specific features
-  // (circuit_breaker, dead_letter_queue). Using np directly is safe since
-  // the signature already takes NatsClient& — nc is just an alias.
-  NatsClient* nc = np;
+  NatsPublisher* np = &nats;
+  // nc is non-null only when a real NatsClient is passed (production).
+  // In tests, a FakeNatsPublisher is passed and nc will be nullptr —
+  // guarded accesses below skip NatsClient-only features (circuit breaker, DLQ).
+  NatsClient* nc = dynamic_cast<NatsClient*>(np);
   RateLimiter* rl = &rate_limiter;
   AuthMiddleware* ap = &auth;
 

--- a/src/routes.cpp
+++ b/src/routes.cpp
@@ -2,6 +2,7 @@
 
 #include "projectagamemnon/auth.hpp"
 #include "projectagamemnon/nats_client.hpp"
+#include "projectagamemnon/nats_publisher.hpp"
 #include "projectagamemnon/rate_limiter.hpp"
 #include "projectagamemnon/store.hpp"
 #include "projectagamemnon/version.hpp"
@@ -173,6 +174,10 @@ void register_routes(httplib::Server& server, Store& store, NatsClient& nats,
                      RateLimiter& rate_limiter, AuthMiddleware& auth) {
   Store* sp = &store;
   NatsClient* np = &nats;
+  // nc aliases np for use in lambdas that check NatsClient-specific features
+  // (circuit_breaker, dead_letter_queue). Using np directly is safe since
+  // the signature already takes NatsClient& — nc is just an alias.
+  NatsClient* nc = np;
   RateLimiter* rl = &rate_limiter;
   AuthMiddleware* ap = &auth;
 
@@ -211,30 +216,36 @@ void register_routes(httplib::Server& server, Store& store, NatsClient& nats,
     reply_json(res, 200, {{"status", "ok"}, {"service", "ProjectAgamemnon"}});
   });
 
-  server.Get("/v1/health", [np](const httplib::Request&, httplib::Response& res) {
-    reply_json(res, 200,
-               {{"status", "ok"},
-                {"nats_circuit", np->circuit_breaker().state_label()},
-                {"dlq_depth", np->dead_letter_queue().size()}});
+  server.Get("/v1/health", [nc](const httplib::Request&, httplib::Response& res) {
+    json body = {{"status", "ok"}};
+    if (nc != nullptr) {
+      body["nats_circuit"] = nc->circuit_breaker().state_label();
+      body["dlq_depth"] = nc->dead_letter_queue().size();
+    }
+    reply_json(res, 200, body);
   });
 
   // GET /v1/dead-letter — drain and return all dead-lettered messages
-  // np is owned by main() and outlives the server; reference capture is safe.
-  server.Get("/v1/dead-letter", [np](const httplib::Request&, httplib::Response& res) {
-    auto entries = np->dead_letter_queue().drain();
+  // nc is owned by main() and outlives the server; reference capture is safe.
+  server.Get("/v1/dead-letter", [nc](const httplib::Request&, httplib::Response& res) {
     json arr = json::array();
-    for (const auto& e : entries) {
-      arr.push_back({{"subject", e.subject},
-                     {"payload", e.payload},
-                     {"attempts", e.attempts},
-                     {"timestamp_ms", e.timestamp_ms}});
+    if (nc != nullptr) {
+      auto entries = nc->dead_letter_queue().drain();
+      for (const auto& e : entries) {
+        arr.push_back({{"subject", e.subject},
+                       {"payload", e.payload},
+                       {"attempts", e.attempts},
+                       {"timestamp_ms", e.timestamp_ms}});
+      }
     }
     reply_json(res, 200, {{"dead_letter_queue", arr}});
   });
 
   // DELETE /v1/dead-letter — discard all dead-lettered messages
-  server.Delete("/v1/dead-letter", [np](const httplib::Request&, httplib::Response& res) {
-    np->dead_letter_queue().clear();
+  server.Delete("/v1/dead-letter", [nc](const httplib::Request&, httplib::Response& res) {
+    if (nc != nullptr) {
+      nc->dead_letter_queue().clear();
+    }
     reply_json(res, 200, {{"cleared", true}});
   });
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -135,7 +135,10 @@ target_compile_options(${PROJECT_NAME}_integration_tests PRIVATE
 target_link_libraries(${PROJECT_NAME}_integration_tests
   PRIVATE
     ${PROJECT_NAME}::${PROJECT_NAME}
-    GTest::gtest_main)
+    agamemnon_lib
+    GTest::gtest_main
+    httplib::httplib
+    nlohmann_json::nlohmann_json)
 
 gtest_discover_tests(${PROJECT_NAME}_integration_tests
   PROPERTIES LABELS "integration")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,6 +6,7 @@ find_package(httplib REQUIRED)
 find_package(nlohmann_json REQUIRED)
 find_package(OpenSSL REQUIRED)
 
+# ── Unit tests ───────────────────────────────────────────────────────────────
 add_executable(${PROJECT_NAME}_tests
   src/test_main.cpp
   src/test_store.cpp
@@ -105,3 +106,36 @@ target_link_libraries(${PROJECT_NAME}_routes_tests
     Threads::Threads)
 
 gtest_discover_tests(${PROJECT_NAME}_routes_tests DISCOVERY_TIMEOUT 120)
+
+# ── Integration tests ────────────────────────────────────────────────────────
+add_executable(${PROJECT_NAME}_integration_tests
+  src/integration/test_agent_endpoints.cpp
+  src/integration/test_task_lifecycle.cpp
+  src/integration/test_chaos_endpoints.cpp)
+
+target_compile_features(${PROJECT_NAME}_integration_tests PRIVATE cxx_std_20)
+set_target_properties(${PROJECT_NAME}_integration_tests PROPERTIES CXX_EXTENSIONS OFF)
+
+target_include_directories(${PROJECT_NAME}_integration_tests
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/integration
+    ${CMAKE_SOURCE_DIR}/include)
+
+# Suppress warnings from external headers (httplib, nats) in test binary.
+target_compile_options(${PROJECT_NAME}_integration_tests PRIVATE
+  -Wno-old-style-cast
+  -Wno-useless-cast
+  -Wno-conversion
+  -Wno-sign-conversion
+  -Wno-shadow
+  -Wno-format-nonliteral
+  -Wno-double-promotion
+  -Wno-cast-align)
+
+target_link_libraries(${PROJECT_NAME}_integration_tests
+  PRIVATE
+    ${PROJECT_NAME}::${PROJECT_NAME}
+    GTest::gtest_main)
+
+gtest_discover_tests(${PROJECT_NAME}_integration_tests
+  PROPERTIES LABELS "integration")

--- a/test/src/integration/server_fixture.hpp
+++ b/test/src/integration/server_fixture.hpp
@@ -5,7 +5,9 @@
 #include <thread>
 
 #define CPPHTTPLIB_NO_EXCEPTIONS
+#include "projectagamemnon/auth.hpp"
 #include "projectagamemnon/fake_nats_publisher.hpp"
+#include "projectagamemnon/rate_limiter.hpp"
 #include "projectagamemnon/routes.hpp"
 #include "projectagamemnon/store.hpp"
 
@@ -18,6 +20,10 @@ namespace projectagamemnon::test {
 /// Test fixture that starts a real httplib::Server on a free port.
 /// All test classes in the integration binary share a single server instance
 /// via inline static members (one-definition rule satisfied by C++17 inline).
+///
+/// Auth is disabled (empty API key — all requests pass).
+/// Rate limiting is effectively unlimited (1e9 tokens/s, 1e9 burst).
+/// NATS uses a FakeNatsPublisher to capture publish() calls for assertions.
 class AgamemnonServerFixture : public ::testing::Test {
  public:
   static httplib::Client& client() { return *client_; }
@@ -28,9 +34,11 @@ class AgamemnonServerFixture : public ::testing::Test {
   static void SetUpTestSuite() {
     store_ = new Store();
     nats_ = new FakeNatsPublisher();
+    rate_limiter_ = new RateLimiter(1e9, 1e9);  // effectively unlimited for tests
+    auth_ = new AuthMiddleware("");              // empty key — all requests pass auth
 
     server_ = new httplib::Server();
-    register_routes(*server_, *store_, *nats_);
+    register_routes(*server_, *store_, *nats_, *rate_limiter_, *auth_);
 
     // Let the OS pick a free port.
     int bound_port = server_->bind_to_any_port("127.0.0.1");
@@ -56,11 +64,15 @@ class AgamemnonServerFixture : public ::testing::Test {
     delete client_;
     delete server_thread_;
     delete server_;
+    delete auth_;
+    delete rate_limiter_;
     delete nats_;
     delete store_;
     client_ = nullptr;
     server_thread_ = nullptr;
     server_ = nullptr;
+    auth_ = nullptr;
+    rate_limiter_ = nullptr;
     nats_ = nullptr;
     store_ = nullptr;
   }
@@ -74,6 +86,8 @@ class AgamemnonServerFixture : public ::testing::Test {
   inline static httplib::Client* client_ = nullptr;
   inline static Store* store_ = nullptr;
   inline static FakeNatsPublisher* nats_ = nullptr;
+  inline static RateLimiter* rate_limiter_ = nullptr;
+  inline static AuthMiddleware* auth_ = nullptr;
 };
 
 }  // namespace projectagamemnon::test

--- a/test/src/integration/server_fixture.hpp
+++ b/test/src/integration/server_fixture.hpp
@@ -5,12 +5,12 @@
 #include <thread>
 
 #define CPPHTTPLIB_NO_EXCEPTIONS
-#include "httplib.h"
-#include "nlohmann/json.hpp"
 #include "projectagamemnon/fake_nats_publisher.hpp"
 #include "projectagamemnon/routes.hpp"
 #include "projectagamemnon/store.hpp"
 
+#include "httplib.h"
+#include "nlohmann/json.hpp"
 #include <gtest/gtest.h>
 
 namespace projectagamemnon::test {

--- a/test/src/integration/server_fixture.hpp
+++ b/test/src/integration/server_fixture.hpp
@@ -1,0 +1,79 @@
+#pragma once
+
+#include <chrono>
+#include <string>
+#include <thread>
+
+#define CPPHTTPLIB_NO_EXCEPTIONS
+#include "httplib.h"
+#include "nlohmann/json.hpp"
+#include "projectagamemnon/fake_nats_publisher.hpp"
+#include "projectagamemnon/routes.hpp"
+#include "projectagamemnon/store.hpp"
+
+#include <gtest/gtest.h>
+
+namespace projectagamemnon::test {
+
+/// Test fixture that starts a real httplib::Server on a free port.
+/// All test classes in the integration binary share a single server instance
+/// via inline static members (one-definition rule satisfied by C++17 inline).
+class AgamemnonServerFixture : public ::testing::Test {
+ public:
+  static httplib::Client& client() { return *client_; }
+  static Store& store() { return *store_; }
+  static FakeNatsPublisher& nats() { return *nats_; }
+
+ protected:
+  static void SetUpTestSuite() {
+    store_ = new Store();
+    nats_ = new FakeNatsPublisher();
+
+    server_ = new httplib::Server();
+    register_routes(*server_, *store_, *nats_);
+
+    // Let the OS pick a free port.
+    int bound_port = server_->bind_to_any_port("127.0.0.1");
+    ASSERT_GT(bound_port, 0) << "Failed to bind server to a free port";
+    port_ = bound_port;
+
+    server_thread_ = new std::thread([] { server_->listen_after_bind(); });
+
+    client_ = new httplib::Client("127.0.0.1", port_);
+    client_->set_connection_timeout(5);
+    client_->set_read_timeout(5);
+
+    // Wait for the server to start accepting connections (up to 2 seconds).
+    for (int i = 0; i < 40; ++i) {
+      if (auto r = client_->Get("/health"); r && r->status == 200) break;
+      std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+  }
+
+  static void TearDownTestSuite() {
+    server_->stop();
+    if (server_thread_->joinable()) server_thread_->join();
+    delete client_;
+    delete server_thread_;
+    delete server_;
+    delete nats_;
+    delete store_;
+    client_ = nullptr;
+    server_thread_ = nullptr;
+    server_ = nullptr;
+    nats_ = nullptr;
+    store_ = nullptr;
+  }
+
+  void SetUp() override { nats_->clear(); }
+
+  // inline static: each TU that includes this header shares the same variable.
+  inline static int port_ = 0;
+  inline static httplib::Server* server_ = nullptr;
+  inline static std::thread* server_thread_ = nullptr;
+  inline static httplib::Client* client_ = nullptr;
+  inline static Store* store_ = nullptr;
+  inline static FakeNatsPublisher* nats_ = nullptr;
+};
+
+}  // namespace projectagamemnon::test

--- a/test/src/integration/server_fixture.hpp
+++ b/test/src/integration/server_fixture.hpp
@@ -35,7 +35,7 @@ class AgamemnonServerFixture : public ::testing::Test {
     store_ = new Store();
     nats_ = new FakeNatsPublisher();
     rate_limiter_ = new RateLimiter(1e9, 1e9);  // effectively unlimited for tests
-    auth_ = new AuthMiddleware("");              // empty key — all requests pass auth
+    auth_ = new AuthMiddleware("");             // empty key — all requests pass auth
 
     server_ = new httplib::Server();
     register_routes(*server_, *store_, *nats_, *rate_limiter_, *auth_);

--- a/test/src/integration/test_agent_endpoints.cpp
+++ b/test/src/integration/test_agent_endpoints.cpp
@@ -1,0 +1,158 @@
+#include "server_fixture.hpp"
+
+#include <gtest/gtest.h>
+#include "nlohmann/json.hpp"
+
+namespace projectagamemnon::test {
+
+using json = nlohmann::json;
+
+class AgentEndpointTest : public AgamemnonServerFixture {};
+
+TEST_F(AgentEndpointTest, CreateAgentReturns201WithIdAndName) {
+  json body = {{"name", "test-agent"}, {"type", "worker"}, {"host", "localhost"}};
+  auto res = client().Post("/v1/agents", body.dump(), "application/json");
+  ASSERT_NE(res, nullptr);
+  EXPECT_EQ(res->status, 201);
+
+  auto data = json::parse(res->body);
+  EXPECT_TRUE(data.contains("agent"));
+  EXPECT_FALSE(data["agent"]["id"].get<std::string>().empty());
+  EXPECT_EQ(data["agent"]["name"].get<std::string>(), "test-agent");
+}
+
+TEST_F(AgentEndpointTest, CreateAgentPublishesCreatedEvent) {
+  json body = {{"name", "pub-agent"}, {"type", "worker"}, {"host", "myhost"}};
+  auto res = client().Post("/v1/agents", body.dump(), "application/json");
+  ASSERT_NE(res, nullptr);
+  ASSERT_EQ(res->status, 201);
+
+  EXPECT_TRUE(nats().has_subject_prefix("hi.agents.myhost.pub-agent.created"));
+}
+
+TEST_F(AgentEndpointTest, GetAgentById) {
+  json body = {{"name", "get-agent"}, {"type", "worker"}, {"host", "localhost"}};
+  auto create_res = client().Post("/v1/agents", body.dump(), "application/json");
+  ASSERT_NE(create_res, nullptr);
+  ASSERT_EQ(create_res->status, 201);
+
+  std::string id = json::parse(create_res->body)["agent"]["id"].get<std::string>();
+  auto res = client().Get("/v1/agents/" + id);
+  ASSERT_NE(res, nullptr);
+  EXPECT_EQ(res->status, 200);
+
+  auto data = json::parse(res->body);
+  EXPECT_TRUE(data.contains("agent"));
+  EXPECT_EQ(data["agent"]["id"].get<std::string>(), id);
+}
+
+TEST_F(AgentEndpointTest, GetAgentByIdNotFound) {
+  auto res = client().Get("/v1/agents/nonexistent-id-xyz");
+  ASSERT_NE(res, nullptr);
+  EXPECT_EQ(res->status, 404);
+}
+
+TEST_F(AgentEndpointTest, GetAgentByName) {
+  json body = {{"name", "named-agent"}, {"type", "worker"}, {"host", "localhost"}};
+  auto create_res = client().Post("/v1/agents", body.dump(), "application/json");
+  ASSERT_NE(create_res, nullptr);
+  ASSERT_EQ(create_res->status, 201);
+
+  auto res = client().Get("/v1/agents/by-name/named-agent");
+  ASSERT_NE(res, nullptr);
+  EXPECT_EQ(res->status, 200);
+  EXPECT_EQ(json::parse(res->body)["agent"]["name"].get<std::string>(), "named-agent");
+}
+
+TEST_F(AgentEndpointTest, ListAgentsContainsCreated) {
+  json body = {{"name", "listed-agent"}, {"type", "worker"}, {"host", "localhost"}};
+  auto create_res = client().Post("/v1/agents", body.dump(), "application/json");
+  ASSERT_NE(create_res, nullptr);
+  ASSERT_EQ(create_res->status, 201);
+  std::string id = json::parse(create_res->body)["agent"]["id"].get<std::string>();
+
+  auto res = client().Get("/v1/agents");
+  ASSERT_NE(res, nullptr);
+  EXPECT_EQ(res->status, 200);
+
+  // Response: {"agents": [...]}
+  auto data = json::parse(res->body);
+  ASSERT_TRUE(data.contains("agents")) << "Response: " << res->body;
+  bool found = false;
+  for (const auto& a : data["agents"]) {
+    if (a.contains("id") && a["id"].get<std::string>() == id) {
+      found = true;
+      break;
+    }
+  }
+  EXPECT_TRUE(found) << "Created agent not found in list";
+}
+
+TEST_F(AgentEndpointTest, PatchAgentUpdatesFields) {
+  json body = {{"name", "patch-agent"}, {"type", "worker"}, {"host", "localhost"}};
+  auto create_res = client().Post("/v1/agents", body.dump(), "application/json");
+  ASSERT_NE(create_res, nullptr);
+  ASSERT_EQ(create_res->status, 201);
+  std::string id = json::parse(create_res->body)["agent"]["id"].get<std::string>();
+
+  json patch = {{"description", "updated description"}};
+  auto res = client().Patch("/v1/agents/" + id, patch.dump(), "application/json");
+  ASSERT_NE(res, nullptr);
+  EXPECT_EQ(res->status, 200);
+  EXPECT_TRUE(nats().has_subject_prefix("hi.agents."));
+}
+
+TEST_F(AgentEndpointTest, StartAgentSetsStatusOnline) {
+  json body = {{"name", "start-agent"}, {"type", "worker"}, {"host", "localhost"}};
+  auto create_res = client().Post("/v1/agents", body.dump(), "application/json");
+  ASSERT_NE(create_res, nullptr);
+  ASSERT_EQ(create_res->status, 201);
+  std::string id = json::parse(create_res->body)["agent"]["id"].get<std::string>();
+
+  auto res = client().Post("/v1/agents/" + id + "/start", "", "application/json");
+  ASSERT_NE(res, nullptr);
+  EXPECT_EQ(res->status, 200);
+  EXPECT_EQ(json::parse(res->body)["status"].get<std::string>(), "online");
+}
+
+TEST_F(AgentEndpointTest, StopAgentSetsStatusOffline) {
+  json body = {{"name", "stop-agent"}, {"type", "worker"}, {"host", "localhost"}};
+  auto create_res = client().Post("/v1/agents", body.dump(), "application/json");
+  ASSERT_NE(create_res, nullptr);
+  ASSERT_EQ(create_res->status, 201);
+  std::string id = json::parse(create_res->body)["agent"]["id"].get<std::string>();
+
+  client().Post("/v1/agents/" + id + "/start", "", "application/json");
+
+  auto res = client().Post("/v1/agents/" + id + "/stop", "", "application/json");
+  ASSERT_NE(res, nullptr);
+  EXPECT_EQ(res->status, 200);
+  EXPECT_EQ(json::parse(res->body)["status"].get<std::string>(), "offline");
+}
+
+TEST_F(AgentEndpointTest, DeleteAgentReturns200ThenGetReturns404) {
+  json body = {{"name", "delete-agent"}, {"type", "worker"}, {"host", "localhost"}};
+  auto create_res = client().Post("/v1/agents", body.dump(), "application/json");
+  ASSERT_NE(create_res, nullptr);
+  ASSERT_EQ(create_res->status, 201);
+  std::string id = json::parse(create_res->body)["agent"]["id"].get<std::string>();
+
+  auto del_res = client().Delete("/v1/agents/" + id);
+  ASSERT_NE(del_res, nullptr);
+  EXPECT_EQ(del_res->status, 200);
+  EXPECT_TRUE(nats().has_subject_prefix("hi.agents."));
+
+  auto get_res = client().Get("/v1/agents/" + id);
+  ASSERT_NE(get_res, nullptr);
+  EXPECT_EQ(get_res->status, 404);
+}
+
+TEST_F(AgentEndpointTest, CreateDockerAgentReturns201) {
+  json body = {{"name", "docker-agent"}, {"type", "worker"}, {"host", "docker"}, {"image", "ubuntu:22.04"}};
+  auto res = client().Post("/v1/agents/docker", body.dump(), "application/json");
+  ASSERT_NE(res, nullptr);
+  EXPECT_EQ(res->status, 201);
+  EXPECT_TRUE(nats().has_subject_prefix("hi.agents.docker.docker-agent.created"));
+}
+
+}  // namespace projectagamemnon::test

--- a/test/src/integration/test_agent_endpoints.cpp
+++ b/test/src/integration/test_agent_endpoints.cpp
@@ -1,7 +1,6 @@
-#include "server_fixture.hpp"
-
-#include <gtest/gtest.h>
 #include "nlohmann/json.hpp"
+#include "server_fixture.hpp"
+#include <gtest/gtest.h>
 
 namespace projectagamemnon::test {
 
@@ -148,7 +147,8 @@ TEST_F(AgentEndpointTest, DeleteAgentReturns200ThenGetReturns404) {
 }
 
 TEST_F(AgentEndpointTest, CreateDockerAgentReturns201) {
-  json body = {{"name", "docker-agent"}, {"type", "worker"}, {"host", "docker"}, {"image", "ubuntu:22.04"}};
+  json body = {
+      {"name", "docker-agent"}, {"type", "worker"}, {"host", "docker"}, {"image", "ubuntu:22.04"}};
   auto res = client().Post("/v1/agents/docker", body.dump(), "application/json");
   ASSERT_NE(res, nullptr);
   EXPECT_EQ(res->status, 201);

--- a/test/src/integration/test_chaos_endpoints.cpp
+++ b/test/src/integration/test_chaos_endpoints.cpp
@@ -1,0 +1,120 @@
+#include "server_fixture.hpp"
+
+#include <gtest/gtest.h>
+#include "nlohmann/json.hpp"
+
+namespace projectagamemnon::test {
+
+using json = nlohmann::json;
+
+class ChaosEndpointTest : public AgamemnonServerFixture {};
+
+TEST_F(ChaosEndpointTest, ListFaultsIsArray) {
+  auto res = client().Get("/v1/chaos");
+  ASSERT_NE(res, nullptr);
+  EXPECT_EQ(res->status, 200);
+  // Response: {"faults": [...]}
+  auto data = json::parse(res->body);
+  ASSERT_TRUE(data.contains("faults")) << "Response: " << res->body;
+  EXPECT_TRUE(data["faults"].is_array());
+}
+
+TEST_F(ChaosEndpointTest, InjectLatencyFaultReturns201) {
+  auto res = client().Post("/v1/chaos/latency", "", "application/json");
+  ASSERT_NE(res, nullptr);
+  EXPECT_EQ(res->status, 201);
+
+  // Response: {"fault": {...}}
+  auto data = json::parse(res->body);
+  ASSERT_TRUE(data.contains("fault")) << "Response: " << res->body;
+  const auto& fault = data["fault"];
+  EXPECT_TRUE(fault.contains("id"));
+  EXPECT_EQ(fault.value("type", ""), "latency");
+  EXPECT_EQ(fault.value("active", false), true);
+
+  EXPECT_TRUE(nats().has_subject("hi.agents.chaos.injected"));
+}
+
+TEST_F(ChaosEndpointTest, InjectFaultAppearsInList) {
+  auto inject_res = client().Post("/v1/chaos/packet-loss", "", "application/json");
+  ASSERT_NE(inject_res, nullptr);
+  ASSERT_EQ(inject_res->status, 201);
+  std::string fault_id = json::parse(inject_res->body)["fault"]["id"].get<std::string>();
+
+  auto list_res = client().Get("/v1/chaos");
+  ASSERT_NE(list_res, nullptr);
+  EXPECT_EQ(list_res->status, 200);
+
+  auto data = json::parse(list_res->body);
+  ASSERT_TRUE(data.contains("faults"));
+  const auto& faults = data["faults"];
+  ASSERT_TRUE(faults.is_array());
+
+  bool found = false;
+  for (const auto& f : faults) {
+    if (f.contains("id") && f["id"].get<std::string>() == fault_id) {
+      found = true;
+      break;
+    }
+  }
+  EXPECT_TRUE(found) << "Injected fault not found in chaos list";
+}
+
+TEST_F(ChaosEndpointTest, RemoveFaultReturns200AndPublishesNats) {
+  auto inject_res = client().Post("/v1/chaos/cpu-spike", "", "application/json");
+  ASSERT_NE(inject_res, nullptr);
+  ASSERT_EQ(inject_res->status, 201);
+  std::string fault_id = json::parse(inject_res->body)["fault"]["id"].get<std::string>();
+
+  nats().clear();
+
+  auto del_res = client().Delete("/v1/chaos/" + fault_id);
+  ASSERT_NE(del_res, nullptr);
+  EXPECT_EQ(del_res->status, 200);
+
+  auto data = json::parse(del_res->body);
+  EXPECT_EQ(data.value("deleted", ""), fault_id);
+  EXPECT_TRUE(nats().has_subject("hi.agents.chaos.removed"));
+}
+
+TEST_F(ChaosEndpointTest, RemoveNonExistentFaultReturns404) {
+  auto res = client().Delete("/v1/chaos/does-not-exist-999");
+  ASSERT_NE(res, nullptr);
+  EXPECT_EQ(res->status, 404);
+}
+
+TEST_F(ChaosEndpointTest, RemoveFaultDisappearsFromList) {
+  auto inject_res = client().Post("/v1/chaos/network-drop", "", "application/json");
+  ASSERT_NE(inject_res, nullptr);
+  ASSERT_EQ(inject_res->status, 201);
+  std::string fault_id = json::parse(inject_res->body)["fault"]["id"].get<std::string>();
+
+  auto del_res = client().Delete("/v1/chaos/" + fault_id);
+  ASSERT_NE(del_res, nullptr);
+  ASSERT_EQ(del_res->status, 200);
+
+  auto list_res = client().Get("/v1/chaos");
+  ASSERT_NE(list_res, nullptr);
+  EXPECT_EQ(list_res->status, 200);
+
+  auto data = json::parse(list_res->body);
+  ASSERT_TRUE(data.contains("faults"));
+  for (const auto& f : data["faults"]) {
+    if (f.contains("id")) {
+      EXPECT_NE(f["id"].get<std::string>(), fault_id) << "Deleted fault still in list";
+    }
+  }
+}
+
+TEST_F(ChaosEndpointTest, InjectMultipleFaultTypes) {
+  for (const auto& fault_type : {"latency", "jitter", "disk-full"}) {
+    auto res = client().Post(std::string("/v1/chaos/") + fault_type, "", "application/json");
+    ASSERT_NE(res, nullptr);
+    EXPECT_EQ(res->status, 201) << "Failed to inject fault type: " << fault_type;
+    auto data = json::parse(res->body);
+    ASSERT_TRUE(data.contains("fault")) << "Response: " << res->body;
+    EXPECT_EQ(data["fault"].value("type", ""), fault_type);
+  }
+}
+
+}  // namespace projectagamemnon::test

--- a/test/src/integration/test_chaos_endpoints.cpp
+++ b/test/src/integration/test_chaos_endpoints.cpp
@@ -1,7 +1,6 @@
-#include "server_fixture.hpp"
-
-#include <gtest/gtest.h>
 #include "nlohmann/json.hpp"
+#include "server_fixture.hpp"
+#include <gtest/gtest.h>
 
 namespace projectagamemnon::test {
 

--- a/test/src/integration/test_task_lifecycle.cpp
+++ b/test/src/integration/test_task_lifecycle.cpp
@@ -44,7 +44,7 @@ TEST_F(TaskLifecycleTest, CreateTaskReturns201AndDispatchesToMyrmidon) {
   ASSERT_FALSE(team_id.empty());
 
   json body = {
-      {"subject", "Implement feature X"}, {"type", "coding"}, {"description", "Write the code"}};
+      {"subject", "Implement feature X"}, {"type", "implementation"}, {"description", "Write the code"}};
   auto res = client().Post("/v1/teams/" + team_id + "/tasks", body.dump(), "application/json");
   ASSERT_NE(res, nullptr);
   EXPECT_EQ(res->status, 201);
@@ -56,7 +56,7 @@ TEST_F(TaskLifecycleTest, CreateTaskReturns201AndDispatchesToMyrmidon) {
   EXPECT_EQ(data["task"]["status"].get<std::string>(), "pending");
 
   EXPECT_TRUE(nats().has_subject("hi.tasks.created"));
-  EXPECT_TRUE(nats().has_subject_prefix("hi.myrmidon.coding."));
+  EXPECT_TRUE(nats().has_subject_prefix("hi.myrmidon.implementation."));
 }
 
 TEST_F(TaskLifecycleTest, GetTaskByTeamAndId) {
@@ -126,7 +126,7 @@ TEST_F(TaskLifecycleTest, PutTaskUpdatesStatus) {
   ASSERT_EQ(create_res->status, 201);
   std::string task_id = json::parse(create_res->body)["task"]["id"].get<std::string>();
 
-  json update = {{"status", "in_progress"}, {"subject", "Update task"}};
+  json update = {{"status", "running"}, {"subject", "Update task"}};
   auto res =
       client().Put("/v1/teams/" + team_id + "/tasks/" + task_id, update.dump(), "application/json");
   ASSERT_NE(res, nullptr);
@@ -146,7 +146,7 @@ TEST_F(TaskLifecycleTest, PatchTaskPartialUpdate) {
   ASSERT_EQ(create_res->status, 201);
   std::string task_id = json::parse(create_res->body)["task"]["id"].get<std::string>();
 
-  json patch = {{"status", "in_progress"}};
+  json patch = {{"status", "running"}};
   auto res = client().Patch("/v1/teams/" + team_id + "/tasks/" + task_id, patch.dump(),
                             "application/json");
   ASSERT_NE(res, nullptr);

--- a/test/src/integration/test_task_lifecycle.cpp
+++ b/test/src/integration/test_task_lifecycle.cpp
@@ -1,7 +1,6 @@
-#include "server_fixture.hpp"
-
-#include <gtest/gtest.h>
 #include "nlohmann/json.hpp"
+#include "server_fixture.hpp"
+#include <gtest/gtest.h>
 
 namespace projectagamemnon::test {
 
@@ -44,7 +43,8 @@ TEST_F(TaskLifecycleTest, CreateTaskReturns201AndDispatchesToMyrmidon) {
   std::string team_id = make_team("dispatch-team");
   ASSERT_FALSE(team_id.empty());
 
-  json body = {{"subject", "Implement feature X"}, {"type", "coding"}, {"description", "Write the code"}};
+  json body = {
+      {"subject", "Implement feature X"}, {"type", "coding"}, {"description", "Write the code"}};
   auto res = client().Post("/v1/teams/" + team_id + "/tasks", body.dump(), "application/json");
   ASSERT_NE(res, nullptr);
   EXPECT_EQ(res->status, 201);
@@ -64,7 +64,8 @@ TEST_F(TaskLifecycleTest, GetTaskByTeamAndId) {
   ASSERT_FALSE(team_id.empty());
 
   json body = {{"subject", "Get task test"}, {"type", "general"}};
-  auto create_res = client().Post("/v1/teams/" + team_id + "/tasks", body.dump(), "application/json");
+  auto create_res =
+      client().Post("/v1/teams/" + team_id + "/tasks", body.dump(), "application/json");
   ASSERT_NE(create_res, nullptr);
   ASSERT_EQ(create_res->status, 201);
   std::string task_id = json::parse(create_res->body)["task"]["id"].get<std::string>();
@@ -81,7 +82,8 @@ TEST_F(TaskLifecycleTest, ListTasksForTeam) {
   ASSERT_FALSE(team_id.empty());
 
   json body = {{"subject", "Listed task"}, {"type", "general"}};
-  auto create_res = client().Post("/v1/teams/" + team_id + "/tasks", body.dump(), "application/json");
+  auto create_res =
+      client().Post("/v1/teams/" + team_id + "/tasks", body.dump(), "application/json");
   ASSERT_NE(create_res, nullptr);
   ASSERT_EQ(create_res->status, 201);
 
@@ -99,7 +101,8 @@ TEST_F(TaskLifecycleTest, ListAllTasks) {
   ASSERT_FALSE(team_id.empty());
 
   json body = {{"subject", "Global task"}, {"type", "general"}};
-  auto create_res = client().Post("/v1/teams/" + team_id + "/tasks", body.dump(), "application/json");
+  auto create_res =
+      client().Post("/v1/teams/" + team_id + "/tasks", body.dump(), "application/json");
   ASSERT_NE(create_res, nullptr);
   ASSERT_EQ(create_res->status, 201);
 
@@ -117,13 +120,15 @@ TEST_F(TaskLifecycleTest, PutTaskUpdatesStatus) {
   ASSERT_FALSE(team_id.empty());
 
   json body = {{"subject", "Update task"}, {"type", "general"}};
-  auto create_res = client().Post("/v1/teams/" + team_id + "/tasks", body.dump(), "application/json");
+  auto create_res =
+      client().Post("/v1/teams/" + team_id + "/tasks", body.dump(), "application/json");
   ASSERT_NE(create_res, nullptr);
   ASSERT_EQ(create_res->status, 201);
   std::string task_id = json::parse(create_res->body)["task"]["id"].get<std::string>();
 
   json update = {{"status", "in_progress"}, {"subject", "Update task"}};
-  auto res = client().Put("/v1/teams/" + team_id + "/tasks/" + task_id, update.dump(), "application/json");
+  auto res =
+      client().Put("/v1/teams/" + team_id + "/tasks/" + task_id, update.dump(), "application/json");
   ASSERT_NE(res, nullptr);
   EXPECT_EQ(res->status, 200);
 
@@ -135,13 +140,15 @@ TEST_F(TaskLifecycleTest, PatchTaskPartialUpdate) {
   ASSERT_FALSE(team_id.empty());
 
   json body = {{"subject", "Patch task"}, {"type", "general"}};
-  auto create_res = client().Post("/v1/teams/" + team_id + "/tasks", body.dump(), "application/json");
+  auto create_res =
+      client().Post("/v1/teams/" + team_id + "/tasks", body.dump(), "application/json");
   ASSERT_NE(create_res, nullptr);
   ASSERT_EQ(create_res->status, 201);
   std::string task_id = json::parse(create_res->body)["task"]["id"].get<std::string>();
 
   json patch = {{"status", "in_progress"}};
-  auto res = client().Patch("/v1/teams/" + team_id + "/tasks/" + task_id, patch.dump(), "application/json");
+  auto res = client().Patch("/v1/teams/" + team_id + "/tasks/" + task_id, patch.dump(),
+                            "application/json");
   ASSERT_NE(res, nullptr);
   EXPECT_EQ(res->status, 200);
   EXPECT_TRUE(nats().has_subject_prefix("hi.tasks." + team_id + "." + task_id + ".updated"));
@@ -152,14 +159,16 @@ TEST_F(TaskLifecycleTest, TaskCompletionSetsCompletedAt) {
   ASSERT_FALSE(team_id.empty());
 
   json body = {{"subject", "Complete task"}, {"type", "general"}};
-  auto create_res = client().Post("/v1/teams/" + team_id + "/tasks", body.dump(), "application/json");
+  auto create_res =
+      client().Post("/v1/teams/" + team_id + "/tasks", body.dump(), "application/json");
   ASSERT_NE(create_res, nullptr);
   ASSERT_EQ(create_res->status, 201);
   std::string task_id = json::parse(create_res->body)["task"]["id"].get<std::string>();
 
   // update_task returns the task object directly (not wrapped in {"task": ...})
   json patch = {{"status", "completed"}};
-  auto res = client().Patch("/v1/teams/" + team_id + "/tasks/" + task_id, patch.dump(), "application/json");
+  auto res = client().Patch("/v1/teams/" + team_id + "/tasks/" + task_id, patch.dump(),
+                            "application/json");
   ASSERT_NE(res, nullptr);
   EXPECT_EQ(res->status, 200);
 

--- a/test/src/integration/test_task_lifecycle.cpp
+++ b/test/src/integration/test_task_lifecycle.cpp
@@ -43,8 +43,9 @@ TEST_F(TaskLifecycleTest, CreateTaskReturns201AndDispatchesToMyrmidon) {
   std::string team_id = make_team("dispatch-team");
   ASSERT_FALSE(team_id.empty());
 
-  json body = {
-      {"subject", "Implement feature X"}, {"type", "implementation"}, {"description", "Write the code"}};
+  json body = {{"subject", "Implement feature X"},
+               {"type", "implementation"},
+               {"description", "Write the code"}};
   auto res = client().Post("/v1/teams/" + team_id + "/tasks", body.dump(), "application/json");
   ASSERT_NE(res, nullptr);
   EXPECT_EQ(res->status, 201);

--- a/test/src/integration/test_task_lifecycle.cpp
+++ b/test/src/integration/test_task_lifecycle.cpp
@@ -1,0 +1,197 @@
+#include "server_fixture.hpp"
+
+#include <gtest/gtest.h>
+#include "nlohmann/json.hpp"
+
+namespace projectagamemnon::test {
+
+using json = nlohmann::json;
+
+class TaskLifecycleTest : public AgamemnonServerFixture {};
+
+// Helper: create a team and return its id.
+// Must be a free function — accesses public static client().
+static std::string make_team(const std::string& name) {
+  json body = {{"name", name}};
+  auto res = AgamemnonServerFixture::client().Post("/v1/teams", body.dump(), "application/json");
+  if (!res || res->status != 201) return {};
+  // Response: {"team": {...}}
+  auto data = json::parse(res->body);
+  return data["team"]["id"].get<std::string>();
+}
+
+TEST_F(TaskLifecycleTest, CreateTeamReturns201) {
+  json body = {{"name", "team-alpha"}};
+  auto res = client().Post("/v1/teams", body.dump(), "application/json");
+  ASSERT_NE(res, nullptr);
+  EXPECT_EQ(res->status, 201);
+  EXPECT_TRUE(nats().has_subject("hi.agents.team.created"));
+}
+
+TEST_F(TaskLifecycleTest, GetTeamById) {
+  std::string team_id = make_team("get-team");
+  ASSERT_FALSE(team_id.empty());
+
+  auto res = client().Get("/v1/teams/" + team_id);
+  ASSERT_NE(res, nullptr);
+  EXPECT_EQ(res->status, 200);
+  auto data = json::parse(res->body);
+  EXPECT_TRUE(data.contains("team"));
+  EXPECT_EQ(data["team"]["id"].get<std::string>(), team_id);
+}
+
+TEST_F(TaskLifecycleTest, CreateTaskReturns201AndDispatchesToMyrmidon) {
+  std::string team_id = make_team("dispatch-team");
+  ASSERT_FALSE(team_id.empty());
+
+  json body = {{"subject", "Implement feature X"}, {"type", "coding"}, {"description", "Write the code"}};
+  auto res = client().Post("/v1/teams/" + team_id + "/tasks", body.dump(), "application/json");
+  ASSERT_NE(res, nullptr);
+  EXPECT_EQ(res->status, 201);
+
+  // Response: {"task": {...}}
+  auto data = json::parse(res->body);
+  ASSERT_TRUE(data.contains("task")) << "Response: " << res->body;
+  EXPECT_FALSE(data["task"]["id"].get<std::string>().empty());
+  EXPECT_EQ(data["task"]["status"].get<std::string>(), "pending");
+
+  EXPECT_TRUE(nats().has_subject("hi.tasks.created"));
+  EXPECT_TRUE(nats().has_subject_prefix("hi.myrmidon.coding."));
+}
+
+TEST_F(TaskLifecycleTest, GetTaskByTeamAndId) {
+  std::string team_id = make_team("get-task-team");
+  ASSERT_FALSE(team_id.empty());
+
+  json body = {{"subject", "Get task test"}, {"type", "general"}};
+  auto create_res = client().Post("/v1/teams/" + team_id + "/tasks", body.dump(), "application/json");
+  ASSERT_NE(create_res, nullptr);
+  ASSERT_EQ(create_res->status, 201);
+  std::string task_id = json::parse(create_res->body)["task"]["id"].get<std::string>();
+
+  auto res = client().Get("/v1/teams/" + team_id + "/tasks/" + task_id);
+  ASSERT_NE(res, nullptr);
+  EXPECT_EQ(res->status, 200);
+  auto data = json::parse(res->body);
+  EXPECT_EQ(data["task"]["id"].get<std::string>(), task_id);
+}
+
+TEST_F(TaskLifecycleTest, ListTasksForTeam) {
+  std::string team_id = make_team("list-tasks-team");
+  ASSERT_FALSE(team_id.empty());
+
+  json body = {{"subject", "Listed task"}, {"type", "general"}};
+  auto create_res = client().Post("/v1/teams/" + team_id + "/tasks", body.dump(), "application/json");
+  ASSERT_NE(create_res, nullptr);
+  ASSERT_EQ(create_res->status, 201);
+
+  auto res = client().Get("/v1/teams/" + team_id + "/tasks");
+  ASSERT_NE(res, nullptr);
+  EXPECT_EQ(res->status, 200);
+  // Response: {"tasks": [...]}
+  auto data = json::parse(res->body);
+  ASSERT_TRUE(data.contains("tasks")) << "Response: " << res->body;
+  EXPECT_GE(data["tasks"].size(), 1u);
+}
+
+TEST_F(TaskLifecycleTest, ListAllTasks) {
+  std::string team_id = make_team("all-tasks-team");
+  ASSERT_FALSE(team_id.empty());
+
+  json body = {{"subject", "Global task"}, {"type", "general"}};
+  auto create_res = client().Post("/v1/teams/" + team_id + "/tasks", body.dump(), "application/json");
+  ASSERT_NE(create_res, nullptr);
+  ASSERT_EQ(create_res->status, 201);
+
+  auto res = client().Get("/v1/tasks");
+  ASSERT_NE(res, nullptr);
+  EXPECT_EQ(res->status, 200);
+  // Response: {"tasks": [...]}
+  auto data = json::parse(res->body);
+  ASSERT_TRUE(data.contains("tasks")) << "Response: " << res->body;
+  EXPECT_GE(data["tasks"].size(), 1u);
+}
+
+TEST_F(TaskLifecycleTest, PutTaskUpdatesStatus) {
+  std::string team_id = make_team("put-task-team");
+  ASSERT_FALSE(team_id.empty());
+
+  json body = {{"subject", "Update task"}, {"type", "general"}};
+  auto create_res = client().Post("/v1/teams/" + team_id + "/tasks", body.dump(), "application/json");
+  ASSERT_NE(create_res, nullptr);
+  ASSERT_EQ(create_res->status, 201);
+  std::string task_id = json::parse(create_res->body)["task"]["id"].get<std::string>();
+
+  json update = {{"status", "in_progress"}, {"subject", "Update task"}};
+  auto res = client().Put("/v1/teams/" + team_id + "/tasks/" + task_id, update.dump(), "application/json");
+  ASSERT_NE(res, nullptr);
+  EXPECT_EQ(res->status, 200);
+
+  EXPECT_TRUE(nats().has_subject_prefix("hi.tasks." + team_id + "." + task_id + ".updated"));
+}
+
+TEST_F(TaskLifecycleTest, PatchTaskPartialUpdate) {
+  std::string team_id = make_team("patch-task-team");
+  ASSERT_FALSE(team_id.empty());
+
+  json body = {{"subject", "Patch task"}, {"type", "general"}};
+  auto create_res = client().Post("/v1/teams/" + team_id + "/tasks", body.dump(), "application/json");
+  ASSERT_NE(create_res, nullptr);
+  ASSERT_EQ(create_res->status, 201);
+  std::string task_id = json::parse(create_res->body)["task"]["id"].get<std::string>();
+
+  json patch = {{"status", "in_progress"}};
+  auto res = client().Patch("/v1/teams/" + team_id + "/tasks/" + task_id, patch.dump(), "application/json");
+  ASSERT_NE(res, nullptr);
+  EXPECT_EQ(res->status, 200);
+  EXPECT_TRUE(nats().has_subject_prefix("hi.tasks." + team_id + "." + task_id + ".updated"));
+}
+
+TEST_F(TaskLifecycleTest, TaskCompletionSetsCompletedAt) {
+  std::string team_id = make_team("complete-task-team");
+  ASSERT_FALSE(team_id.empty());
+
+  json body = {{"subject", "Complete task"}, {"type", "general"}};
+  auto create_res = client().Post("/v1/teams/" + team_id + "/tasks", body.dump(), "application/json");
+  ASSERT_NE(create_res, nullptr);
+  ASSERT_EQ(create_res->status, 201);
+  std::string task_id = json::parse(create_res->body)["task"]["id"].get<std::string>();
+
+  // update_task returns the task object directly (not wrapped in {"task": ...})
+  json patch = {{"status", "completed"}};
+  auto res = client().Patch("/v1/teams/" + team_id + "/tasks/" + task_id, patch.dump(), "application/json");
+  ASSERT_NE(res, nullptr);
+  EXPECT_EQ(res->status, 200);
+
+  auto data = json::parse(res->body);
+  // Routes wrap in {"task": result} — and result is the task object itself.
+  const auto& task = data.contains("task") ? data["task"] : data;
+  EXPECT_EQ(task.value("status", ""), "completed");
+}
+
+TEST_F(TaskLifecycleTest, UpdateTeam) {
+  std::string team_id = make_team("update-me-team");
+  ASSERT_FALSE(team_id.empty());
+
+  json update = {{"name", "updated-team"}};
+  auto res = client().Put("/v1/teams/" + team_id, update.dump(), "application/json");
+  ASSERT_NE(res, nullptr);
+  EXPECT_EQ(res->status, 200);
+  EXPECT_TRUE(nats().has_subject("hi.agents.team.updated"));
+}
+
+TEST_F(TaskLifecycleTest, DeleteTeam) {
+  std::string team_id = make_team("delete-me-team");
+  ASSERT_FALSE(team_id.empty());
+
+  auto res = client().Delete("/v1/teams/" + team_id);
+  ASSERT_NE(res, nullptr);
+  EXPECT_EQ(res->status, 200);
+  EXPECT_TRUE(nats().has_subject("hi.agents.team.deleted"));
+
+  auto get_res = client().Get("/v1/teams/" + team_id);
+  ASSERT_NE(get_res, nullptr);
+  EXPECT_EQ(get_res->status, 404);
+}
+
+}  // namespace projectagamemnon::test


### PR DESCRIPTION
## Summary

- Introduces a `NatsPublisher` abstract interface and derives `NatsClient` from it, enabling a `FakeNatsPublisher` test double to be injected without a live NATS server
- Extracts `agamemnon_lib` STATIC CMake target (routes.cpp, store.cpp, nats_client.cpp) so the integration test binary can link business logic without the server `main()`
- Adds 29 integration tests covering agent create/update/delete, task lifecycle dispatch to myrmidon work queues, and chaos fault injection — all tagged with the `integration` ctest label
- The `integration-tests` CI job in `_required.yml` now finds tests via `ctest -L integration` instead of falling through to the full-suite fallback

## Test plan

- [x] `ctest -L integration --dry-run` lists all 29 new tests (no "No tests were found" message)
- [x] `ctest -L integration --output-on-failure` → **29/29 passed**
- [x] `ctest --output-on-failure` (full suite) → **31/31 passed** (no regressions in existing 2 unit tests)
- [x] Simulated exact CI script from `_required.yml:207-215`: falls into the `else` branch (integration tests found)

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)