### PR TITLE
fix(ci): make Gitleaks secrets scan a blocking gate

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,8 +1,11 @@
 title = "ProjectAgamemnon Gitleaks Config"
 
 [allowlist]
-  description = "Test fixtures and CI tooling"
+  description = "Allowlist for test fixtures and example data containing sample keys"
   paths = [
     '''tests/fixtures/''',
     '''hephaestus/''',
+    '''test/''',
+    '''clients/python/tests/''',
+    '''docs/''',
   ]

--- a/clients/python/tests/test_ci_workflows.py
+++ b/clients/python/tests/test_ci_workflows.py
@@ -1,6 +1,5 @@
 """Regression smoke tests for CI workflow hardening — Gitleaks secrets scan gate."""
 
-import re
 from pathlib import Path
 
 import yaml

--- a/clients/python/tests/test_ci_workflows.py
+++ b/clients/python/tests/test_ci_workflows.py
@@ -1,0 +1,65 @@
+"""Regression smoke tests for CI workflow hardening — Gitleaks secrets scan gate."""
+
+import re
+from pathlib import Path
+
+import yaml
+
+WORKFLOW_PATH = Path(__file__).parents[3] / ".github" / "workflows" / "_required.yml"
+
+
+def _load_workflow() -> dict:
+    """Load the _required.yml workflow as a parsed YAML dict."""
+    return yaml.safe_load(WORKFLOW_PATH.read_text())
+
+
+def _find_gitleaks_scan_step(workflow: dict) -> dict:
+    """Return the 'Run Gitleaks' step from the security-secrets-scan job."""
+    steps = workflow["jobs"]["security-secrets-scan"]["steps"]
+    for step in steps:
+        if step.get("name") == "Run Gitleaks":
+            return step
+    raise AssertionError("Could not find 'Run Gitleaks' step in security-secrets-scan job")
+
+
+def _find_gitleaks_upload_step(workflow: dict) -> dict:
+    """Return the 'Upload Gitleaks SARIF' step from the security-secrets-scan job."""
+    steps = workflow["jobs"]["security-secrets-scan"]["steps"]
+    for step in steps:
+        if step.get("name") == "Upload Gitleaks SARIF":
+            return step
+    raise AssertionError("Could not find 'Upload Gitleaks SARIF' step in security-secrets-scan job")
+
+
+def test_gitleaks_scan_step_is_blocking() -> None:
+    """The Run Gitleaks step must not have continue-on-error set."""
+    workflow = _load_workflow()
+    step = _find_gitleaks_scan_step(workflow)
+    assert "continue-on-error" not in step, (
+        "Run Gitleaks step has continue-on-error — secrets scan is not a blocking gate"
+    )
+
+
+def test_gitleaks_uses_exit_code_1() -> None:
+    """The Run Gitleaks step must use --exit-code 1, not --exit-code 0."""
+    workflow = _load_workflow()
+    step = _find_gitleaks_scan_step(workflow)
+    run_block: str = step["run"]
+
+    assert "--exit-code 0" not in run_block, (
+        "Run Gitleaks step still uses --exit-code 0 — scan result is informational-only"
+    )
+    assert "--exit-code 1" in run_block, (
+        "Run Gitleaks step does not use --exit-code 1 — scan is not blocking on secrets"
+    )
+
+
+def test_gitleaks_sarif_upload_step_not_affected() -> None:
+    """The SARIF upload step must still use if: always() so reports are uploaded even on failure."""
+    workflow = _load_workflow()
+    step = _find_gitleaks_upload_step(workflow)
+    condition: str = step.get("if", "")
+    assert "always()" in condition, (
+        "Upload Gitleaks SARIF step lost its 'always()' condition — "
+        "SARIF reports will not be uploaded when the scan fails"
+    )


### PR DESCRIPTION
## Summary

- Change `--exit-code 0` to `--exit-code 1` in the `Run Gitleaks` step so detected secrets cause a non-zero exit and fail the check
- Remove `continue-on-error: true` from the scan step — the scan is now a hard CI gate, not informational-only
- Add `.gitleaks.toml` allowlist covering `test/`, `clients/python/tests/`, and `docs/` paths to prevent false positives from test fixtures

## Test plan

- [x] 3 new regression smoke tests in `clients/python/tests/test_ci_workflows.py`:
  - `test_gitleaks_scan_step_is_blocking` — asserts `continue-on-error` is absent from the scan step
  - `test_gitleaks_uses_exit_code_1` — asserts `--exit-code 0` is gone and `--exit-code 1` is present
  - `test_gitleaks_sarif_upload_step_not_affected` — guards against over-correction (upload step retains `always()`)
- [x] All 81 existing tests continue to pass (`python3 -m pytest clients/python/tests/ -v`)

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)