### PR TITLE
fix(ci): make pip-audit a blocking gate for Python dependency vulnerabilities

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -221,14 +221,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install pip-audit
-        run: pip install pip-audit
+      - uses: actions/cache@v4
+        with:
+          path: |
+            clients/python/.pixi
+            ~/.cache/rattler/cache
+          key: pixi-lint-${{ runner.os }}-${{ hashFiles('clients/python/pixi.lock') }}
+          restore-keys: pixi-lint-${{ runner.os }}-
+
+      - uses: prefix-dev/setup-pixi@v0.8.1
+        with:
+          pixi-version: v0.39.5
+          manifest-path: clients/python/pixi.toml
 
       - name: Python client dependency audit
-        run: |
-          pip install -r clients/python/pyproject.toml 2>/dev/null || true
-          cd clients/python
-          pip-audit --require-hashes 2>/dev/null || pip-audit || true
+        run: pixi run --manifest-path clients/python/pixi.toml --environment lint audit
 
       - name: Install Trivy
         run: |

--- a/clients/python/pixi.toml
+++ b/clients/python/pixi.toml
@@ -27,5 +27,12 @@ lint = "ruff check src/ tests/"
 format = "ruff format src/ tests/"
 typecheck = "mypy src/"
 
+[feature.lint.pypi-dependencies]
+pip-audit = ">=2.8"
+
+[feature.lint.tasks]
+audit = "pip-audit --skip-editable"
+
 [environments]
 default = { features = ["dev"], solve-group = "default" }
+lint    = { features = ["lint"], solve-group = "default" }


### PR DESCRIPTION
## Summary

- Removes the `|| true` fallback and `2>/dev/null` suppression from the `security/dependency-scan` job that rendered pip-audit a no-op CI gate
- Adds a `[feature.lint]` environment to `clients/python/pixi.toml` with `pip-audit >=2.8` and an `audit` task, making the invocation repo-authoritative
- Replaces the broken raw pip-audit step in `_required.yml` with `pixi run --environment lint audit` — no escape hatches, exits non-zero on any known vulnerability
- Uses a separate `pixi-lint-*` cache key to avoid colliding with the existing `pixi-${{ runner.os }}-*` key used by python-client jobs

## Test plan

- [x] Ran `pixi install --manifest-path clients/python/pixi.toml --environment lint` — lint environment resolves and installs cleanly
- [x] Ran `pixi run --manifest-path clients/python/pixi.toml --environment lint audit` — exits 0 with "No known vulnerabilities found" on clean dependencies
- [x] Confirmed no `|| true`, `2>/dev/null`, or `continue-on-error` anywhere in the updated step
- [x] Confirmed `pixi-lint-*` cache key does not collide with `pixi-${{ runner.os }}-*` key in python-client.yml

Closes #58
Part of #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)