### PR TITLE
feat(ci): add Conan and FetchContent build caching to all CI workflows

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -18,6 +18,25 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Restore Conan cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.conan2
+          key: conan-${{ runner.os }}-debug-${{ hashFiles('conanfile.py') }}
+          restore-keys: |
+            conan-${{ runner.os }}-debug-
+            conan-${{ runner.os }}-
+
+      - name: Restore FetchContent cache
+        uses: actions/cache@v4
+        with:
+          path: build/_deps
+          key: fetchcontent-${{ runner.os }}-clang-debug-${{ hashFiles('CMakeLists.txt', 'cmake/**/*.cmake') }}
+          restore-keys: |
+            fetchcontent-${{ runner.os }}-clang-debug-
+            fetchcontent-${{ runner.os }}-clang-
+            fetchcontent-${{ runner.os }}-
+
       - name: Install clang-format
         run: sudo apt-get update && sudo apt-get install -y clang-format
 
@@ -154,6 +173,25 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Restore Conan cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.conan2
+          key: conan-${{ runner.os }}-release-${{ hashFiles('conanfile.py') }}
+          restore-keys: |
+            conan-${{ runner.os }}-release-
+            conan-${{ runner.os }}-
+
+      - name: Restore FetchContent cache
+        uses: actions/cache@v4
+        with:
+          path: build/_deps
+          key: fetchcontent-${{ runner.os }}-gcc-release-${{ hashFiles('CMakeLists.txt', 'cmake/**/*.cmake') }}
+          restore-keys: |
+            fetchcontent-${{ runner.os }}-gcc-release-
+            fetchcontent-${{ runner.os }}-gcc-
+            fetchcontent-${{ runner.os }}-
+
       - name: Install system dependencies
         run: |
           sudo apt-get update
@@ -183,6 +221,25 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
+
+      - name: Restore Conan cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.conan2
+          key: conan-${{ runner.os }}-release-${{ hashFiles('conanfile.py') }}
+          restore-keys: |
+            conan-${{ runner.os }}-release-
+            conan-${{ runner.os }}-
+
+      - name: Restore FetchContent cache
+        uses: actions/cache@v4
+        with:
+          path: build/_deps
+          key: fetchcontent-${{ runner.os }}-gcc-release-${{ hashFiles('CMakeLists.txt', 'cmake/**/*.cmake') }}
+          restore-keys: |
+            fetchcontent-${{ runner.os }}-gcc-release-
+            fetchcontent-${{ runner.os }}-gcc-
+            fetchcontent-${{ runner.os }}-
 
       - name: Install system dependencies
         run: |
@@ -282,6 +339,25 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
+
+      - name: Restore Conan cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.conan2
+          key: conan-${{ runner.os }}-release-${{ hashFiles('conanfile.py') }}
+          restore-keys: |
+            conan-${{ runner.os }}-release-
+            conan-${{ runner.os }}-
+
+      - name: Restore FetchContent cache
+        uses: actions/cache@v4
+        with:
+          path: build/_deps
+          key: fetchcontent-${{ runner.os }}-gcc-release-${{ hashFiles('CMakeLists.txt', 'cmake/**/*.cmake') }}
+          restore-keys: |
+            fetchcontent-${{ runner.os }}-gcc-release-
+            fetchcontent-${{ runner.os }}-gcc-
+            fetchcontent-${{ runner.os }}-
 
       - name: Install system dependencies
         run: |

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -19,6 +19,25 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Restore Conan cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.conan2
+          key: conan-${{ runner.os }}-${{ matrix.build_type }}-${{ hashFiles('conanfile.py') }}
+          restore-keys: |
+            conan-${{ runner.os }}-${{ matrix.build_type }}-
+            conan-${{ runner.os }}-
+
+      - name: Restore FetchContent cache
+        uses: actions/cache@v4
+        with:
+          path: build/_deps
+          key: fetchcontent-${{ runner.os }}-${{ matrix.compiler }}-${{ matrix.build_type }}-${{ hashFiles('CMakeLists.txt', 'cmake/**/*.cmake') }}
+          restore-keys: |
+            fetchcontent-${{ runner.os }}-${{ matrix.compiler }}-${{ matrix.build_type }}-
+            fetchcontent-${{ runner.os }}-${{ matrix.compiler }}-
+            fetchcontent-${{ runner.os }}-
+
       - name: Install dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -12,6 +12,26 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
+
+      - name: Restore Conan cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.conan2
+          key: conan-${{ runner.os }}-debug-${{ hashFiles('conanfile.py') }}
+          restore-keys: |
+            conan-${{ runner.os }}-debug-
+            conan-${{ runner.os }}-
+
+      - name: Restore FetchContent cache
+        uses: actions/cache@v4
+        with:
+          path: build/_deps
+          key: fetchcontent-${{ runner.os }}-gcc-debug-${{ hashFiles('CMakeLists.txt', 'cmake/**/*.cmake') }}
+          restore-keys: |
+            fetchcontent-${{ runner.os }}-gcc-debug-
+            fetchcontent-${{ runner.os }}-gcc-
+            fetchcontent-${{ runner.os }}-
+
       - name: Install dependencies
         run: |
           sudo apt-get install -y ninja-build gcovr

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -22,6 +22,26 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
+
+      - name: Restore Conan cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.conan2
+          key: conan-${{ runner.os }}-debug-${{ hashFiles('conanfile.py') }}
+          restore-keys: |
+            conan-${{ runner.os }}-debug-
+            conan-${{ runner.os }}-
+
+      - name: Restore FetchContent cache
+        uses: actions/cache@v4
+        with:
+          path: build/_deps
+          key: fetchcontent-${{ runner.os }}-clang-debug-${{ hashFiles('CMakeLists.txt', 'cmake/**/*.cmake') }}
+          restore-keys: |
+            fetchcontent-${{ runner.os }}-clang-debug-
+            fetchcontent-${{ runner.os }}-clang-
+            fetchcontent-${{ runner.os }}-
+
       - name: Install dependencies
         run: |
           sudo apt-get install -y ninja-build clang clang-tidy


### PR DESCRIPTION
## Summary

- Add `actions/cache@v4` restore steps for Conan packages (`~/.conan2`) and FetchContent artifacts (`build/_deps`) to every CI job that calls `conan install` or `cmake --preset`
- Cache keys incorporate OS + compiler + build_type + file hash (`conanfile.py` for Conan, `CMakeLists.txt`/`cmake/**/*.cmake` for FetchContent) so that dependency bumps automatically bust the cache
- `restore-keys:` fallback chain (narrowest → OS-only) enables partial hits when a new dep is added mid-key
- Uses explicit `actions/cache@v4` steps (not `cache: true` on setup actions) per team knowledge base — avoids HTTP 400 failures

**Affected workflows:**
| File | Jobs patched |
|------|-------------|
| `build-test.yml` | `build-test` (matrix: gcc/clang × debug/release) |
| `_required.yml` | `lint`, `unit-tests`, `integration-tests`, `build` |
| `code-coverage.yml` | `coverage` |
| `static-analysis.yml` | `clang-tidy` |

## Test plan

- [ ] First CI run on this branch: expect cache misses — look for "Cache saved successfully" in Actions logs
- [ ] Second CI run (re-push): expect cache hits — "Cache restored successfully", no `Cloning into '..._deps/nats_c-src'` in build logs
- [ ] Schema-validation job passes (validates all `*.yml` with `check-jsonschema`)
- [ ] Verify cache key busting: bumping a dep version in `conanfile.py` should cause a Conan cache miss

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)