### PR TITLE
fix(deps): bump nats.c FetchContent pin v3.9.1 → v3.12.0 and add Renovate group rule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ include(FetchContent)
 FetchContent_Declare(
   nats_c
   GIT_REPOSITORY https://github.com/nats-io/nats.c.git
-  GIT_TAG        v3.9.1
+  GIT_TAG        v3.12.0
   GIT_SHALLOW    TRUE
 )
 set(NATS_BUILD_STREAMING OFF CACHE BOOL "" FORCE)

--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,12 @@
   ],
   "packageRules": [
     {
+      "matchManagers": ["regex"],
+      "matchPackageNames": ["nats-io/nats.c"],
+      "groupName": "nats.c FetchContent pin",
+      "automerge": false
+    },
+    {
       "matchManagers": ["conan"],
       "groupName": "C++ Conan dependencies"
     },


### PR DESCRIPTION
## Summary

- **CMakeLists.txt:33** — bump `GIT_TAG v3.9.1` → `GIT_TAG v3.12.0`, aligning the actual build pin with the version documented in CLAUDE.md
- **renovate.json** — add `packageRules` entry for the `regex` custom manager targeting `nats-io/nats.c` with `automerge: false`; makes Renovate's FetchContent coverage explicit and prevents unreviewed transport-layer upgrades

nats.c stays as FetchContent — Conan migration was evaluated and rejected due to `cnats` ConanCenter availability uncertainty (see team learnings).

## Test plan

- [ ] `just build` succeeds with v3.12.0 (env requires `libssl-dev`; OpenSSL not found in this sandbox — pre-existing gap unrelated to this change)
- [ ] `just test` green once build env is complete
- [ ] Renovate regex dry-run: pattern in `customManagers` extracts `depName=nats-io/nats.c`, `currentValue=v3.12.0` from updated CMakeLists.txt block
- [ ] `npx renovate-config-validator renovate.json` passes (JSON well-formed, schema valid)
- [ ] CI matrix green on push

Closes #63
Part of #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)