### PR TITLE
feat(ci): add C++ SBOM and Grype vulnerability scanning for native dependencies

### DIFF
--- a/.github/cpp-fetchcontent-deps.cdx.json
+++ b/.github/cpp-fetchcontent-deps.cdx.json
@@ -1,0 +1,13 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.4",
+  "version": 1,
+  "components": [
+    {
+      "type": "library",
+      "name": "nats.c",
+      "version": "3.9.1",
+      "purl": "pkg:github/nats-io/nats.c@v3.9.1"
+    }
+  ]
+}

--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -218,6 +218,9 @@ jobs:
   security-dependency-scan:
     name: security/dependency-scan
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - uses: actions/checkout@v4
 
@@ -237,6 +240,48 @@ jobs:
 
       - name: Trivy filesystem scan
         run: trivy fs --exit-code 1 --severity HIGH,CRITICAL --scanners vuln .
+
+      - name: Install Conan
+        run: pip install conan
+
+      - name: Detect Conan profile
+        run: conan profile detect --force
+
+      - name: Generate Conan lock file
+        run: conan lock create conanfile.py --lockfile-out=conan.lock --build=missing
+
+      - name: Install Syft
+        run: |
+          SYFT_VERSION=1.4.1
+          curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh \
+            | sh -s -- -b /usr/local/bin "v${SYFT_VERSION}"
+          syft version
+
+      - name: Install Grype
+        run: |
+          GRYPE_VERSION=0.87.0
+          curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh \
+            | sh -s -- -b /usr/local/bin "v${GRYPE_VERSION}"
+          grype version
+
+      - name: Generate SBOM from Conan lock
+        run: syft . --override-default-catalogers conan -o cyclonedx-json=conan-sbom.cdx.json
+
+      - name: Scan Conan SBOM for CVEs
+        run: grype sbom:conan-sbom.cdx.json --fail-on high --output table
+
+      - name: Scan FetchContent deps (nats.c) for CVEs
+        run: grype sbom:.github/cpp-fetchcontent-deps.cdx.json --fail-on high --output table
+
+      - name: Upload C++ SBOMs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cpp-sbom
+          path: |
+            conan-sbom.cdx.json
+            .github/cpp-fetchcontent-deps.cdx.json
+          retention-days: 90
 
   # ── 5. security/secrets-scan ───────────────────────────────────────────────
   security-secrets-scan:


### PR DESCRIPTION
## Summary

- Adds Syft+Grype scanning for Conan-managed C++ deps (`cpp-httplib/0.18.3`, `nlohmann_json/3.11.3`, `gtest/1.14.0`) in the `security-dependency-scan` CI job — Trivy does not natively parse `conanfile.py`.
- Creates `.github/cpp-fetchcontent-deps.cdx.json`: a manually maintained CycloneDX fragment for the `nats.c v3.9.1` FetchContent dependency (not enumerable from a manifest), which is also scanned by Grype.
- Uploads both SBOMs as a 90-day workflow artifact for audit trail.
- Pins Syft v1.4.1 and Grype v0.87.0 explicitly to avoid silent tool upgrades.
- Adds `permissions: contents: read; security-events: write` to the job.

## Test plan

- [ ] Push triggers `security-dependency-scan` job; confirm new steps appear: `Generate Conan lock file`, `Generate SBOM from Conan lock`, `Scan Conan SBOM for CVEs`, `Scan FetchContent deps (nats.c) for CVEs`
- [ ] Confirm `cpp-sbom` artifact is uploaded and contains both `conan-sbom.cdx.json` and `.github/cpp-fetchcontent-deps.cdx.json`
- [ ] Confirm existing `Python client dependency audit` and `Trivy filesystem scan` steps still pass unchanged
- [ ] Confirm job runs on both push to main and pull_request (already covered by the top-level `on:` triggers in `_required.yml`)

Closes #64
Part of #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)