### PR TITLE
fix(ci): make Gitleaks secrets scan blocking

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -261,12 +261,11 @@ jobs:
         run: |
           if [ -f .gitleaks.toml ]; then
             gitleaks detect --source . --config .gitleaks.toml \
-              --report-format sarif --report-path gitleaks.sarif --exit-code 0
+              --report-format sarif --report-path gitleaks.sarif --exit-code 1
           else
             gitleaks detect --source . \
-              --report-format sarif --report-path gitleaks.sarif --exit-code 0
+              --report-format sarif --report-path gitleaks.sarif --exit-code 1
           fi
-        continue-on-error: true
 
       - name: Upload Gitleaks SARIF
         if: always() && hashFiles('gitleaks.sarif') != ''

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,8 @@
+title = "ProjectAgamemnon Gitleaks Config"
+
+[allowlist]
+  description = "Test fixtures and CI tooling"
+  paths = [
+    '''tests/fixtures/''',
+    '''hephaestus/''',
+  ]


### PR DESCRIPTION
## Summary

- Changed `--exit-code 0` → `--exit-code 1` in both branches of the `Run Gitleaks` step so that any detected secret causes the CI job to fail
- Removed `continue-on-error: true` from the `Run Gitleaks` step (the SARIF upload step above it is unaffected and still uses `if: always()`)
- Added `.gitleaks.toml` with an allowlist for test fixtures and hephaestus tooling to prevent false positives

Previously the scan was purely cosmetic — secrets committed to the repo would never fail CI enforcement.

## Test plan

- [x] Ran `gitleaks detect --source . --config .gitleaks.toml --exit-code 1 --verbose` locally — exits 0 (no leaks found across 123 commits)
- [x] Verified diff: exactly two `--exit-code 0` → `--exit-code 1` changes and one `continue-on-error` removal (only from the gitleaks step)
- [x] Confirmed the mypy `continue-on-error: true` at line 57 was NOT accidentally removed
- [x] CI will enforce blocking secrets scan on this PR and all future PRs

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)