### PR TITLE
fix(docker): replace wget healthcheck with compiled binary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,40 @@ target_compile_options(${PROJECT_NAME}_server PRIVATE
   -Wno-cast-align
 )
 
+# ── Healthcheck binary ───────────────────────────────────────────────────────
+add_executable(${PROJECT_NAME}_healthcheck src/healthcheck_main.cpp)
+
+target_compile_features(${PROJECT_NAME}_healthcheck PRIVATE cxx_std_20)
+set_target_properties(${PROJECT_NAME}_healthcheck PROPERTIES CXX_EXTENSIONS OFF)
+
+target_include_directories(
+  ${PROJECT_NAME}_healthcheck
+  PRIVATE
+    ${PROJECT_SOURCE_DIR}/include
+    ${PROJECT_SOURCE_DIR}/src
+)
+
+target_link_libraries(
+  ${PROJECT_NAME}_healthcheck
+  PRIVATE
+    httplib::httplib
+    OpenSSL::SSL
+    OpenSSL::Crypto
+)
+
+target_compile_options(${PROJECT_NAME}_healthcheck PRIVATE
+  -Wno-old-style-cast
+  -Wno-useless-cast
+  -Wno-conversion
+  -Wno-sign-conversion
+  -Wno-shadow
+  -Wno-double-promotion
+  -Wno-cast-align
+)
+
+install(TARGETS ${PROJECT_NAME}_healthcheck
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+
 # ── Tests ────────────────────────────────────────────────────────────────────
 if(${PROJECT_NAME}_BUILD_TESTING)
   enable_testing()

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,17 +41,17 @@ RUN cmake -B build -G Ninja \
     -DProjectAgamemnon_ENABLE_CLANG_TIDY=OFF \
     -DProjectAgamemnon_ENABLE_CPPCHECK=OFF \
     -DProjectAgamemnon_WARNINGS_AS_ERRORS=OFF \
-    && cmake --build build --target ProjectAgamemnon_server
+    && cmake --build build --target ProjectAgamemnon_server ProjectAgamemnon_healthcheck
 
 # ── Runtime image ─────────────────────────────────────────────────────────────
 FROM ubuntu:24.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libssl3 \
-    wget \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /src/build/ProjectAgamemnon_server /usr/local/bin/ProjectAgamemnon_server
+COPY --from=builder /src/build/ProjectAgamemnon_healthcheck /usr/local/bin/ProjectAgamemnon_healthcheck
 
 EXPOSE 8080
 
@@ -59,7 +59,7 @@ ENV NATS_URL=nats://localhost:4222
 ENV PORT=8080
 
 HEALTHCHECK --interval=10s --timeout=3s --start-period=5s --retries=3 \
-    CMD wget -qO- http://localhost:${PORT}/v1/health || exit 1
+    CMD ["/usr/local/bin/ProjectAgamemnon_healthcheck"]
 
 RUN useradd -r -s /usr/sbin/nologin agamemnon
 USER agamemnon

--- a/src/healthcheck_main.cpp
+++ b/src/healthcheck_main.cpp
@@ -1,0 +1,26 @@
+#define CPPHTTPLIB_NO_EXCEPTIONS
+#include <cstdlib>
+#include <iostream>
+
+#include "httplib.h"
+
+int main() {
+  const char* port_env = std::getenv("PORT");
+  int port = port_env ? std::atoi(port_env) : 8080;
+
+  httplib::Client client("localhost", port);
+  client.set_connection_timeout(2);
+  client.set_read_timeout(2);
+
+  auto res = client.Get("/v1/health");
+  if (res && res->status == 200) {
+    return 0;
+  }
+
+  if (res) {
+    std::cerr << "healthcheck: HTTP " << res->status << "\n";
+  } else {
+    std::cerr << "healthcheck: connection failed\n";
+  }
+  return 1;
+}


### PR DESCRIPTION
## Summary

- Removes `wget` from the runtime Docker image — it was installed solely for the `HEALTHCHECK` command, unnecessarily expanding the attack surface
- Adds `src/healthcheck_main.cpp`: a minimal C++ binary that makes a single HTTP GET to `http://localhost:${PORT}/v1/health` using `cpp-httplib` (already a Conan dependency — zero new deps) and exits 0 on HTTP 200, 1 otherwise
- Adds `ProjectAgamemnon_healthcheck` CMake target with the same warning suppression flags as the server target; installed alongside the server binary
- Updates `Dockerfile` builder step to build both `ProjectAgamemnon_server` and `ProjectAgamemnon_healthcheck`; copies the binary into the runtime image; switches `HEALTHCHECK` to exec-form (`CMD [...]`) — no shell required

Closes #68
Part of #36

## Test plan

- [ ] `just build` passes — `ProjectAgamemnon_healthcheck` binary produced in `build/`
- [ ] `docker build -t agamemnon-test .` succeeds; no `wget` in runtime layer (`docker history` shows no wget install)
- [ ] `docker run --rm agamemnon-test which wget` exits non-zero (wget absent)
- [ ] `docker run --rm agamemnon-test /usr/local/bin/ProjectAgamemnon_healthcheck` exits 0 when server is running
- [ ] `docker inspect <container> --format='{{.State.Health.Status}}'` returns `healthy` within 30s of startup
- [ ] CI passes (markdownlint, clang-tidy, build, test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)