### PR TITLE
feat(resilience): circuit breaker, retries, dead-letter queue, HTTP timeouts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,13 +73,45 @@ target_compile_options(agamemnon_peer_discovery PRIVATE
   -Wno-sign-conversion
 )
 
-# ── Server executable ────────────────────────────────────────────────────────
-add_executable(${PROJECT_NAME}_server
-  src/server_main.cpp
+# ── agamemnon_lib — shared by server executable and tests ────────────────────
+# Excludes server_main.cpp so gtest_main doesn't conflict with main().
+add_library(agamemnon_lib STATIC
   src/routes.cpp
   src/nats_client.cpp
-  $<TARGET_OBJECTS:agamemnon_peer_discovery>
+  src/circuit_breaker.cpp
+  src/dead_letter_queue.cpp
 )
+
+target_compile_features(agamemnon_lib PUBLIC cxx_std_20)
+set_target_properties(agamemnon_lib PROPERTIES CXX_EXTENSIONS OFF)
+
+target_include_directories(agamemnon_lib
+  PUBLIC  ${PROJECT_SOURCE_DIR}/include
+  PRIVATE ${PROJECT_SOURCE_DIR}/src
+)
+
+target_link_libraries(agamemnon_lib
+  PUBLIC
+    httplib::httplib
+    nlohmann_json::nlohmann_json
+    nats_static
+    OpenSSL::SSL
+    OpenSSL::Crypto
+)
+
+target_compile_options(agamemnon_lib PRIVATE
+  -Wno-old-style-cast
+  -Wno-useless-cast
+  -Wno-conversion
+  -Wno-sign-conversion
+  -Wno-shadow
+  -Wno-format-nonliteral
+  -Wno-double-promotion
+  -Wno-cast-align
+)
+
+# ── Server executable ────────────────────────────────────────────────────────
+add_executable(${PROJECT_NAME}_server src/server_main.cpp)
 
 target_compile_features(${PROJECT_NAME}_server PRIVATE cxx_std_20)
 set_target_properties(${PROJECT_NAME}_server PROPERTIES CXX_EXTENSIONS OFF)
@@ -91,17 +123,7 @@ target_include_directories(
     ${PROJECT_SOURCE_DIR}/src
 )
 
-target_link_libraries(
-  ${PROJECT_NAME}_server
-  PRIVATE
-    ${PROJECT_NAME}::${PROJECT_NAME}
-    httplib::httplib
-    nlohmann_json::nlohmann_json
-    nats_static
-    OpenSSL::SSL
-    OpenSSL::Crypto
-    agamemnon_peer_discovery
-)
+target_link_libraries(${PROJECT_NAME}_server PRIVATE agamemnon_lib agamemnon_peer_discovery)
 
 # Suppress warnings from external headers on the server target
 target_compile_options(${PROJECT_NAME}_server PRIVATE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,7 @@ target_compile_options(agamemnon_peer_discovery PRIVATE
 # Excludes server_main.cpp so gtest_main doesn't conflict with main().
 add_library(agamemnon_lib STATIC
   src/routes.cpp
+  src/store.cpp
   src/nats_client.cpp
   src/circuit_breaker.cpp
   src/dead_letter_queue.cpp

--- a/include/projectagamemnon/circuit_breaker.hpp
+++ b/include/projectagamemnon/circuit_breaker.hpp
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <string>
+
+namespace projectagamemnon {
+
+/// Three-state circuit breaker guarding NATS publish operations.
+///
+/// State transitions:
+///   Closed  → Open      : failure_count reaches threshold
+///   Open    → HalfOpen  : probe_interval has elapsed since opening
+///   HalfOpen → Closed   : probe publish succeeds (failure_count reset)
+///   HalfOpen → Open     : probe publish fails (timer reset)
+class CircuitBreaker {
+ public:
+  enum class State : uint8_t { Closed, Open, HalfOpen };
+
+  struct Config {
+    int failure_threshold{5};
+    std::chrono::milliseconds probe_interval{30'000};
+  };
+
+  CircuitBreaker() = default;
+  explicit CircuitBreaker(Config cfg) : cfg_(cfg) {}
+
+  /// Returns true if the caller should attempt a publish.
+  /// Transitions Open→HalfOpen when probe_interval has elapsed.
+  bool allow_attempt() noexcept;
+
+  /// Call after a successful publish.
+  void record_success() noexcept;
+
+  /// Call after a failed publish attempt.
+  void record_failure() noexcept;
+
+  State state() const noexcept {
+    return static_cast<State>(state_.load(std::memory_order_acquire));
+  }
+
+  int failure_count() const noexcept { return failure_count_.load(std::memory_order_relaxed); }
+
+  /// Human-readable state label for health endpoints.
+  std::string state_label() const noexcept;
+
+ private:
+  Config cfg_;
+  std::atomic<uint8_t> state_{static_cast<uint8_t>(State::Closed)};
+  std::atomic<int> failure_count_{0};
+  std::atomic<int64_t> open_since_ms_{0};  // milliseconds since epoch when last opened
+
+  void transition_to_open() noexcept;
+  static int64_t now_ms() noexcept;
+};
+
+}  // namespace projectagamemnon

--- a/include/projectagamemnon/dead_letter_queue.hpp
+++ b/include/projectagamemnon/dead_letter_queue.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <chrono>
+#include <cstddef>
+#include <deque>
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace projectagamemnon {
+
+/// Bounded ring buffer for NATS messages that failed all publish retries.
+///
+/// Thread-safe. Evicts the oldest entry when capacity is exceeded so memory
+/// usage is bounded (default 256 entries).
+class DeadLetterQueue {
+ public:
+  struct Entry {
+    std::string subject;
+    std::string payload;
+    int attempts{0};
+    int64_t timestamp_ms{0};  // milliseconds since epoch (steady_clock)
+  };
+
+  explicit DeadLetterQueue(std::size_t capacity = 256) : capacity_(capacity) {}
+
+  /// Enqueue a failed message. Evicts the oldest entry if at capacity.
+  void push(std::string subject, std::string payload, int attempts);
+
+  /// Remove and return all entries (drains the queue).
+  std::vector<Entry> drain();
+
+  /// Discard all entries without returning them.
+  void clear();
+
+  std::size_t size() const;
+  bool empty() const;
+
+ private:
+  const std::size_t capacity_;
+  mutable std::mutex mu_;
+  std::deque<Entry> queue_;
+};
+
+}  // namespace projectagamemnon

--- a/include/projectagamemnon/nats_client.hpp
+++ b/include/projectagamemnon/nats_client.hpp
@@ -4,17 +4,28 @@
 #include <string>
 
 #include "nlohmann/json.hpp"
+#include "projectagamemnon/circuit_breaker.hpp"
+#include "projectagamemnon/dead_letter_queue.hpp"
 
 namespace projectagamemnon {
 
 /// Thin wrapper around the nats.c client library with JetStream support.
+///
+/// Includes:
+///   - Exponential-backoff retry on infra-class publish failures (up to kMaxRetries)
+///   - Circuit breaker (Closed → Open → HalfOpen) to avoid hammering a dead broker
+///   - Bounded dead-letter queue for messages that exhaust all retries
 ///
 /// Designed for graceful degradation: if the NATS server is unavailable,
 /// connect() returns false and is_connected() returns false.  All publish /
 /// subscribe calls are no-ops when not connected.
 class NatsClient {
  public:
+  static constexpr int kMaxRetries = 3;
+  static constexpr int kBaseRetryMs = 50;
+
   explicit NatsClient(const std::string& url);
+  NatsClient(const std::string& url, CircuitBreaker::Config cb_cfg, std::size_t dlq_capacity);
   ~NatsClient();
 
   // Non-copyable, non-movable (holds raw pointers).
@@ -33,7 +44,9 @@ class NatsClient {
   void ensure_streams();
 
   /// Publish a JSON string to a NATS subject.
-  /// Returns false if not connected or on error.
+  /// Retries up to kMaxRetries times with exponential backoff on infra failures.
+  /// Pushes to the dead-letter queue after all retries are exhausted.
+  /// Returns false if circuit is open, not connected, or all retries fail.
   bool publish(const std::string& subject, const std::string& payload);
 
   /// Subscribe to a subject with a callback.
@@ -46,11 +59,24 @@ class NatsClient {
   void publish_log(const std::string& subject, const std::string& level, const std::string& message,
                    const nlohmann::json& metadata);
 
+  /// Access the dead-letter queue (for drain/clear endpoints).
+  DeadLetterQueue& dead_letter_queue() { return dlq_; }
+  const DeadLetterQueue& dead_letter_queue() const { return dlq_; }
+
+  /// Access the circuit breaker (for health endpoints).
+  const CircuitBreaker& circuit_breaker() const { return breaker_; }
+
  private:
   std::string url_;
   void* conn_ = nullptr;  // natsConnection*  (opaque to avoid header leak)
   void* js_ = nullptr;    // jsCtx*
   bool connected_ = false;
+
+  CircuitBreaker breaker_;
+  DeadLetterQueue dlq_;
+
+  /// Attempt a single low-level publish. Returns natsStatus as int.
+  int do_publish_once(const std::string& subject, const std::string& payload);
 };
 
 }  // namespace projectagamemnon

--- a/include/projectagamemnon/nats_client.hpp
+++ b/include/projectagamemnon/nats_client.hpp
@@ -1,11 +1,12 @@
 #pragma once
 
+#include "projectagamemnon/circuit_breaker.hpp"
+#include "projectagamemnon/dead_letter_queue.hpp"
+
 #include <functional>
 #include <string>
 
 #include "nlohmann/json.hpp"
-#include "projectagamemnon/circuit_breaker.hpp"
-#include "projectagamemnon/dead_letter_queue.hpp"
 
 namespace projectagamemnon {
 

--- a/src/circuit_breaker.cpp
+++ b/src/circuit_breaker.cpp
@@ -1,0 +1,73 @@
+#include "projectagamemnon/circuit_breaker.hpp"
+
+#include <iostream>
+
+namespace projectagamemnon {
+
+int64_t CircuitBreaker::now_ms() noexcept {
+  return std::chrono::duration_cast<std::chrono::milliseconds>(
+             std::chrono::steady_clock::now().time_since_epoch())
+      .count();
+}
+
+void CircuitBreaker::transition_to_open() noexcept {
+  open_since_ms_.store(now_ms(), std::memory_order_relaxed);
+  state_.store(static_cast<uint8_t>(State::Open), std::memory_order_release);
+  std::cerr << "[circuit_breaker] ERROR: NATS circuit OPEN after " << failure_count_.load()
+            << " consecutive failures — messages will be dead-lettered\n";
+}
+
+bool CircuitBreaker::allow_attempt() noexcept {
+  auto s = static_cast<State>(state_.load(std::memory_order_acquire));
+  if (s == State::Closed) return true;
+
+  if (s == State::Open) {
+    int64_t elapsed = now_ms() - open_since_ms_.load(std::memory_order_relaxed);
+    if (elapsed >= cfg_.probe_interval.count()) {
+      state_.store(static_cast<uint8_t>(State::HalfOpen), std::memory_order_release);
+      std::cerr << "[circuit_breaker] NATS circuit HALF-OPEN — sending probe\n";
+      return true;
+    }
+    return false;
+  }
+
+  // HalfOpen: allow the one probe attempt
+  return true;
+}
+
+void CircuitBreaker::record_success() noexcept {
+  auto s = static_cast<State>(state_.load(std::memory_order_acquire));
+  if (s != State::Closed) {
+    std::cerr << "[circuit_breaker] NATS circuit CLOSED — connection restored\n";
+  }
+  failure_count_.store(0, std::memory_order_relaxed);
+  state_.store(static_cast<uint8_t>(State::Closed), std::memory_order_release);
+}
+
+void CircuitBreaker::record_failure() noexcept {
+  int count = failure_count_.fetch_add(1, std::memory_order_relaxed) + 1;
+  auto s = static_cast<State>(state_.load(std::memory_order_acquire));
+
+  if (s == State::HalfOpen) {
+    transition_to_open();
+    return;
+  }
+
+  if (s == State::Closed && count >= cfg_.failure_threshold) {
+    transition_to_open();
+  }
+}
+
+std::string CircuitBreaker::state_label() const noexcept {
+  switch (static_cast<State>(state_.load(std::memory_order_acquire))) {
+    case State::Closed:
+      return "closed";
+    case State::Open:
+      return "open";
+    case State::HalfOpen:
+      return "half_open";
+  }
+  return "unknown";
+}
+
+}  // namespace projectagamemnon

--- a/src/dead_letter_queue.cpp
+++ b/src/dead_letter_queue.cpp
@@ -1,0 +1,46 @@
+#include "projectagamemnon/dead_letter_queue.hpp"
+
+#include <iostream>
+
+namespace projectagamemnon {
+
+static int64_t now_ms() noexcept {
+  return std::chrono::duration_cast<std::chrono::milliseconds>(
+             std::chrono::steady_clock::now().time_since_epoch())
+      .count();
+}
+
+void DeadLetterQueue::push(std::string subject, std::string payload, int attempts) {
+  std::lock_guard<std::mutex> lock(mu_);
+  if (queue_.size() >= capacity_) {
+    std::cerr << "[dlq] WARNING: dead-letter queue full (capacity=" << capacity_
+              << "), evicting oldest entry\n";
+    queue_.pop_front();
+  }
+  queue_.push_back({std::move(subject), std::move(payload), attempts, now_ms()});
+}
+
+std::vector<DeadLetterQueue::Entry> DeadLetterQueue::drain() {
+  std::lock_guard<std::mutex> lock(mu_);
+  std::vector<Entry> result(std::make_move_iterator(queue_.begin()),
+                            std::make_move_iterator(queue_.end()));
+  queue_.clear();
+  return result;
+}
+
+void DeadLetterQueue::clear() {
+  std::lock_guard<std::mutex> lock(mu_);
+  queue_.clear();
+}
+
+std::size_t DeadLetterQueue::size() const {
+  std::lock_guard<std::mutex> lock(mu_);
+  return queue_.size();
+}
+
+bool DeadLetterQueue::empty() const {
+  std::lock_guard<std::mutex> lock(mu_);
+  return queue_.empty();
+}
+
+}  // namespace projectagamemnon

--- a/src/nats_client.cpp
+++ b/src/nats_client.cpp
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <memory>
 #include <string>
+#include <thread>
 
 #include "nats.h"
 #include "nlohmann/json.hpp"
@@ -16,17 +17,49 @@ namespace projectagamemnon {
 static inline natsConnection* to_conn(void* p) { return static_cast<natsConnection*>(p); }
 static inline jsCtx* to_js(void* p) { return static_cast<jsCtx*>(p); }
 
+// Infra-class errors that warrant a retry (transient broker unavailability).
+// Protocol rejections (e.g. NATS_NOT_PERMITTED) should not be retried.
+static bool is_infra_error(natsStatus s) noexcept {
+  switch (s) {
+    case NATS_CONNECTION_CLOSED:
+    case NATS_CONNECTION_DISCONNECTED:
+    case NATS_IO_ERROR:
+    case NATS_NO_SERVER:
+    case NATS_TIMEOUT:
+      return true;
+    default:
+      return false;
+  }
+}
+
 // ── Lifetime ─────────────────────────────────────────────────────────────────
 
 NatsClient::NatsClient(const std::string& url) : url_(url) {}
+
+NatsClient::NatsClient(const std::string& url, CircuitBreaker::Config cb_cfg,
+                       std::size_t dlq_capacity)
+    : url_(url), breaker_(cb_cfg), dlq_(dlq_capacity) {}
 
 NatsClient::~NatsClient() { close(); }
 
 // ── connect ───────────────────────────────────────────────────────────────────
 
 bool NatsClient::connect() {
+  natsOptions* opts = nullptr;
+  natsOptions_Create(&opts);
+  // Allow nats.c internal reconnect attempts before we declare failure.
+  natsOptions_SetMaxReconnect(opts, 5);
+  natsOptions_SetReconnectWait(opts, 500);  // 500 ms between internal reconnect attempts
+
   natsConnection* c = nullptr;
-  natsStatus s = natsConnection_ConnectTo(&c, url_.c_str());
+  natsStatus s = natsConnection_Connect(&c, opts);
+  natsOptions_Destroy(opts);
+
+  if (s != NATS_OK) {
+    // Fall back to simple URL connect (natsOptions_SetServers variant)
+    s = natsConnection_ConnectTo(&c, url_.c_str());
+  }
+
   if (s != NATS_OK) {
     std::cerr << "[nats] WARNING: could not connect to " << url_ << " — " << natsStatus_GetText(s)
               << " (NATS events will be skipped)\n";
@@ -115,16 +148,13 @@ void NatsClient::ensure_streams() {
   }
 }
 
-// ── publish ───────────────────────────────────────────────────────────────────
+// ── do_publish_once ───────────────────────────────────────────────────────────
 
-bool NatsClient::publish(const std::string& subject, const std::string& payload) {
-  if (!connected_ || !conn_) return false;
-
+int NatsClient::do_publish_once(const std::string& subject, const std::string& payload) {
   natsStatus s;
   if (js_) {
     jsPubAck* ack = nullptr;
     jsErrCode jerr = static_cast<jsErrCode>(0);
-    // js_Publish signature: (pubAck**, ctx*, subj, data, dataLen, opts*, errCode*)
     s = js_Publish(&ack, to_js(js_), subject.c_str(), payload.data(),
                    static_cast<int>(payload.size()), nullptr, &jerr);
     if (ack) jsPubAck_Destroy(ack);
@@ -132,11 +162,47 @@ bool NatsClient::publish(const std::string& subject, const std::string& payload)
     s = natsConnection_Publish(to_conn(conn_), subject.c_str(), payload.data(),
                                static_cast<int>(payload.size()));
   }
-  if (s != NATS_OK) {
-    std::cerr << "[nats] publish error on " << subject << ": " << natsStatus_GetText(s) << "\n";
+  return static_cast<int>(s);
+}
+
+// ── publish ───────────────────────────────────────────────────────────────────
+
+bool NatsClient::publish(const std::string& subject, const std::string& payload) {
+  if (!connected_ || !conn_) return false;
+
+  if (!breaker_.allow_attempt()) {
+    std::cerr << "[nats] ERROR: circuit OPEN — dropping publish to " << subject << "\n";
+    dlq_.push(subject, payload, 0);
     return false;
   }
-  return true;
+
+  int delay_ms = kBaseRetryMs;
+  for (int attempt = 1; attempt <= kMaxRetries; ++attempt) {
+    auto s = static_cast<natsStatus>(do_publish_once(subject, payload));
+    if (s == NATS_OK) {
+      breaker_.record_success();
+      return true;
+    }
+
+    std::cerr << "[nats] publish error on " << subject << " (attempt " << attempt << "/"
+              << kMaxRetries << "): " << natsStatus_GetText(s) << "\n";
+
+    if (!is_infra_error(s) || attempt == kMaxRetries) {
+      // Non-retryable error or last attempt exhausted.
+      breaker_.record_failure();
+      dlq_.push(subject, payload, attempt);
+      std::cerr << "[nats] ERROR: publish to " << subject
+                << " failed after all retries — message dead-lettered\n";
+      return false;
+    }
+
+    // Exponential backoff before next retry.
+    std::this_thread::sleep_for(std::chrono::milliseconds(delay_ms));
+    delay_ms *= 2;
+  }
+
+  // Unreachable, but satisfies compiler.
+  return false;
 }
 
 // ── publish_log ───────────────────────────────────────────────────────────────

--- a/src/routes.cpp
+++ b/src/routes.cpp
@@ -61,8 +61,31 @@ void register_routes(httplib::Server& server, Store& store, NatsClient& nats) {
     reply_json(res, 200, {{"status", "ok"}, {"service", "ProjectAgamemnon"}});
   });
 
-  server.Get("/v1/health", [](const httplib::Request&, httplib::Response& res) {
-    reply_json(res, 200, {{"status", "ok"}});
+  server.Get("/v1/health", [np](const httplib::Request&, httplib::Response& res) {
+    reply_json(res, 200,
+               {{"status", "ok"},
+                {"nats_circuit", np->circuit_breaker().state_label()},
+                {"dlq_depth", np->dead_letter_queue().size()}});
+  });
+
+  // GET /v1/dead-letter — drain and return all dead-lettered messages
+  // np is owned by main() and outlives the server; reference capture is safe.
+  server.Get("/v1/dead-letter", [np](const httplib::Request&, httplib::Response& res) {
+    auto entries = np->dead_letter_queue().drain();
+    json arr = json::array();
+    for (const auto& e : entries) {
+      arr.push_back({{"subject", e.subject},
+                     {"payload", e.payload},
+                     {"attempts", e.attempts},
+                     {"timestamp_ms", e.timestamp_ms}});
+    }
+    reply_json(res, 200, {{"dead_letter_queue", arr}});
+  });
+
+  // DELETE /v1/dead-letter — discard all dead-lettered messages
+  server.Delete("/v1/dead-letter", [np](const httplib::Request&, httplib::Response& res) {
+    np->dead_letter_queue().clear();
+    reply_json(res, 200, {{"cleared", true}});
   });
 
   server.Get("/v1/version", [](const httplib::Request&, httplib::Response& res) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,6 +15,8 @@ add_executable(${PROJECT_NAME}_tests
   src/test_routes_malformed.cpp
   src/test_peer_discovery.cpp
   src/test_server_limits.cpp
+  src/test_circuit_breaker.cpp
+  src/test_dead_letter_queue.cpp
   ${PROJECT_SOURCE_DIR}/src/routes.cpp
   ${PROJECT_SOURCE_DIR}/src/store.cpp
   ${PROJECT_SOURCE_DIR}/src/nats_client.cpp
@@ -42,6 +44,7 @@ target_compile_options(${PROJECT_NAME}_tests PRIVATE
 target_link_libraries(${PROJECT_NAME}_tests
   PRIVATE
     ${PROJECT_NAME}::${PROJECT_NAME}
+    agamemnon_lib
     GTest::gtest_main
     httplib::httplib
     nlohmann_json::nlohmann_json
@@ -50,6 +53,17 @@ target_link_libraries(${PROJECT_NAME}_tests
     OpenSSL::SSL
     OpenSSL::Crypto
     Threads::Threads)
+
+target_compile_options(${PROJECT_NAME}_tests PRIVATE
+  -Wno-old-style-cast
+  -Wno-useless-cast
+  -Wno-conversion
+  -Wno-sign-conversion
+  -Wno-shadow
+  -Wno-format-nonliteral
+  -Wno-double-promotion
+  -Wno-cast-align
+)
 
 include(GoogleTest)
 gtest_discover_tests(${PROJECT_NAME}_tests DISCOVERY_TIMEOUT 120)

--- a/test/src/test_circuit_breaker.cpp
+++ b/test/src/test_circuit_breaker.cpp
@@ -1,0 +1,111 @@
+#include "projectagamemnon/circuit_breaker.hpp"
+
+#include <chrono>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+namespace projectagamemnon::test {
+
+using State = CircuitBreaker::State;
+
+TEST(CircuitBreakerTest, InitiallyClosedAndAllowsAttempts) {
+  CircuitBreaker cb;
+  EXPECT_EQ(cb.state(), State::Closed);
+  EXPECT_TRUE(cb.allow_attempt());
+}
+
+TEST(CircuitBreakerTest, OpensAfterFailureThreshold) {
+  CircuitBreaker::Config cfg;
+  cfg.failure_threshold = 3;
+  cfg.probe_interval = std::chrono::milliseconds{60'000};
+  CircuitBreaker cb(cfg);
+
+  cb.record_failure();
+  EXPECT_EQ(cb.state(), State::Closed);
+  cb.record_failure();
+  EXPECT_EQ(cb.state(), State::Closed);
+  cb.record_failure();
+  EXPECT_EQ(cb.state(), State::Open);
+}
+
+TEST(CircuitBreakerTest, OpenCircuitDeniesAttempts) {
+  CircuitBreaker::Config cfg;
+  cfg.failure_threshold = 1;
+  cfg.probe_interval = std::chrono::milliseconds{60'000};
+  CircuitBreaker cb(cfg);
+
+  cb.record_failure();
+  ASSERT_EQ(cb.state(), State::Open);
+  EXPECT_FALSE(cb.allow_attempt());
+}
+
+TEST(CircuitBreakerTest, TransitionsToHalfOpenAfterProbeInterval) {
+  CircuitBreaker::Config cfg;
+  cfg.failure_threshold = 1;
+  cfg.probe_interval = std::chrono::milliseconds{50};
+  CircuitBreaker cb(cfg);
+
+  cb.record_failure();
+  ASSERT_EQ(cb.state(), State::Open);
+
+  std::this_thread::sleep_for(std::chrono::milliseconds{100});
+
+  EXPECT_TRUE(cb.allow_attempt());
+  EXPECT_EQ(cb.state(), State::HalfOpen);
+}
+
+TEST(CircuitBreakerTest, ClosesOnProbeSuccess) {
+  CircuitBreaker::Config cfg;
+  cfg.failure_threshold = 1;
+  cfg.probe_interval = std::chrono::milliseconds{50};
+  CircuitBreaker cb(cfg);
+
+  cb.record_failure();
+  std::this_thread::sleep_for(std::chrono::milliseconds{100});
+  cb.allow_attempt();  // transitions to HalfOpen
+  ASSERT_EQ(cb.state(), State::HalfOpen);
+
+  cb.record_success();
+  EXPECT_EQ(cb.state(), State::Closed);
+  EXPECT_EQ(cb.failure_count(), 0);
+}
+
+TEST(CircuitBreakerTest, ReopensOnProbeFailure) {
+  CircuitBreaker::Config cfg;
+  cfg.failure_threshold = 1;
+  cfg.probe_interval = std::chrono::milliseconds{50};
+  CircuitBreaker cb(cfg);
+
+  cb.record_failure();
+  std::this_thread::sleep_for(std::chrono::milliseconds{100});
+  cb.allow_attempt();  // transitions to HalfOpen
+  ASSERT_EQ(cb.state(), State::HalfOpen);
+
+  cb.record_failure();
+  EXPECT_EQ(cb.state(), State::Open);
+}
+
+TEST(CircuitBreakerTest, SuccessResetsFailureCount) {
+  CircuitBreaker cb;
+  cb.record_failure();
+  cb.record_failure();
+  EXPECT_GT(cb.failure_count(), 0);
+
+  cb.record_success();
+  EXPECT_EQ(cb.failure_count(), 0);
+  EXPECT_EQ(cb.state(), State::Closed);
+}
+
+TEST(CircuitBreakerTest, StateLabelMatchesState) {
+  CircuitBreaker::Config cfg;
+  cfg.failure_threshold = 1;
+  cfg.probe_interval = std::chrono::milliseconds{60'000};
+  CircuitBreaker cb(cfg);
+
+  EXPECT_EQ(cb.state_label(), "closed");
+  cb.record_failure();
+  EXPECT_EQ(cb.state_label(), "open");
+}
+
+}  // namespace projectagamemnon::test

--- a/test/src/test_dead_letter_queue.cpp
+++ b/test/src/test_dead_letter_queue.cpp
@@ -1,0 +1,78 @@
+#include "projectagamemnon/dead_letter_queue.hpp"
+
+#include <gtest/gtest.h>
+
+namespace projectagamemnon::test {
+
+TEST(DeadLetterQueueTest, InitiallyEmpty) {
+  DeadLetterQueue dlq;
+  EXPECT_TRUE(dlq.empty());
+  EXPECT_EQ(dlq.size(), 0u);
+}
+
+TEST(DeadLetterQueueTest, PushIncreasesSize) {
+  DeadLetterQueue dlq;
+  dlq.push("hi.tasks.created", R"({"id":"1"})", 3);
+  EXPECT_EQ(dlq.size(), 1u);
+  EXPECT_FALSE(dlq.empty());
+}
+
+TEST(DeadLetterQueueTest, DrainReturnsAllEntries) {
+  DeadLetterQueue dlq;
+  dlq.push("subj.a", "payload_a", 1);
+  dlq.push("subj.b", "payload_b", 2);
+
+  auto entries = dlq.drain();
+  ASSERT_EQ(entries.size(), 2u);
+  EXPECT_EQ(entries[0].subject, "subj.a");
+  EXPECT_EQ(entries[0].payload, "payload_a");
+  EXPECT_EQ(entries[0].attempts, 1);
+  EXPECT_EQ(entries[1].subject, "subj.b");
+  EXPECT_EQ(entries[1].attempts, 2);
+}
+
+TEST(DeadLetterQueueTest, DrainEmptiesQueue) {
+  DeadLetterQueue dlq;
+  dlq.push("s", "p", 1);
+  dlq.drain();
+  EXPECT_TRUE(dlq.empty());
+}
+
+TEST(DeadLetterQueueTest, ClearEmptiesQueue) {
+  DeadLetterQueue dlq;
+  dlq.push("s", "p", 1);
+  dlq.clear();
+  EXPECT_TRUE(dlq.empty());
+}
+
+TEST(DeadLetterQueueTest, ClearDoesNotReturnEntries) {
+  DeadLetterQueue dlq;
+  dlq.push("s", "p", 1);
+  dlq.clear();
+  auto entries = dlq.drain();
+  EXPECT_TRUE(entries.empty());
+}
+
+TEST(DeadLetterQueueTest, BoundedCapacityEvictsOldest) {
+  DeadLetterQueue dlq(3);
+  dlq.push("s1", "p1", 1);
+  dlq.push("s2", "p2", 1);
+  dlq.push("s3", "p3", 1);
+  // At capacity; next push evicts s1
+  dlq.push("s4", "p4", 1);
+
+  EXPECT_EQ(dlq.size(), 3u);
+  auto entries = dlq.drain();
+  EXPECT_EQ(entries[0].subject, "s2");
+  EXPECT_EQ(entries[2].subject, "s4");
+}
+
+TEST(DeadLetterQueueTest, TimestampIsSet) {
+  DeadLetterQueue dlq;
+  dlq.push("s", "p", 1);
+  auto entries = dlq.drain();
+  ASSERT_EQ(entries.size(), 1u);
+  EXPECT_GT(entries[0].timestamp_ms, 0);
+}
+
+}  // namespace projectagamemnon::test


### PR DESCRIPTION
## Summary

- **CircuitBreaker**: Atomic three-state machine (Closed → Open → HalfOpen) with configurable failure threshold (default 5) and probe interval (default 30s). Logs `ERROR` on trip/recovery.
- **DeadLetterQueue**: Bounded ring buffer (default 256 entries) for messages that exhaust all retries. Evicts oldest on overflow with a warning log.
- **NatsClient resilience**: `publish()` now retries up to 3× with exponential backoff (50ms base) on infra-class NATS errors (`CLOSED`, `DISCONNECTED`, `IO_ERROR`, `NO_SERVER`, `TIMEOUT`). Circuit breaker gates every attempt. Messages that exhaust retries are dead-lettered. Log level escalated from WARN → ERROR.
- **HTTP timeouts**: `set_read_timeout(30s)`, `set_write_timeout(30s)`, `set_keep_alive_timeout(5s)` added before `server.listen()`.
- **New routes**: `GET /v1/dead-letter` (drain + return), `DELETE /v1/dead-letter` (clear). `GET /v1/health` now includes `nats_circuit` and `dlq_depth` fields.
- **agamemnon_lib**: Extracted shared static library target so tests can link against the NATS client and new components without pulling in `server_main.cpp`'s `main()`.

## Test plan

- [ ] `test_circuit_breaker`: 8 unit tests covering Closed→Open trip, Open→HalfOpen probe, HalfOpen→Closed success, HalfOpen→Open re-trip, success resets failure count, state labels
- [ ] `test_dead_letter_queue`: 8 unit tests covering push/drain/clear/empty/bounded eviction/timestamp

All new source files compile cleanly (pre-existing linker issue with gtest ABI mismatch between worktrees is unrelated to this PR).

Closes #71
Part of #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)