### PR TITLE
docs(.github): add issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug report
+about: Report a defect or unexpected behavior
+labels: bug
+---
+
+## Summary
+
+<!-- One-sentence description of the bug -->
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+
+## Expected Behavior
+
+## Actual Behavior
+
+## Environment
+
+- OS:
+- Compiler (GCC/Clang version):
+- Build preset (`debug` / `release`):
+
+## Additional Context
+
+<!-- Logs, stack traces, sanitizer output -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,15 @@
+---
+name: Feature request
+about: Propose a new capability or improvement
+labels: enhancement
+---
+
+## Motivation
+
+<!-- Why is this needed? What problem does it solve? -->
+
+## Proposed Solution
+
+## Alternatives Considered
+
+## Additional Context

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+## Summary
+
+<!-- One-sentence description of this PR -->
+
+## Related Issues
+
+Closes #
+
+## Changes Made
+
+-
+
+## Test Plan
+
+- [ ] `just build` passes
+- [ ] `just test` passes
+- [ ] `just lint` passes
+- [ ] `just format-check` passes
+- [ ] New behavior is covered by tests (if applicable)
+
+## Checklist
+
+- [ ] PR is linked to a GitHub issue
+- [ ] Branch name follows `<issue-number>-<short-description>` convention
+- [ ] Commit messages follow Conventional Commits format
+- [ ] `CONTRIBUTING.md` requirements are met

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,8 @@ Before starting work:
 - Comment on an issue to claim it before starting work
 - Create a new issue if one doesn't exist for your contribution
 
+Use the provided issue templates (bug report, feature request) when opening new issues — they pre-fill the required fields.
+
 ### 2. Branch Naming Convention
 
 Create a feature branch from `main`:


### PR DESCRIPTION
## Summary

Add GitHub issue templates (bug report, feature request) and a PR template to enforce the contribution workflow described in CONTRIBUTING.md.

## Related Issues

Closes #74

## Changes Made

- `.github/ISSUE_TEMPLATE/bug_report.md` — bug report template with reproduction steps, expected/actual behavior, environment fields
- `.github/ISSUE_TEMPLATE/feature_request.md` — feature request template with motivation, proposed solution, and alternatives
- `.github/PULL_REQUEST_TEMPLATE.md` — PR template with linked issue field, summary, changes, test plan checklist, and pre-submit checklist
- `CONTRIBUTING.md` — added one sentence pointing contributors to the new templates

## Test Plan

- [x] `pixi run pre-commit run --all-files` passes (all hooks green)
- [x] No markdownlint violations (MD040/MD041 disabled in `.markdownlint.yaml`; all other rules satisfied)
- [x] Docs-only change: no C++ code, no CI workflow changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)