### PR TITLE
fix(docs): correct nats.c version in CLAUDE.md (v3.12.0 → v3.9.1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ All inter-component communication flows **through ProjectKeystone** (invisible t
 Components publish/subscribe to logical subjects — Keystone routes transparently:
 
 - Local (intra-host): BlazingMQ + C++20 MessageBus
-- Cross-host: NATS JetStream via nats.c v3.12.0 over Tailscale
+- Cross-host: NATS JetStream via nats.c v3.9.1 over Tailscale
 
 Relevant NATS subjects Agamemnon uses:
 


### PR DESCRIPTION
## Summary

- Corrects the nats.c version documented in CLAUDE.md from `v3.12.0` to `v3.9.1`
- The actual pinned version in `CMakeLists.txt:33` is `v3.9.1`; the documentation was stale/incorrect

## Test plan

- No code changes — documentation-only fix
- Verified against `CMakeLists.txt` `GIT_TAG v3.9.1` (line 33)

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)