### PR TITLE
perf(docker): add BuildKit cache mounts for apt, pip, and Conan

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
+# syntax=docker/dockerfile:1
 FROM ubuntu:24.04 AS builder
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends \
     cmake \
     ninja-build \
     make \
@@ -12,14 +15,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-pip \
     && rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install --break-system-packages conan && conan profile detect
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip3 install --break-system-packages conan && conan profile detect
 
 WORKDIR /src
 
 # Copy Conan files first for dependency caching.
 COPY conanfile.py ./
 COPY conan/ conan/
-RUN conan install . \
+RUN --mount=type=cache,target=/root/.conan2/p,sharing=locked \
+    conan install . \
     --output-folder=build \
     --profile=conan/profiles/default \
     --build=missing
@@ -46,7 +51,9 @@ RUN cmake -B build -G Ninja \
 # ── Runtime image ─────────────────────────────────────────────────────────────
 FROM ubuntu:24.04
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends \
     libssl3 \
     wget \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary

- Add `# syntax=docker/dockerfile:1` directive to enable BuildKit extended syntax
- Add `--mount=type=cache` mounts to all four `RUN` steps that download packages:
  - Builder `apt-get`: `/var/cache/apt` + `/var/lib/apt` (`sharing=locked`)
  - `pip3 install conan`: `/root/.cache/pip`
  - `conan install`: `/root/.conan2/p` (`sharing=locked`)
  - Runtime `apt-get`: `/var/cache/apt` + `/var/lib/apt` (`sharing=locked`)
- No structural changes to multi-stage build or `COPY` ordering

## Test plan

- [ ] Cold build: `DOCKER_BUILDKIT=1 docker build --progress=plain -t agamemnon:test .` — verifies image builds successfully
- [ ] Warm build (no source changes): verify `CACHED` markers appear on `apt-get` and `pip3 install` layers in `--progress=plain` output
- [ ] Warm build (source-only change, e.g. `touch src/main.cpp`): verify `apt-get`, `pip3 install`, and `conan install` layers show `CACHED`
- [ ] `hadolint Dockerfile` — no new warnings (pre-existing DL3008/DL3013 unrelated to this change)
- [ ] `docker run --rm agamemnon:test ProjectAgamemnon_server --help` or equivalent exits 0

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)