### PR TITLE
feat(dx): add .editorconfig, .gitattributes, and devcontainer (#80)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+{
+  "name": "ProjectAgamemnon",
+  "dockerFile": "../Dockerfile",
+  "workspaceFolder": "/workspace",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
+  "postCreateCommand": "pixi install && just deps",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "llvm-vs-code-extensions.vscode-clangd",
+        "ms-vscode.cmake-tools",
+        "EditorConfig.EditorConfig",
+        "tamasfe.even-better-toml",
+        "redhat.vscode-yaml"
+      ],
+      "settings": {
+        "editor.formatOnSave": true,
+        "clangd.arguments": ["--compile-commands-dir=build/debug"],
+        "cmake.configureOnOpen": false
+      }
+    }
+  }
+}

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,37 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{cpp,hpp,h,cc,cxx}]
+indent_style = space
+
+[*.{cmake,cmake.in}]
+indent_style = space
+
+[CMakeLists.txt]
+indent_style = space
+
+[*.{yml,yaml}]
+indent_style = space
+
+[*.{json,toml}]
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab
+
+[*.sh]
+indent_style = space
+indent_size = 2
+
+[justfile]
+indent_style = space
+indent_size = 2

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,21 @@
+# Normalize line endings to LF on commit
+* text=auto eol=lf
+
+# Force binary treatment for compiled artifacts
+*.a binary
+*.so binary
+*.o binary
+
+# Explicitly text
+*.cpp text eol=lf
+*.hpp text eol=lf
+*.h   text eol=lf
+*.cmake text eol=lf
+CMakeLists.txt text eol=lf
+*.json text eol=lf
+*.toml text eol=lf
+*.yaml text eol=lf
+*.yml  text eol=lf
+*.md   text eol=lf
+*.sh   text eol=lf
+justfile text eol=lf

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,12 @@ repos:
       - id: check-merge-conflict
       - id: mixed-line-ending
 
+  - repo: https://github.com/editorconfig-checker/editorconfig-checker.python
+    rev: 3.2.0
+    hooks:
+      - id: editorconfig-checker
+        exclude: '^(build/|install/|\.git/)'
+
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v17.0.6
     hooks:


### PR DESCRIPTION
## Summary

- Add `.editorconfig` enforcing UTF-8, LF line endings, final newlines, and space indentation across all file types. `indent_size` is intentionally omitted for C++, CMake, and YAML files where authoritative formatters (clang-format, yamllint) are already in place.
- Add `.gitattributes` to normalize line endings to LF at the Git layer, pairing with `.editorconfig` for belt-and-suspenders coverage.
- Add `.devcontainer/devcontainer.json` for one-click VS Code / GitHub Codespaces setup with clangd, CMake Tools, EditorConfig, and TOML/YAML extensions pre-installed.
- Add `editorconfig-checker` pre-commit hook (rev `3.2.0`) to enforce `.editorconfig` compliance in CI.

## Test plan

- [x] `pre-commit run editorconfig-checker --all-files` — Passed
- [x] `pre-commit run trailing-whitespace --all-files` — Passed
- [x] `pre-commit run end-of-file-fixer --all-files` — Passed
- [x] `pre-commit run mixed-line-ending --all-files` — Passed
- [x] `pre-commit run check-json --all-files` — Passed (validates devcontainer.json)
- [x] `pre-commit run check-yaml --all-files` — Passed
- [x] `pre-commit run --all-files` — Full suite green
- [x] `git add --renormalize .` — Only `.pre-commit-config.yaml` touched (no pre-existing CRLF files)

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)