### PR TITLE
feat(rate-limit): add per-IP token-bucket rate limiter on all endpoints

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,7 @@ add_library(agamemnon_lib STATIC
   src/circuit_breaker.cpp
   src/dead_letter_queue.cpp
   src/github_client.cpp
+  src/rate_limiter.cpp
 )
 
 target_compile_features(agamemnon_lib PUBLIC cxx_std_20)

--- a/cmake/SourcesAndHeaders.cmake
+++ b/cmake/SourcesAndHeaders.cmake
@@ -6,9 +6,11 @@
 # this library.
 set(sources
     src/version_info.cpp
-    src/store.cpp)
+    src/store.cpp
+    src/rate_limiter.cpp)
 
 set(headers
     include/projectagamemnon/version.hpp
     include/projectagamemnon/store.hpp
-    include/projectagamemnon/peer_discovery.hpp)
+    include/projectagamemnon/peer_discovery.hpp
+    include/projectagamemnon/rate_limiter.hpp)

--- a/include/projectagamemnon/rate_limiter.hpp
+++ b/include/projectagamemnon/rate_limiter.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <chrono>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+
+namespace projectagamemnon {
+
+/// Token-bucket rate limiter with per-client-IP tracking.
+///
+/// Each client IP gets its own bucket. Tokens refill at `tokens_per_second`
+/// up to `burst_capacity`. Each allowed request consumes one token.
+/// Buckets unseen for >5 minutes are evicted to bound memory growth.
+class RateLimiter {
+ public:
+  /// @param tokens_per_second  Sustained request rate allowed per client IP.
+  /// @param burst_capacity     Maximum tokens (burst allowance) per client IP.
+  RateLimiter(double tokens_per_second, double burst_capacity);
+
+  /// Returns true if the request from `client_ip` is within the rate limit.
+  /// Thread-safe.
+  bool allow(const std::string& client_ip);
+
+  /// Returns how many seconds until the next token is available for `client_ip`.
+  /// Returns 0 if a token is already available.
+  /// Thread-safe.
+  double retry_after_seconds(const std::string& client_ip);
+
+ private:
+  struct Bucket {
+    double tokens;
+    std::chrono::steady_clock::time_point last_seen;
+  };
+
+  void refill(Bucket& bucket, std::chrono::steady_clock::time_point now) const;
+  void evict_stale(std::chrono::steady_clock::time_point now);
+
+  double tokens_per_second_;
+  double burst_capacity_;
+
+  std::mutex mutex_;
+  std::unordered_map<std::string, Bucket> buckets_;
+
+  static constexpr auto kEvictAfter = std::chrono::minutes{5};
+  static constexpr int kEvictCheckInterval = 100;
+  int request_count_since_evict_{0};
+};
+
+}  // namespace projectagamemnon

--- a/include/projectagamemnon/routes.hpp
+++ b/include/projectagamemnon/routes.hpp
@@ -9,10 +9,12 @@ namespace projectagamemnon {
 
 class Store;
 class NatsClient;
+class RateLimiter;
 
 /// Register all /v1/ route handlers on the given server.
-/// Both Store and NatsClient are passed by reference; they must outlive the
-/// server (they are owned by main).
-void register_routes(httplib::Server& server, Store& store, NatsClient& nats);
+/// Store, NatsClient, and RateLimiter are passed by reference; they must
+/// outlive the server (they are owned by main).
+void register_routes(httplib::Server& server, Store& store, NatsClient& nats,
+                     RateLimiter& rate_limiter);
 
 }  // namespace projectagamemnon

--- a/src/rate_limiter.cpp
+++ b/src/rate_limiter.cpp
@@ -1,0 +1,72 @@
+#include "projectagamemnon/rate_limiter.hpp"
+
+#include <algorithm>
+
+namespace projectagamemnon {
+
+RateLimiter::RateLimiter(double tokens_per_second, double burst_capacity)
+    : tokens_per_second_(tokens_per_second), burst_capacity_(burst_capacity) {}
+
+void RateLimiter::refill(Bucket& bucket, std::chrono::steady_clock::time_point now) const {
+  auto elapsed = std::chrono::duration<double>(now - bucket.last_seen).count();
+  bucket.tokens = std::min(burst_capacity_, bucket.tokens + elapsed * tokens_per_second_);
+  bucket.last_seen = now;
+}
+
+void RateLimiter::evict_stale(std::chrono::steady_clock::time_point now) {
+  // Called under mutex_ — no need to re-lock.
+  for (auto it = buckets_.begin(); it != buckets_.end();) {
+    if ((now - it->second.last_seen) > kEvictAfter) {
+      it = buckets_.erase(it);
+    } else {
+      ++it;
+    }
+  }
+}
+
+bool RateLimiter::allow(const std::string& client_ip) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  auto now = std::chrono::steady_clock::now();
+
+  auto [it, inserted] = buckets_.emplace(client_ip, Bucket{burst_capacity_, now});
+  Bucket& bucket = it->second;
+
+  if (!inserted) {
+    refill(bucket, now);
+  }
+
+  if (++request_count_since_evict_ >= kEvictCheckInterval) {
+    request_count_since_evict_ = 0;
+    evict_stale(now);
+    // Iterator `it`/`bucket` may be invalidated after eviction if the IP was
+    // just evicted, but that can't happen: we just refreshed last_seen above.
+  }
+
+  if (bucket.tokens >= 1.0) {
+    bucket.tokens -= 1.0;
+    return true;
+  }
+  return false;
+}
+
+double RateLimiter::retry_after_seconds(const std::string& client_ip) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  auto now = std::chrono::steady_clock::now();
+
+  auto it = buckets_.find(client_ip);
+  if (it == buckets_.end()) {
+    return 0.0;
+  }
+
+  Bucket bucket = it->second;
+  refill(bucket, now);
+
+  if (bucket.tokens >= 1.0) {
+    return 0.0;
+  }
+
+  double tokens_needed = 1.0 - bucket.tokens;
+  return tokens_needed / tokens_per_second_;
+}
+
+}  // namespace projectagamemnon

--- a/src/routes.cpp
+++ b/src/routes.cpp
@@ -134,10 +134,9 @@ void register_routes(httplib::Server& server, Store& store, NatsClient& nats,
       int retry_int = static_cast<int>(retry) + 1;
       res.status = 429;
       res.set_header("Retry-After", std::to_string(retry_int));
-      res.set_content(
-          R"({"error":"rate limit exceeded","retry_after_seconds":)" + std::to_string(retry_int) +
-              "}",
-          "application/json");
+      res.set_content(R"({"error":"rate limit exceeded","retry_after_seconds":)" +
+                          std::to_string(retry_int) + "}",
+                      "application/json");
       return httplib::Server::HandlerResponse::Handled;
     }
     return httplib::Server::HandlerResponse::Unhandled;

--- a/src/routes.cpp
+++ b/src/routes.cpp
@@ -1,6 +1,7 @@
 #include "projectagamemnon/routes.hpp"
 
 #include "projectagamemnon/nats_client.hpp"
+#include "projectagamemnon/rate_limiter.hpp"
 #include "projectagamemnon/store.hpp"
 #include "projectagamemnon/version.hpp"
 
@@ -116,9 +117,31 @@ static bool require_string_array(httplib::Response& res, const json& arr,
 // avoid dangling-reference UB when the lambda outlives register_routes' stack.
 // Both store and nats are owned by main() and outlive the server.
 
-void register_routes(httplib::Server& server, Store& store, NatsClient& nats) {
+void register_routes(httplib::Server& server, Store& store, NatsClient& nats,
+                     RateLimiter& rate_limiter) {
   Store* sp = &store;
   NatsClient* np = &nats;
+  RateLimiter* rl = &rate_limiter;
+
+  // Enforce per-IP rate limit on every request except health checks.
+  server.set_pre_routing_handler([rl](const httplib::Request& req, httplib::Response& res) {
+    // Health endpoints are exempt — they must remain reachable for liveness probes.
+    if (req.path == "/health" || req.path == "/v1/health") {
+      return httplib::Server::HandlerResponse::Unhandled;
+    }
+    if (!rl->allow(req.remote_addr)) {
+      double retry = rl->retry_after_seconds(req.remote_addr);
+      int retry_int = static_cast<int>(retry) + 1;
+      res.status = 429;
+      res.set_header("Retry-After", std::to_string(retry_int));
+      res.set_content(
+          R"({"error":"rate limit exceeded","retry_after_seconds":)" + std::to_string(retry_int) +
+              "}",
+          "application/json");
+      return httplib::Server::HandlerResponse::Handled;
+    }
+    return httplib::Server::HandlerResponse::Unhandled;
+  });
 
   // ── Health / version ────────────────────────────────────────────────────
   server.Get("/health", [](const httplib::Request&, httplib::Response& res) {

--- a/src/server_main.cpp
+++ b/src/server_main.cpp
@@ -2,6 +2,7 @@
 #include "projectagamemnon/nats_client.hpp"
 #include "projectagamemnon/peer_discovery.hpp"
 #include "projectagamemnon/port_parse.hpp"
+#include "projectagamemnon/rate_limiter.hpp"
 #include "projectagamemnon/routes.hpp"
 #include "projectagamemnon/store.hpp"
 #include "projectagamemnon/version.hpp"
@@ -84,6 +85,15 @@ int main() {
   } else {
     std::cerr << "[agamemnon] WARNING: running without NATS — events will be skipped\n";
   }
+
+  // ── Rate limiter ──────────────────────────────────────────────────────────
+  const char* rps_env = std::getenv("RATE_LIMIT_RPS");
+  const char* burst_env = std::getenv("RATE_LIMIT_BURST");
+  double rate_limit_rps = rps_env ? std::stod(rps_env) : 60.0;
+  double rate_limit_burst = burst_env ? std::stod(burst_env) : 120.0;
+  projectagamemnon::RateLimiter rate_limiter(rate_limit_rps, rate_limit_burst);
+  std::cout << "[agamemnon] rate limiting: " << rate_limit_rps << " req/s, burst "
+            << rate_limit_burst << "\n";
 
   // ── HTTP server ───────────────────────────────────────────────────────────
   auto env_int = [](const char* name, int def) -> int {

--- a/src/server_main.cpp
+++ b/src/server_main.cpp
@@ -110,7 +110,7 @@ int main() {
   server.set_payload_max_length(static_cast<size_t>(env_int("SERVER_REQUEST_SIZE_LIMIT_MB", 4)) *
                                 1024UL * 1024UL);
 
-  projectagamemnon::register_routes(server, store, nats);
+  projectagamemnon::register_routes(server, store, nats, rate_limiter);
 
   const char* port_env = std::getenv("PORT");
   int port = 8080;

--- a/test/src/test_rate_limiter.cpp
+++ b/test/src/test_rate_limiter.cpp
@@ -1,0 +1,79 @@
+#include "projectagamemnon/rate_limiter.hpp"
+
+#include <chrono>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+namespace projectagamemnon::test {
+
+// Use high burst/rps so tests don't need long sleeps.
+static constexpr double kRps = 10.0;
+static constexpr double kBurst = 5.0;
+
+TEST(RateLimiterTest, AllowsRequestsWithinBurst) {
+  RateLimiter rl(kRps, kBurst);
+  for (int i = 0; i < static_cast<int>(kBurst); ++i) {
+    EXPECT_TRUE(rl.allow("1.2.3.4")) << "request " << i << " should be allowed";
+  }
+}
+
+TEST(RateLimiterTest, DeniesRequestsWhenBucketExhausted) {
+  RateLimiter rl(kRps, kBurst);
+  for (int i = 0; i < static_cast<int>(kBurst); ++i) {
+    rl.allow("1.2.3.4");
+  }
+  EXPECT_FALSE(rl.allow("1.2.3.4"));
+}
+
+TEST(RateLimiterTest, AllowsAgainAfterRefill) {
+  RateLimiter rl(kRps, kBurst);
+  for (int i = 0; i < static_cast<int>(kBurst); ++i) {
+    rl.allow("1.2.3.4");
+  }
+  ASSERT_FALSE(rl.allow("1.2.3.4"));
+
+  // Wait long enough for at least 1 token to refill (1/kRps seconds + margin).
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  EXPECT_TRUE(rl.allow("1.2.3.4"));
+}
+
+TEST(RateLimiterTest, DifferentIpsAreIndependent) {
+  RateLimiter rl(kRps, kBurst);
+  // Exhaust bucket for IP A.
+  for (int i = 0; i < static_cast<int>(kBurst); ++i) {
+    rl.allow("10.0.0.1");
+  }
+  ASSERT_FALSE(rl.allow("10.0.0.1"));
+
+  // IP B should still have a full bucket.
+  EXPECT_TRUE(rl.allow("10.0.0.2"));
+}
+
+TEST(RateLimiterTest, RetryAfterIsZeroWhenTokensAvailable) {
+  RateLimiter rl(kRps, kBurst);
+  EXPECT_DOUBLE_EQ(rl.retry_after_seconds("1.2.3.4"), 0.0);
+}
+
+TEST(RateLimiterTest, RetryAfterIsPositiveWhenBucketExhausted) {
+  RateLimiter rl(kRps, kBurst);
+  for (int i = 0; i < static_cast<int>(kBurst); ++i) {
+    rl.allow("1.2.3.4");
+  }
+  rl.allow("1.2.3.4");  // one over the limit to ensure exhaustion
+  double secs = rl.retry_after_seconds("1.2.3.4");
+  EXPECT_GT(secs, 0.0);
+  EXPECT_LE(secs, 1.0 / kRps + 0.1);  // should not be more than 1 token's worth
+}
+
+TEST(RateLimiterTest, NewClientHasFullBurst) {
+  RateLimiter rl(kRps, kBurst);
+  // A brand-new IP should be able to make kBurst consecutive requests.
+  int allowed = 0;
+  for (int i = 0; i < static_cast<int>(kBurst) + 2; ++i) {
+    if (rl.allow("192.168.1.1")) ++allowed;
+  }
+  EXPECT_EQ(allowed, static_cast<int>(kBurst));
+}
+
+}  // namespace projectagamemnon::test

--- a/test/src/test_routes_malformed.cpp
+++ b/test/src/test_routes_malformed.cpp
@@ -1,4 +1,5 @@
 #include "projectagamemnon/nats_client.hpp"
+#include "projectagamemnon/rate_limiter.hpp"
 #include "projectagamemnon/routes.hpp"
 #include "projectagamemnon/store.hpp"
 
@@ -19,12 +20,13 @@ class RoutesTest : public ::testing::Test {
  protected:
   Store store_;
   NatsClient nats_{"nats://127.0.0.1:4222"};  // disconnected — all publish() are no-ops
+  RateLimiter rate_limiter_{1e9, 1e9};        // effectively unlimited for tests
   httplib::Server server_;
   std::thread server_thread_;
   std::unique_ptr<httplib::Client> client_;
 
   void SetUp() override {
-    register_routes(server_, store_, nats_);
+    register_routes(server_, store_, nats_, rate_limiter_);
     int port = server_.bind_to_any_port("127.0.0.1");
     ASSERT_GT(port, 0);
     server_thread_ = std::thread([this] { server_.listen_after_bind(); });


### PR DESCRIPTION
## Summary

- Implements `RateLimiter` class (token-bucket algorithm, `include/projectagamemnon/rate_limiter.hpp` + `src/rate_limiter.cpp`) with per-IP tracking, thread-safe bucket map, and stale-entry eviction after 5 minutes
- Installed as a cpp-httplib `set_pre_routing_handler` in `register_routes()` — covers all endpoints in one place, no per-handler changes needed
- `/health` and `/v1/health` are exempt so liveness probes remain reachable under rate limiting
- Exhausted buckets return HTTP 429 with a `Retry-After` header (seconds until next token available)
- Configurable via `RATE_LIMIT_RPS` and `RATE_LIMIT_BURST` environment variables (defaults: 60 req/s, burst 120)

## Test plan

- [x] `RateLimiterTest.AllowsRequestsWithinBurst` — burst capacity is fully usable
- [x] `RateLimiterTest.DeniesRequestsWhenBucketExhausted` — returns false once bucket is empty
- [x] `RateLimiterTest.AllowsAgainAfterRefill` — tokens refill at the configured rate
- [x] `RateLimiterTest.DifferentIpsAreIndependent` — one IP exhausted does not block another
- [x] `RateLimiterTest.RetryAfterIsZeroWhenTokensAvailable` — no delay when tokens exist
- [x] `RateLimiterTest.RetryAfterIsPositiveWhenBucketExhausted` — correct delay reported
- [x] `RateLimiterTest.NewClientHasFullBurst` — fresh IPs start with full burst capacity
- [x] All 9 tests pass (`ctest --preset debug --output-on-failure`)
- [x] Server binary (`ProjectAgamemnon_server`) compiles and links cleanly

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)