### PR TITLE
docs(security): add GDPR/data privacy considerations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -241,6 +241,11 @@ Include: clear title, steps to reproduce, expected vs actual behavior, compiler/
 **Do not open public issues for security vulnerabilities.**
 See [SECURITY.md](SECURITY.md) for the responsible disclosure process.
 
+### Data & Privacy
+
+For questions about what data this service stores or requests to delete records,
+see the [Data & Privacy](SECURITY.md#data--privacy) section of SECURITY.md.
+
 ## Code of Conduct
 
 Please review our [Code of Conduct](CODE_OF_CONDUCT.md) before contributing.

--- a/README.md
+++ b/README.md
@@ -27,3 +27,9 @@ ctest --preset debug
 ## License
 
 MIT
+
+## Data & Privacy
+
+ProjectAgamemnon processes infrastructure metadata only (agent IDs, Tailscale host
+identifiers, task state). It does not collect personal data. See
+[SECURITY.md](SECURITY.md) for the full data and privacy policy.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -107,6 +107,52 @@ When you report a vulnerability:
 - Social engineering attacks
 - Physical security
 
+## Data & Privacy
+
+### What Agamemnon Processes
+
+- **Agent ownership records** — agent ID, host Tailscale IP (100.x.x.x), agent type, and
+  registration timestamp. Stored as GitHub Issues/Projects items.
+- **Task metadata** — task ID, assigned agent, state transitions, and timestamps. Stored as
+  GitHub Issues/Projects items.
+- **Host identifiers** — Tailscale 100.x.x.x addresses used transiently for peer discovery.
+  Not logged to persistent storage by default.
+- **No end-user PII** — data describes infrastructure agents, not natural persons.
+
+### GDPR Applicability
+
+As an internal mesh service operating on infrastructure metadata, ProjectAgamemnon does not
+process personal data of natural persons in the GDPR sense under normal deployment conditions.
+
+If deployed in a context where agent IDs or host records could be linked to a natural person
+(e.g., developer workstations serving as agent hosts), the **deployer** is responsible for
+compliance with applicable data protection regulations.
+
+### Data Retention
+
+- Task and agent records live as GitHub Issues/Projects items; retention follows the GitHub
+  repository's own retention and deletion settings.
+- No local disk persistence beyond build artifacts — there is no embedded database or local
+  log file containing identifiers by default.
+- Log output (stdout/stderr) may include agent IDs and host IPs; deployers should apply
+  appropriate log rotation and retention policies.
+
+### Data Deletion
+
+To remove records:
+
+- **Agent or task records** — close or delete the corresponding GitHub Issue or Project item.
+- **NATS JetStream subjects** — use the NATS CLI to delete the relevant stream
+  (`hi.tasks.>`, `hi.pipeline.>`, `hi.myrmidon.{type}.>`).
+- **Data questions** — contact <4211002+mvillmow@users.noreply.github.com>.
+
+### Data Minimization
+
+- Agamemnon stores only the identifiers necessary for orchestration. No passwords, tokens,
+  or credentials are recorded in task or agent state.
+- Tailscale IPs are used transiently for peer discovery and are not written to persistent
+  storage by default.
+
 ## Security Best Practices
 
 When contributing to ProjectAgamemnon:


### PR DESCRIPTION
## Summary

- Adds a **Data & Privacy** section to `SECURITY.md` covering what data Agamemnon processes, GDPR applicability, retention policy, deletion procedures, and data minimization posture
- Adds a pointer paragraph to `README.md` under a new **Data & Privacy** section
- Adds a **Data & Privacy** subsection to `CONTRIBUTING.md` under **Reporting Issues**

## Changes

All changes are documentation-only — no executable code modified.

**`SECURITY.md`** (primary): new `## Data & Privacy` section between `## Scope` and `## Security Best Practices` documenting:
- What data is processed (agent IDs, Tailscale IPs, task metadata) — no end-user PII
- GDPR applicability (deployer responsibility when agent IDs could link to a person)
- Data retention (GitHub Issues/Projects; no local persistence by default)
- Data deletion instructions (GitHub items + NATS CLI)
- Data minimization posture

**`README.md`**: short pointer section after `## License`

**`CONTRIBUTING.md`**: `### Data & Privacy` subsection under `## Reporting Issues`

## Test plan

- [x] `pixi run pre-commit run --all-files` passes (trim whitespace, end-of-file, yaml, json, merge conflicts, clang-format)
- [x] `npx markdownlint-cli2 SECURITY.md README.md CONTRIBUTING.md` → 0 errors (matches `.markdownlint.yaml` config used in CI)
- [x] SECURITY.md anchor `#data--privacy` verified correct (GitHub lowercases, strips `&`, keeps `--` for ` & `)

Closes #84
Part of #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)