### PR TITLE
chore(ci): remove silent-failure workarounds; add regression guard

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -175,6 +175,59 @@ jobs:
       - name: Run symlink check
         run: bash scripts/check-symlinks.sh
 
+  forbid-suppressions:
+    name: forbid-suppressions
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: "Reject silent-failure workaround in shell/YAML/Dockerfile/justfile/HCL"
+        run: |
+          # Scans ProjectAgamemnon sources. Matches the forbidden idiom at end
+          # of line or before a trailing comment. See
+          # HomericIntelligence/Odysseus#280.
+          set -euo pipefail
+          mapfile -t files < <(git ls-files \
+            -- \
+            '*.sh' '*.bash' '*.yml' '*.yaml' '*.hcl' \
+            'Dockerfile*' '**/Dockerfile*' \
+            'justfile' '**/justfile' 'Justfile' '**/Justfile')
+          # Skip this workflow file itself (heredoc would otherwise self-match).
+          declare -a scan_files=()
+          for f in "${files[@]}"; do
+            case "$f" in
+              .github/workflows/_required.yml) continue ;;
+            esac
+            scan_files+=("$f")
+          done
+          if [ "${#scan_files[@]}" -eq 0 ]; then
+            echo "No files to scan"
+            exit 0
+          fi
+          if grep -nE '\|\|[[:space:]]*true([[:space:]]*$|[[:space:]]+#)' "${scan_files[@]}"; then
+            echo ""
+            echo '::error::Found silent-failure workarounds above. Refactor per HomericIntelligence/Odysseus#280.'
+            exit 1
+          fi
+          echo 'OK: no silent-failure workarounds found'
+
+      - name: "Reject continue-on-error workflow opt-out"
+        run: |
+          set -euo pipefail
+          mapfile -t files < <(git ls-files -- '.github/workflows/*.yml' '.github/workflows/*.yaml')
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "No workflow files"
+            exit 0
+          fi
+          if grep -nE '^[[:space:]]*continue-on-error:[[:space:]]*true[[:space:]]*$' "${files[@]}"; then
+            echo ""
+            echo '::error::Found continue-on-error true above; fix root cause.'
+            echo '::error::See HomericIntelligence/Odysseus#280.'
+            exit 1
+          fi
+          echo 'OK: no "continue-on-error: true" found'
+
   # ── 2. unit-tests ──────────────────────────────────────────────────────────
   unit-tests:
     name: unit-tests

--- a/.github/workflows/python-client.yml
+++ b/.github/workflows/python-client.yml
@@ -41,17 +41,32 @@ jobs:
 
       - name: Track deprecated KEYSTONE_* env var names
         run: |
-          count=$(grep -rn --include="*.py" \
+          # Bucket D: capture once into a variable so the no-match exit code
+          # from grep does not poison the run under set -e/pipefail. `grep`
+          # without -q exits 0 (match), 1 (no match), or >1 (error); we treat
+          # 0/1 as "ran successfully" and surface anything else.
+          set +e
+          set -uo pipefail
+          raw=$(grep -rn --include="*.py" \
             "KEYSTONE_LOG_LEVEL\|KEYSTONE_POLL_INTERVAL\|KEYSTONE_SHUTDOWN_TIMEOUT" \
-            clients/python/src \
-            | grep -v '^\s*#' \
-            | wc -l)
-          if [ "$count" -gt 0 ]; then
+            clients/python/src)
+          rc=$?
+          if [ "$rc" -gt 1 ]; then
+            echo "::error::grep failed with exit code $rc"
+            exit "$rc"
+          fi
+          # Filter out comment-only lines.
+          filtered=$(printf '%s\n' "$raw" | grep -v '^\s*#')
+          frc=$?
+          if [ "$frc" -gt 1 ]; then
+            echo "::error::grep -v failed with exit code $frc"
+            exit "$frc"
+          fi
+          set -e
+          if [ -n "$filtered" ]; then
+            count=$(printf '%s\n' "$filtered" | wc -l)
             echo "::warning::Found $count reference(s) to deprecated KEYSTONE_* env vars in src/ - should be 0 before shim removal"
-            grep -rn --include="*.py" \
-              "KEYSTONE_LOG_LEVEL\|KEYSTONE_POLL_INTERVAL\|KEYSTONE_SHUTDOWN_TIMEOUT" \
-              clients/python/src \
-              | grep -v '^\s*#' || true
+            printf '%s\n' "$filtered"
           else
             echo "PASSED: No deprecated KEYSTONE_* references found in src/"
           fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,3 +35,26 @@ repos:
         entry: scripts/validate-openapi.sh
         files: ^docs/api/openapi\.yaml$
         pass_filenames: false
+
+      - id: forbid-or-true
+        name: "forbid silent-failure workaround in shell/YAML/Dockerfile/justfile/HCL"
+        description: >
+          Rejects the `or-true` idiom (and its whitespace variants) in shell,
+          YAML, Dockerfile, justfile, and HCL sources. Refactor to an explicit
+          `if`-guard, a real conditional, or a documented `set +e`/`set -e`
+          bracket. See HomericIntelligence/Odysseus#280.
+        language: pygrep
+        entry: '\|\|\s*true(\s*$|\s+#)'
+        files: \.(sh|bash|yml|yaml|hcl)$|(^|/)Dockerfile[^/]*$|(^|/)[Jj]ustfile$
+        types: [text]
+        pass_filenames: true
+
+      - id: forbid-continue-on-error
+        name: "forbid continue-on-error workflow opt-out"
+        description: >
+          GitHub Actions `continue-on-error true` (truthy form) hides real CI
+          failures. Fix the underlying job/step instead.
+        language: pygrep
+        entry: '^\s*continue-on-error:\s*true\s*$'
+        files: ^\.github/workflows/.*\.ya?ml$
+        pass_filenames: true

--- a/scripts/check-release-readiness.sh
+++ b/scripts/check-release-readiness.sh
@@ -27,18 +27,43 @@ else
 fi
 
 # 2. GitHub pypi environment exists with tag policy
-ENV_JSON=$(gh api "repos/${REPO}/environments/${ENV_NAME}" 2>/dev/null || true)
+# Bucket A: keep the "missing environment is a graceful FAIL not a crash" semantic,
+# but distinguish a 404 (environment absent) from a transport/auth error that
+# would otherwise be silently swallowed by `|| true`.
+ENV_JSON=""
+if env_out=$(gh api "repos/${REPO}/environments/${ENV_NAME}" 2>&1); then
+    ENV_JSON="$env_out"
+elif printf '%s' "$env_out" | grep -q "HTTP 404"; then
+    ENV_JSON=""
+else
+    fail "gh api '${ENV_NAME}' failed unexpectedly: ${env_out}"
+    ENV_JSON=""
+fi
 if [[ -z "$ENV_JSON" ]]; then
     fail "GitHub environment '${ENV_NAME}' does not exist — create it under repo Settings → Environments"
 else
     ok "GitHub environment '${ENV_NAME}' exists"
-    POLICY_JSON=$(gh api "repos/${REPO}/environments/${ENV_NAME}/deployment-branch-policies" 2>/dev/null || true)
-    TAG_POLICY=$(echo "$POLICY_JSON" | python3 -c "
+    POLICY_JSON=""
+    if pol_out=$(gh api "repos/${REPO}/environments/${ENV_NAME}/deployment-branch-policies" 2>&1); then
+        POLICY_JSON="$pol_out"
+    elif printf '%s' "$pol_out" | grep -q "HTTP 404"; then
+        POLICY_JSON=""
+    else
+        fail "gh api deployment-branch-policies failed unexpectedly: ${pol_out}"
+    fi
+    TAG_POLICY=""
+    if [[ -n "$POLICY_JSON" ]]; then
+        if parsed=$(echo "$POLICY_JSON" | python3 -c "
 import sys, json
 d = json.load(sys.stdin)
 tags = [p for p in d.get('branch_policies', []) if p.get('type') == 'tag']
 print(tags[0]['name'] if tags else '')
-" 2>/dev/null || true)
+" 2>&1); then
+            TAG_POLICY="$parsed"
+        else
+            fail "Failed to parse deployment-branch-policies JSON: ${parsed}"
+        fi
+    fi
     if [[ "$TAG_POLICY" == "$TAG_PATTERN" ]]; then
         ok "  Tag deployment policy '${TAG_PATTERN}' is set"
     else

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -4,8 +4,16 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
-# Configure first to get compile_commands.json
-cmake --preset debug -DProjectAgamemnon_ENABLE_CLANG_TIDY=OFF >/dev/null 2>&1 || true
+# Configure first to get compile_commands.json. If the build directory is
+# already configured, cmake will succeed; if not, we want the configure to
+# attempt and report failure rather than be silently swallowed. Bucket A.
+if ! cmake --preset debug -DProjectAgamemnon_ENABLE_CLANG_TIDY=OFF >/dev/null 2>&1; then
+  echo "warn: cmake --preset debug configure failed; proceeding with existing build/debug if present" >&2
+fi
+if [ ! -f "${ROOT_DIR}/build/debug/compile_commands.json" ]; then
+  echo "error: build/debug/compile_commands.json not found; cannot run clang-tidy" >&2
+  exit 1
+fi
 
 find "${ROOT_DIR}/include" "${ROOT_DIR}/src" "${ROOT_DIR}/test" \
   -name "*.cpp" -o -name "*.hpp" | \


### PR DESCRIPTION
## Summary

Removes every ``|| true`` suppression from this repo and adds a regression
guard so they cannot return. Mirrors HomericIntelligence/Odysseus#280.

- New CI job ``forbid-suppressions`` in ``.github/workflows/_required.yml``
  that fails the PR if any ``|| true`` (end-of-line/comment variants) or
  ``continue-on-error: true`` reappears.
- Two new pygrep pre-commit hooks (``forbid-or-true``,
  ``forbid-continue-on-error``) added to the existing ``local`` repo block
  in ``.pre-commit-config.yaml``.

## Refactors

| File | Line(s) | Bucket | Notes |
|------|--------|--------|-------|
| ``scripts/lint.sh`` | 8 | A | cmake configure failure was silently swallowed; now warns and aborts if ``compile_commands.json`` is absent. |
| ``scripts/check-release-readiness.sh`` | 30, 35, 41 | A | ``gh api`` failures were indistinguishable from a legitimate 404; JSON parse errors were hidden. Now distinguishes HTTP 404 from transport/auth/parse errors and surfaces the latter via ``fail``. |
| ``.github/workflows/python-client.yml`` | 54 | D | ``grep \| grep -v`` pipefail trap replaced with explicit capture into a variable and ``$?`` exit-code probing (rc 0/1 acceptable, rc>1 fails the step). |

## Verification

- ``pre-commit run --files <changed files>``: all new hooks pass; only
  the pre-existing ``validate-openapi`` hook fails (broken on main,
  unrelated to this PR — confirmed by running it against ``main``).
- ``bash -n`` on every modified ``.sh``: OK.
- ``python3 -c 'yaml.safe_load(...)'`` on every modified workflow / YAML:
  OK.
- Repo-wide ``grep -nE '\|\|[[:space:]]*true([[:space:]]*$\|[[:space:]]+#)'``
  on tracked sources: zero matches.

## Test plan

- [ ] CI ``forbid-suppressions`` job passes (this PR adds it).
- [ ] CI ``lint``, ``unit-tests``, ``integration-tests``, ``build`` jobs all green.
- [ ] Pre-commit hook ``forbid-or-true`` rejects a deliberate regression locally.

Reference: HomericIntelligence/Odysseus#280

Generated with [Claude Code](https://claude.com/claude-code)