### PR TITLE
fix(api): route /tasks/:id/complete through TaskStateMachine (#158)

### DIFF
--- a/src/orchestrator.cpp
+++ b/src/orchestrator.cpp
@@ -106,9 +106,36 @@ void Orchestrator::on_myrmidon_completion(const std::string& subject, const std:
       return;
     }
 
-    // L3 tasks go InProgress → Completed.
-    // Higher-layer tasks also resolve when myrmidon reports done.
-    if (task->state == TaskState::Delegated) state_machine_.try_transition(*task, TaskEvent::Start);
+    // Drive the task through every transition required to reach InProgress before
+    // attempting Complete.  A myrmidon may report completion faster than the
+    // orchestrator's intermediate transitions (Submit/Delegate/Start) were applied,
+    // so we walk the state machine here instead of assuming a single starting state.
+    //
+    // Path from any non-terminal state to InProgress:
+    //   Pending     -> (Delegate)  -> Delegated   [L3 leaves only; guard rejects others]
+    //   Pending     -> (Submit)    -> Decomposing -> (Delegate) -> Delegated
+    //   Decomposing -> (Delegate)  -> Delegated
+    //   Delegated   -> (Start)     -> InProgress
+    //   Escalated   -> (Retry)     -> Delegated   -> (Start) -> InProgress
+    //
+    // Each try_transition is a no-op when the event is not valid for the current
+    // state, so the chained calls below safely advance the task toward InProgress
+    // without ever moving past it, and Complete is only applied from InProgress.
+    if (task->state == TaskState::Escalated) {
+      state_machine_.try_transition(*task, TaskEvent::Retry);
+    }
+    if (task->state == TaskState::Pending) {
+      // L3 leaves go straight Pending -> Delegated; others must Submit first.
+      if (!state_machine_.try_transition(*task, TaskEvent::Delegate)) {
+        state_machine_.try_transition(*task, TaskEvent::Submit);
+      }
+    }
+    if (task->state == TaskState::Decomposing) {
+      state_machine_.try_transition(*task, TaskEvent::Delegate);
+    }
+    if (task->state == TaskState::Delegated) {
+      state_machine_.try_transition(*task, TaskEvent::Start);
+    }
     state_machine_.try_transition(*task, TaskEvent::Complete);
     store_.update_hmas_task(*task);
 

--- a/test/src/test_routes.cpp
+++ b/test/src/test_routes.cpp
@@ -520,6 +520,57 @@ TEST_F(RoutesHappyPathTest, CompleteTaskSuccess) {
   auto body = json::parse(res->body);
   EXPECT_EQ(body["task_id"], task_id);
   EXPECT_TRUE(body["completed"].get<bool>());
+
+  // Regression guard for #158: the /complete route must actually advance the
+  // task through the state machine to Completed — not leave it stranded in an
+  // earlier state.
+  auto state = Get("/v1/tasks/" + task_id + "/state");
+  ASSERT_TRUE(state);
+  ASSERT_EQ(state->status, 200);
+  EXPECT_EQ(json::parse(state->body)["state"], "Completed");
+}
+
+// Regression test for #158: a myrmidon may report completion before the
+// orchestrator has been able to Start the task.  In that race the task is
+// still in Pending (or Delegated) when /complete fires, and the old code only
+// handled the Delegated case — leaving Pending tasks stuck.  The fix must
+// drive the task through the TaskStateMachine to Completed regardless of
+// which valid non-terminal state it started in.
+TEST_F(RoutesHappyPathTest, CompleteTaskFromPendingReachesCompleted) {
+  auto create = Post("/v1/briefs", {{"title", "race brief"},
+                                    {"repos", json::array({"repo-r"})},
+                                    {"modules", json::object({{"repo-r", json::array({"mod"})}})}});
+  ASSERT_TRUE(create);
+  ASSERT_EQ(create->status, 201);
+  auto plan = json::parse(create->body);
+
+  // Pick the L3 leaf — planning_breakdown creates it in TaskState::Pending and
+  // submit() only Delegates the L0 root, so this task is genuinely Pending.
+  std::string leaf_id;
+  for (const auto& t : plan["tasks"]) {
+    if (t["layer"] == "L3_TaskAgent") {
+      leaf_id = t["id"];
+      break;
+    }
+  }
+  ASSERT_FALSE(leaf_id.empty()) << "expected an L3 leaf task in the plan";
+
+  // Sanity check: leaf starts in Pending.
+  auto before = Get("/v1/tasks/" + leaf_id + "/state");
+  ASSERT_TRUE(before);
+  ASSERT_EQ(before->status, 200);
+  EXPECT_EQ(json::parse(before->body)["state"], "Pending");
+
+  auto res = Post("/v1/tasks/" + leaf_id + "/complete", json::object());
+  ASSERT_TRUE(res);
+  ASSERT_EQ(res->status, 200);
+
+  auto after = Get("/v1/tasks/" + leaf_id + "/state");
+  ASSERT_TRUE(after);
+  ASSERT_EQ(after->status, 200);
+  EXPECT_EQ(json::parse(after->body)["state"], "Completed")
+      << "POST /v1/tasks/:id/complete must drive Pending tasks through the "
+         "TaskStateMachine to Completed (#158)";
 }
 
 }  // namespace projectagamemnon::test


### PR DESCRIPTION
## Summary
- `POST /v1/tasks/:id/complete` previously only advanced `Delegated → InProgress` before calling `Complete`, so a fast myrmidon callback against a task still in `Pending`/`Decomposing`/`Escalated` was rejected by `TaskStateMachine` and left the task stuck.
- `Orchestrator::on_myrmidon_completion` now walks the task through every transition required to reach `InProgress` (`Retry` ← Escalated, `Submit`/`Delegate` ← Pending, `Delegate` ← Decomposing, `Start` ← Delegated) before attempting `Complete`. Every step uses `state_machine_.try_transition`, so terminal states are never bypassed.
- Closes #158.

## Test plan
- [x] New `RoutesHappyPathTest.CompleteTaskFromPendingReachesCompleted`: submits a brief, picks the L3 leaf (created in `Pending`), POSTs `/complete`, and asserts `GET /v1/tasks/:id/state` returns `Completed`. Fails on `main`, passes here.
- [x] Existing `RoutesHappyPathTest.CompleteTaskSuccess` strengthened to assert final state is `Completed` (was only checking the response body, which would have masked the bug).
- [x] No changes to the state machine itself — purely additive transition driving inside the orchestrator. Existing `test_orchestrator.cpp` cases continue to apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)