### PR TITLE
docs(api): add servers entry to OpenAPI spec (#146)

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -20,6 +20,18 @@ info:
 servers:
   - url: http://localhost:8080
     description: Local development (default port; override with PORT env var)
+  - url: http://{tailscaleHost}:{port}
+    description: |
+      Production / mesh access over Tailscale. Requires the caller to be
+      authenticated to the same tailnet. `tailscaleHost` is either the peer's
+      Tailscale IPv4 address (`100.x.y.z`) or its MagicDNS name.
+    variables:
+      tailscaleHost:
+        default: 100.64.0.1
+        description: Tailscale IPv4 (100.x.y.z) or MagicDNS hostname of the Agamemnon peer
+      port:
+        default: "8080"
+        description: Port Agamemnon is listening on (PORT env var; default 8080)
 
 tags:
   - name: health


### PR DESCRIPTION
## Summary
- Adds a second `servers:` entry to `docs/api/openapi.yaml` documenting Tailscale-based production/mesh access.
- Uses OpenAPI 3.x server variables (`tailscaleHost`, `port`) so integrators can substitute either a `100.x.y.z` IPv4 or a MagicDNS name plus a custom port.
- Keeps the existing localhost entry as the default for local development.

Closes #146

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('docs/api/openapi.yaml'))"` — spec parses cleanly
- [ ] CI: pre-commit + OpenAPI validation jobs pass

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with Claude Code