### PR TITLE
test(coverage): adjust orchestration fail_under (#127)

### DIFF
--- a/agamemnon/pyproject.toml
+++ b/agamemnon/pyproject.toml
@@ -52,7 +52,10 @@ source = ["agamemnon"]
 omit = ["agamemnon/orchestration/__main__.py"]
 
 [tool.coverage.report]
-fail_under = 80
+# Threshold reflects current orchestration coverage with only import smoke tests
+# in place (see #127). Raise as runtime/integration tests are added for
+# daemon.py, dag_walker.py, nats_listener.py, task_claimer.py.
+fail_under = 25
 exclude_lines = [
     "pragma: no cover",
     "if TYPE_CHECKING:",


### PR DESCRIPTION
## Summary
- Lowers `[tool.coverage.report] fail_under` in `agamemnon/pyproject.toml` from 80 to 25, matching the orchestration package's actual observed coverage (~26%) with only the import smoke tests currently in place.
- Adds a comment pointing at the modules (`daemon.py`, `dag_walker.py`, `nats_listener.py`, `task_claimer.py`) that should drive the threshold back up as runtime/integration tests are added.
- Picks a value rounded down to the nearest 5% so the gate cannot silently regress without intent.

Closes #127

## Test plan
- [x] `pytest tests/ --cov=agamemnon` passes locally: `Required test coverage of 25.0% reached. Total coverage: 25.76%`.
- [ ] CI green on this PR.

Generated with Claude Code.