### PR TITLE
chore(lint): enforce markdownlint table-header rules (#141)

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -20,3 +20,11 @@ MD041: false
 
 MD046:
   style: fenced
+
+# Table rules (issue #141): explicitly enforce table formatting so header
+# separators, pipe style, and column counts are validated in CI rather than
+# relying on markdownlint's default ruleset.
+MD055:
+  style: leading_and_trailing  # Require leading and trailing pipes on every row (forces a clear header separator)
+MD056: true                    # table-column-count: every row must have the same column count as the header
+MD058: true                    # blanks-around-tables: tables must be surrounded by blank lines


### PR DESCRIPTION
## Summary

Explicitly enables markdownlint table-formatting rules in `.markdownlint.yaml` so table header separators, pipe style, and column counts are validated by CI:

- `MD055: { style: leading_and_trailing }` — every table row must have leading + trailing pipes, forcing a clear header separator
- `MD056: true` — table-column-count consistency
- `MD058: true` — blanks-around-tables

Previously these were covered only via `default: true`. Per issue #141, explicit configuration is preferred so the rule audit on README/RELEASING/AGENTS tables is intentional rather than implicit.

Closes #141

## Test plan

- [x] `npx markdownlint-cli2@0.18.1 "**/*.md" --config .markdownlint.yaml` reports 0 errors on 16 files (this is the version pinned by `DavidAnson/markdownlint-cli2-action@v20.0.0` used in CI)
- [x] README.md, RELEASING.md, AGENTS.md tables all pass with the new explicit rules
- [ ] CI markdownlint job green on this PR