### PR TITLE
chore(deps): pin python <3.14 in agamemnon/pixi.toml (#109)

### DIFF
--- a/agamemnon/pixi.toml
+++ b/agamemnon/pixi.toml
@@ -6,7 +6,7 @@ channels = ["conda-forge"]
 platforms = ["linux-64", "osx-arm64", "osx-64"]
 
 [dependencies]
-python = ">=3.11,<4"
+python = ">=3.11,<3.14"
 
 [pypi-dependencies]
 "HomericIntelligence-Agamemnon-Orchestration" = { path = ".", editable = true }


### PR DESCRIPTION
## Summary
- Pin `python` to `>=3.11,<3.14` in `agamemnon/pixi.toml` so pixi resolves Python 3.13 instead of 3.14
- Eliminates the pytest-asyncio `DeprecationWarning` for `asyncio.get_event_loop_policy` (slated for removal in 3.16)
- No `agamemnon/pixi.lock` exists in the repo, so no lockfile regeneration is required

Closes #109

## Test plan
- [ ] CI green on the PR
- [ ] Once a pytest-asyncio release supports Python 3.14, the upper bound can be relaxed in a follow-up

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>