### PR TITLE
docs: env var migration guide (#118)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,16 @@ NATS_URL=nats://localhost:4222 PORT=8080 ./build/debug/ProjectAgamemnon_server
 |---|---|---|
 | `NATS_URL` | `nats://localhost:4222` | NATS server connection URL |
 | `PORT` | `8080` | TCP port the HTTP server listens on |
+| `AGAMEMNON_LOG_LEVEL` | `INFO` | Orchestration daemon logging verbosity |
+| `AGAMEMNON_POLL_INTERVAL` | `1.0` | Orchestration daemon routing-loop poll interval (seconds) |
+| `AGAMEMNON_SHUTDOWN_TIMEOUT` | `30.0` | Orchestration daemon graceful-shutdown wait (seconds) |
+
+> **Upgrading from ProjectKeystone?** The `KEYSTONE_LOG_LEVEL`,
+> `KEYSTONE_POLL_INTERVAL`, and `KEYSTONE_SHUTDOWN_TIMEOUT` variables were
+> renamed to their `AGAMEMNON_*` equivalents. Setting the legacy names against
+> the server-side daemon is a silent no-op. See
+> [docs/migration-from-keystone.md](docs/migration-from-keystone.md) for the
+> full rename table and remediation steps.
 
 ## API Endpoints
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,5 +1,13 @@
 # Releasing
 
+> **Operator note:** When releasing a version that drops the legacy
+> `KEYSTONE_*` deprecation shim from `agamemnon_client.config`, call this out
+> explicitly in the release notes and link
+> [docs/migration-from-keystone.md](docs/migration-from-keystone.md). The
+> server-side daemon (`agamemnon.orchestration.config`) has never accepted the
+> legacy names — operators who skipped the rename will see silent default
+> regressions unless they read the migration guide.
+
 ## Python Client (`HomericIntelligence-Agamemnon`)
 
 Releases are triggered by pushing a `v*` tag (e.g. `v0.1.0`). The

--- a/agamemnon/orchestration/daemon.py
+++ b/agamemnon/orchestration/daemon.py
@@ -103,7 +103,7 @@ def main(argv: list[str] | None = None) -> int:
         "--log-level",
         default=None,
         choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
-        help="Logging verbosity level (default: from KEYSTONE_LOG_LEVEL env var or INFO)",
+        help="Logging verbosity level (default: from AGAMEMNON_LOG_LEVEL env var or INFO)",
     )
     parser.add_argument(
         "--poll-interval",

--- a/docs/migration-from-keystone.md
+++ b/docs/migration-from-keystone.md
@@ -1,0 +1,139 @@
+# Migration Guide: `KEYSTONE_*` → `AGAMEMNON_*` Environment Variables
+
+ProjectAgamemnon was originally developed under the name **ProjectKeystone**.
+During the rename, the orchestration daemon's runtime configuration variables
+were renamed from `KEYSTONE_*` to `AGAMEMNON_*`. Deployments or `.env` files
+that still set the old names will **silently fall back to defaults** in the
+server-side daemon, which can mask production misconfiguration.
+
+This document lists every renamed variable, describes the current behaviour of
+each consumer, and gives copy-paste-ready remediation steps.
+
+## Rename Table
+
+| Old name (`KEYSTONE_*`) | New name (`AGAMEMNON_*`) | Default | Consumed by |
+|---|---|---|---|
+| `KEYSTONE_LOG_LEVEL` | `AGAMEMNON_LOG_LEVEL` | `INFO` | `agamemnon.orchestration.config.Settings`, `agamemnon_client.config.Settings` |
+| `KEYSTONE_POLL_INTERVAL` | `AGAMEMNON_POLL_INTERVAL` | `1.0` (seconds) | `agamemnon.orchestration.config.Settings`, `agamemnon_client.config.Settings` |
+| `KEYSTONE_SHUTDOWN_TIMEOUT` | `AGAMEMNON_SHUTDOWN_TIMEOUT` | `30.0` (seconds) | `agamemnon.orchestration.config.Settings`, `agamemnon_client.config.Settings` |
+
+## Behaviour by Consumer
+
+There are two independent configuration loaders in this repository. They have
+different fallback behaviour for the legacy names — operators must update
+**both** sides:
+
+### 1. Server-side daemon (`agamemnon.orchestration.config`)
+
+The orchestration daemon shipped inside ProjectAgamemnon **only** reads the
+new `AGAMEMNON_*` names. Setting `KEYSTONE_LOG_LEVEL=DEBUG` against this
+daemon is a no-op — the daemon will silently use the `INFO` default.
+
+```python
+# agamemnon/orchestration/config.py
+log_level: str = field(
+    default_factory=lambda: os.environ.get("AGAMEMNON_LOG_LEVEL", "INFO")
+)
+```
+
+### 2. Python client library (`agamemnon_client.config`)
+
+The published `HomericIntelligence-Agamemnon` Python client includes a
+compatibility shim. If only the legacy variable is set, the client will read
+it and emit a `DeprecationWarning`:
+
+```python
+# clients/python/src/agamemnon_client/config.py
+def _get_with_fallback(new_name: str, old_name: str, default: str) -> str:
+    if new_name in os.environ:
+        return os.environ[new_name]
+    if old_name in os.environ:
+        warnings.warn(
+            f"{old_name} is deprecated; use {new_name} instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return os.environ[old_name]
+    return default
+```
+
+The shim is provided for end-user convenience while consumers migrate. It
+will be removed in a future release; do **not** rely on it for new
+deployments.
+
+## Remediation
+
+### Step 1 — Audit your deployment
+
+Search every `.env` file, systemd unit, Docker Compose override, Kubernetes
+manifest, and Ansible role for the legacy prefix:
+
+```bash
+grep -RIn 'KEYSTONE_' \
+    .env* \
+    /etc/agamemnon/ \
+    deploy/ \
+    k8s/ \
+    ansible/ \
+    docker-compose*.yml \
+    2>/dev/null
+```
+
+### Step 2 — Rename in place
+
+Replace each occurrence with the new name. The values themselves do not
+change — only the variable names.
+
+```bash
+# .env (before)
+KEYSTONE_LOG_LEVEL=DEBUG
+KEYSTONE_POLL_INTERVAL=0.5
+KEYSTONE_SHUTDOWN_TIMEOUT=60
+
+# .env (after)
+AGAMEMNON_LOG_LEVEL=DEBUG
+AGAMEMNON_POLL_INTERVAL=0.5
+AGAMEMNON_SHUTDOWN_TIMEOUT=60
+```
+
+For docker-compose:
+
+```yaml
+services:
+  agamemnon:
+    environment:
+      AGAMEMNON_LOG_LEVEL: DEBUG
+      AGAMEMNON_POLL_INTERVAL: "0.5"
+      AGAMEMNON_SHUTDOWN_TIMEOUT: "60"
+```
+
+### Step 3 — Verify after deploy
+
+After restarting the daemon, confirm the new values are in effect. The Python
+client surfaces a `DeprecationWarning` if it picked up a legacy name — treat
+those warnings as actionable findings, not noise:
+
+```python
+import warnings
+warnings.simplefilter("error", DeprecationWarning)  # fail fast in tests
+from agamemnon_client.config import load_settings
+load_settings()
+```
+
+For the server-side daemon, check the structured logs at startup and confirm
+the effective `log_level` matches what you intended.
+
+## Why This Matters
+
+The original rename PR (#26) did not include a deprecation shim on the
+server side or a migration note. Issue #118 was filed to close that gap.
+Without this guide, operators upgrading across the rename boundary will see
+their explicit log-level / poll-interval / shutdown-timeout overrides
+silently revert to defaults — a classic silent-failure regression.
+
+## See Also
+
+- Issue [#118](https://github.com/HomericIntelligence/ProjectAgamemnon/issues/118) — the tracking issue for this guide
+- Issue [#26](https://github.com/HomericIntelligence/ProjectAgamemnon/issues/26) — the original Keystone → Agamemnon rename
+- [README.md](../README.md#environment-variables) — full environment variable reference
+- [RELEASING.md](../RELEASING.md) — release cadence for the Python client (where the shim lives)


### PR DESCRIPTION
## Summary

- Adds `docs/migration-from-keystone.md` documenting the `KEYSTONE_*` -> `AGAMEMNON_*` env var rename with a rename table, per-consumer behaviour notes (server-side daemon vs. client shim), and step-by-step remediation
- Surfaces the orchestration daemon env vars (`AGAMEMNON_LOG_LEVEL`, `AGAMEMNON_POLL_INTERVAL`, `AGAMEMNON_SHUTDOWN_TIMEOUT`) in `README.md`'s Environment Variables table and links the migration guide
- Cross-links the migration guide from `RELEASING.md` so the shim-removal timeline is operator-visible
- Fixes a stale `--log-level` help string in `agamemnon/orchestration/daemon.py` that still referenced the old `KEYSTONE_LOG_LEVEL` name

This is option (A) from the issue (the documentation route) — a shim already exists in `clients/python/src/agamemnon_client/config.py` for client consumers; the guide makes the asymmetry between client and server-side behaviour explicit so operators don't get bitten by silent default regressions on the server.

Closes #118

## Test plan

- [ ] CI: markdownlint passes on the new doc and README/RELEASING edits
- [ ] CI: existing pytest suite still green (no behavioural changes to config loaders)
- [ ] Manual: links from README and RELEASING resolve to `docs/migration-from-keystone.md`

Generated with [Claude Code](https://claude.com/claude-code)