### PR TITLE
fix(release): handle missing GPG key gracefully (#103)

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -38,6 +38,23 @@ Register the OIDC publisher at <https://pypi.org/manage/account/publishing/>
 These five values must match the workflow file exactly or the OIDC exchange
 will be rejected.
 
+#### 3. GPG signing key
+
+`just release` runs `git commit -S` and `git tag -s`, both of which require a
+usable GPG secret key. The readiness check verifies a key is present *before*
+any files are mutated.
+
+```bash
+# Verify you have a secret key:
+gpg --list-secret-keys
+
+# If none, generate one (or import an existing key) and tell git to use it:
+gpg --full-generate-key
+git config --global user.signingkey <KEYID>
+git config --global commit.gpgsign true
+git config --global tag.gpgsign true
+```
+
 ### Cutting a release
 
 ```bash

--- a/scripts/check-release-readiness.sh
+++ b/scripts/check-release-readiness.sh
@@ -19,6 +19,20 @@ warn() { printf '\033[33m[WARN]\033[0m %s\n' "$1"; }
 
 FAILED=0
 
+# 0. GPG signing key is available
+# `just release` runs `git commit -S` and `git tag -s`, both of which require a
+# usable GPG secret key. If none is configured, those commands fail with an
+# opaque "gpg failed to sign the data" error *after* bump-version.py has
+# already mutated pyproject.toml — leaving the working tree dirty. Detect the
+# missing key here so the user gets an actionable error before any mutation.
+if ! command -v gpg >/dev/null 2>&1; then
+    fail "gpg is not installed — install GnuPG (e.g. 'apt install gnupg' or 'brew install gnupg') and configure a signing key; see RELEASING.md"
+elif ! gpg --list-secret-keys --with-colons 2>/dev/null | grep -q '^sec:'; then
+    fail "No GPG secret key found — 'just release' uses 'git commit -S' and 'git tag -s'; generate or import a signing key and run 'git config --global user.signingkey <KEYID>'; see RELEASING.md"
+else
+    ok "GPG secret key is available for signing"
+fi
+
 # 1. Workflow file exists on main
 if git show "origin/main:.github/workflows/${WORKFLOW}" &>/dev/null; then
     ok "Workflow '${WORKFLOW}' is present on main"


### PR DESCRIPTION
## Summary

- `just release` calls `git commit -S` and `git tag -s`, which fail with an opaque "gpg failed to sign the data" error if no GPG secret key is configured — but only *after* `bump-version.py` has already mutated `clients/python/pyproject.toml`, leaving a dirty working tree the user has to clean up by hand.
- Add a GPG key presence check at the top of `scripts/check-release-readiness.sh` so the user gets an actionable error *before* any files are mutated.
- Document the GPG signing key as a release prerequisite in `RELEASING.md`.

## Behaviour

The new check runs first (numbered `# 0.`) and reports one of three outcomes:

| Condition | Result |
|---|---|
| `gpg` not on PATH | `[FAIL]` with install instructions, abort before mutation |
| `gpg` present, no secret key (`gpg --list-secret-keys --with-colons` has no `sec:` line) | `[FAIL]` with `gpg --full-generate-key` / `git config user.signingkey` instructions |
| Secret key present | `[OK] GPG secret key is available for signing` |

No `\|\| true`, no `--no-verify`, no `continue-on-error`.

Closes #103

## Test plan
- [x] `bash -n scripts/check-release-readiness.sh` passes
- [x] Local smoke test: GPG section reports OK first in environments with a key configured
- [ ] CI green on this PR