### PR TITLE
feat(config): validate AGAMEMNON_LOG_LEVEL values (#132)

### DIFF
--- a/agamemnon/orchestration/config.py
+++ b/agamemnon/orchestration/config.py
@@ -5,6 +5,31 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass, field
 
+VALID_LOG_LEVELS: tuple[str, ...] = ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL")
+
+
+def _validate_log_level(value: str) -> str:
+    """Normalize and validate a log level string.
+
+    Accepts the standard Python logging level names case-insensitively
+    and returns the canonical uppercase form. Raises ``ValueError`` with
+    a clear message listing accepted values for any other input so that
+    misconfiguration fails loudly at startup rather than silently falling
+    back to ``WARNING`` inside ``logging.basicConfig``.
+    """
+    if not isinstance(value, str):
+        raise ValueError(
+            f"AGAMEMNON_LOG_LEVEL must be a string, got {type(value).__name__}. "
+            f"Accepted values: {', '.join(VALID_LOG_LEVELS)}."
+        )
+    normalized = value.strip().upper()
+    if normalized not in VALID_LOG_LEVELS:
+        raise ValueError(
+            f"Invalid log level {value!r}. "
+            f"Accepted values: {', '.join(VALID_LOG_LEVELS)}."
+        )
+    return normalized
+
 
 @dataclass
 class Settings:
@@ -20,6 +45,14 @@ class Settings:
     shutdown_timeout: float = field(
         default_factory=lambda: float(os.environ.get("AGAMEMNON_SHUTDOWN_TIMEOUT", "30.0"))
     )
+
+    def __post_init__(self) -> None:
+        self.log_level = _validate_log_level(self.log_level)
+
+    def __setattr__(self, name: str, value: object) -> None:
+        if name == "log_level" and isinstance(value, str):
+            value = _validate_log_level(value)
+        super().__setattr__(name, value)
 
 
 def load_settings() -> Settings:

--- a/agamemnon/tests/test_log_level_validation.py
+++ b/agamemnon/tests/test_log_level_validation.py
@@ -1,0 +1,87 @@
+"""Tests for AGAMEMNON_LOG_LEVEL validation in Settings.
+
+See issue #132 — misconfigured log levels should fail loudly at startup
+rather than silently falling back to WARNING via logging.basicConfig.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agamemnon.orchestration.config import (
+    VALID_LOG_LEVELS,
+    Settings,
+    load_settings,
+)
+
+
+class TestLogLevelValidation:
+    """Validate that Settings rejects bad log levels and normalizes good ones."""
+
+    @pytest.mark.parametrize("level", list(VALID_LOG_LEVELS))
+    def test_accepts_canonical_levels(
+        self, monkeypatch: pytest.MonkeyPatch, level: str
+    ) -> None:
+        """All documented log levels are accepted in canonical form."""
+        monkeypatch.setenv("AGAMEMNON_LOG_LEVEL", level)
+        s = load_settings()
+        assert s.log_level == level
+
+    @pytest.mark.parametrize(
+        ("supplied", "expected"),
+        [
+            ("debug", "DEBUG"),
+            ("Info", "INFO"),
+            ("  warning  ", "WARNING"),
+            ("ERROR", "ERROR"),
+            ("critical", "CRITICAL"),
+        ],
+    )
+    def test_accepts_case_insensitively_and_normalizes(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        supplied: str,
+        expected: str,
+    ) -> None:
+        """Mixed-case and whitespace input is normalized to canonical uppercase."""
+        monkeypatch.setenv("AGAMEMNON_LOG_LEVEL", supplied)
+        s = load_settings()
+        assert s.log_level == expected
+
+    def test_default_is_info_when_env_unset(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Without AGAMEMNON_LOG_LEVEL set, default is INFO."""
+        monkeypatch.delenv("AGAMEMNON_LOG_LEVEL", raising=False)
+        s = load_settings()
+        assert s.log_level == "INFO"
+
+    @pytest.mark.parametrize("bad_value", ["TYPO", "verbose", "", "NOTSET", "warn"])
+    def test_rejects_invalid_values(
+        self, monkeypatch: pytest.MonkeyPatch, bad_value: str
+    ) -> None:
+        """Unknown log levels raise ValueError listing accepted values."""
+        monkeypatch.setenv("AGAMEMNON_LOG_LEVEL", bad_value)
+        with pytest.raises(ValueError) as excinfo:
+            load_settings()
+        msg = str(excinfo.value)
+        for valid in VALID_LOG_LEVELS:
+            assert valid in msg
+
+    def test_setattr_validates_assignment(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Assigning an invalid log_level after construction also raises."""
+        monkeypatch.setenv("AGAMEMNON_LOG_LEVEL", "INFO")
+        s = load_settings()
+        with pytest.raises(ValueError, match="Invalid log level"):
+            s.log_level = "TYPO"
+
+    def test_setattr_normalizes_assignment(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Assigning a lowercase log_level normalizes it."""
+        monkeypatch.setenv("AGAMEMNON_LOG_LEVEL", "INFO")
+        s = Settings()
+        s.log_level = "debug"
+        assert s.log_level == "DEBUG"


### PR DESCRIPTION
## Summary
- Validate `AGAMEMNON_LOG_LEVEL` against the documented set (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`) so misconfiguration fails loudly at startup instead of silently falling back to `WARNING` inside `logging.basicConfig`.
- Accept values case-insensitively and normalize to canonical uppercase. Default remains `INFO`.
- Validation runs in `__post_init__` and on every `__setattr__`, covering the CLI override path in `daemon.main`.

## Test plan
- [x] `python3 -m pytest tests/` (31 passed — 18 new + 13 existing)
- [x] `ruff check orchestration/config.py tests/test_log_level_validation.py`
- [x] Parametrized rejection of `TYPO`, `verbose`, `""`, `NOTSET`, `warn` with error message listing accepted values
- [x] Case/whitespace normalization (`debug` → `DEBUG`, `  warning  ` → `WARNING`)

Closes #132