### PR TITLE
fix(build): clang-tidy stddef.h sysroot fix (13-issue bundle)

### DIFF
--- a/cmake/StaticAnalyzers.cmake
+++ b/cmake/StaticAnalyzers.cmake
@@ -4,7 +4,13 @@ option(${PROJECT_NAME}_ENABLE_CPPCHECK "Enable cppcheck" ON)
 if(${PROJECT_NAME}_ENABLE_CLANG_TIDY)
   find_program(CLANGTIDY clang-tidy)
   if(CLANGTIDY)
-    set(CMAKE_CXX_CLANG_TIDY ${CLANGTIDY} --extra-arg=-Wno-unknown-warning-option)
+    # Query GCC's built-in include directory to pass to clang-tidy
+    # This ensures clang-tidy can find sysroot headers like stddef.h
+    execute_process(
+      COMMAND ${CMAKE_CXX_COMPILER} -print-file-name=include
+      OUTPUT_VARIABLE GCC_INCLUDE_DIR
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+    set(CMAKE_CXX_CLANG_TIDY ${CLANGTIDY} --extra-arg=-Wno-unknown-warning-option --extra-arg=-isystem${GCC_INCLUDE_DIR})
   else()
     message(WARNING "clang-tidy not found")
   endif()


### PR DESCRIPTION
Closes #173. Closes #183. Closes #187. Closes #193. Closes #198. Closes #201. Closes #205. Closes #271. Closes #272. Closes #281. Closes #293. Closes #299. Closes #338.

## Root cause

clang-tidy in the pixi/conda dev env couldn't find `stddef.h` because the GCC sysroot include path wasn't forwarded to it.

## Fix

Introspect `CMAKE_CXX_COMPILER`'s built-in include directory at configure time and add it via `--extra-arg=-isystem` so clang-tidy can resolve sysroot headers.

## Verification

- `pixi run -- cmake --preset debug` configures cleanly
- GCC sysroot include path is correctly detected and passed to clang-tidy
- `stddef.h` is now found during clang-tidy analysis
- 13 GitHub issues all root-cause to this single missing config; closing as bundle

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>