### PR TITLE
fix(version_info): silence clang-tidy misc-use-internal-linkage (#177)

### DIFF
--- a/src/version_info.cpp
+++ b/src/version_info.cpp
@@ -7,7 +7,7 @@ namespace projectagamemnon {
 // NOLINT(misc-use-internal-linkage) below: both functions are declared in
 // include/projectagamemnon/version.hpp and consumed externally; internal
 // linkage would be incorrect.
-const char* get_version() { return kVersion.data(); }       // NOLINT(misc-use-internal-linkage)
+const char* get_version() { return kVersion.data(); }           // NOLINT(misc-use-internal-linkage)
 const char* get_project_name() { return kProjectName.data(); }  // NOLINT(misc-use-internal-linkage)
 
 }  // namespace projectagamemnon

--- a/src/version_info.cpp
+++ b/src/version_info.cpp
@@ -4,7 +4,10 @@
 
 namespace projectagamemnon {
 
-const char* get_version() { return kVersion.data(); }
-const char* get_project_name() { return kProjectName.data(); }
+// NOLINT(misc-use-internal-linkage) below: both functions are declared in
+// include/projectagamemnon/version.hpp and consumed externally; internal
+// linkage would be incorrect.
+const char* get_version() { return kVersion.data(); }       // NOLINT(misc-use-internal-linkage)
+const char* get_project_name() { return kProjectName.data(); }  // NOLINT(misc-use-internal-linkage)
 
 }  // namespace projectagamemnon


### PR DESCRIPTION
Closes #177.

## Summary

`get_version()` and `get_project_name()` in `src/version_info.cpp` are declared in `include/projectagamemnon/version.hpp` and used externally, but clang-tidy's `misc-use-internal-linkage` fires when it can't see the header declaration (typically when running without a complete compilation database). Add documented `// NOLINT(misc-use-internal-linkage)` suppressions explaining the external-linkage intent.

Distinct from #385 (sysroot stddef.h fix).

## Verification

`pixi run -- clang-tidy -p build/debug src/version_info.cpp` no longer emits `misc-use-internal-linkage`.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>