### PR TITLE
build(cmake): add tsan preset for concurrency regression testing (#185)

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -63,6 +63,19 @@
         "ProjectAgamemnon_BUILD_TESTING": "ON",
         "ProjectAgamemnon_ENABLE_ASAN": "ON"
       }
+    },
+    {
+      "name": "tsan",
+      "displayName": "Debug build with ThreadSanitizer",
+      "inherits": "base",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "ProjectAgamemnon_BUILD_TESTING": "ON",
+        "ProjectAgamemnon_ENABLE_SANITIZERS": "OFF",
+        "CMAKE_CXX_FLAGS": "-fsanitize=thread -fno-omit-frame-pointer -g",
+        "CMAKE_EXE_LINKER_FLAGS": "-fsanitize=thread",
+        "CMAKE_SHARED_LINKER_FLAGS": "-fsanitize=thread"
+      }
     }
   ],
   "buildPresets": [
@@ -85,6 +98,10 @@
     {
       "name": "asan",
       "configurePreset": "asan"
+    },
+    {
+      "name": "tsan",
+      "configurePreset": "tsan"
     }
   ],
   "testPresets": [
@@ -121,6 +138,16 @@
       "configurePreset": "asan",
       "output": {
         "outputOnFailure": true
+      }
+    },
+    {
+      "name": "tsan",
+      "configurePreset": "tsan",
+      "output": {
+        "outputOnFailure": true
+      },
+      "environment": {
+        "TSAN_OPTIONS": "halt_on_error=1:second_deadlock_stack=1"
       }
     }
   ]

--- a/README.md
+++ b/README.md
@@ -191,6 +191,13 @@ just coverage      # Build + run coverage report
 just clean         # Remove build/ and install/
 ```
 
+Use the `tsan` preset (`cmake --preset tsan && cmake --build --preset tsan && ctest --preset tsan`) for
+concurrency regression testing targeting Store/NatsClient races (see #155, #161, #202). TSan is mutually
+exclusive with ASan/UBSan; the `tsan` preset explicitly disables the default sanitizers.
+
+```bash
+```
+
 Pre-commit hooks enforce formatting and [conventional commits](https://www.conventionalcommits.org/).
 Run `pixi run pre-commit install` once after cloning to activate them. Never bypass hooks with
 `--no-verify`.


### PR DESCRIPTION
Closes #185.

## Summary

Add a `tsan` configure/build/test preset to `CMakePresets.json`. TSan is mutually exclusive with ASan/UBSan, so the new preset inherits from `base` (not `debug`), explicitly disables sanitizers, and adds `-fsanitize=thread` to compile and link flags. The test preset sets `TSAN_OPTIONS=halt_on_error=1:second_deadlock_stack=1`.

Unblocks deterministic race detection for #155, #161, #202.

## Changes

- `CMakePresets.json`: new `tsan` configure preset (inherits `base`, `CMAKE_BUILD_TYPE=Debug`, `ProjectAgamemnon_ENABLE_SANITIZERS=OFF`, `-fsanitize=thread` on CXX/linker flags), matching `tsan` build preset, and `tsan` test preset with `TSAN_OPTIONS` environment
- `README.md`: 2-line note in the Development section explaining when to use the `tsan` preset

## Verification

- `cmake --preset tsan` configures (TSan flags applied via cache variables)
- `cmake --build --preset tsan` builds with `-fsanitize=thread`
- `ctest --preset tsan` runs with TSan reports surfaced as errors via `halt_on_error=1`

> **Note:** Local build not verified — pixi/conan environment not fully provisioned in this agent context. The preset JSON is syntactically valid and structurally consistent with existing presets.

CI matrix integration deferred to a follow-up to avoid hot-file contention with other in-flight PRs.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>