### PR TITLE
refactor(build): extract ProjectAgamemnon_core + nlohmann_json PUBLIC (#189, #182)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,8 +57,9 @@ target_include_directories(
 
 target_link_libraries(
   ${PROJECT_NAME}
-  PRIVATE
+  PUBLIC
     nlohmann_json::nlohmann_json
+  PRIVATE
     prometheus-cpp::core)
 
 set_project_warnings(${PROJECT_NAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,9 +76,9 @@ target_compile_options(agamemnon_peer_discovery PRIVATE
   -Wno-sign-conversion
 )
 
-# ── agamemnon_lib — shared by server executable and tests ────────────────────
+# ── ProjectAgamemnon_core — shared by server executable and tests ─────────────
 # Excludes server_main.cpp so gtest_main does not conflict with main().
-add_library(agamemnon_lib STATIC
+add_library(ProjectAgamemnon_core STATIC
   src/routes.cpp
   src/store.cpp
   src/nats_client.cpp
@@ -94,15 +94,15 @@ add_library(agamemnon_lib STATIC
   src/state_machine.cpp
 )
 
-target_compile_features(agamemnon_lib PUBLIC cxx_std_20)
-set_target_properties(agamemnon_lib PROPERTIES CXX_EXTENSIONS OFF)
+target_compile_features(ProjectAgamemnon_core PUBLIC cxx_std_20)
+set_target_properties(ProjectAgamemnon_core PROPERTIES CXX_EXTENSIONS OFF)
 
-target_include_directories(agamemnon_lib
+target_include_directories(ProjectAgamemnon_core
   PUBLIC  ${PROJECT_SOURCE_DIR}/include
   PRIVATE ${PROJECT_SOURCE_DIR}/src
 )
 
-target_link_libraries(agamemnon_lib
+target_link_libraries(ProjectAgamemnon_core
   PUBLIC
     httplib::httplib
     nlohmann_json::nlohmann_json
@@ -113,7 +113,7 @@ target_link_libraries(agamemnon_lib
     prometheus-cpp::core
 )
 
-target_compile_options(agamemnon_lib PRIVATE
+target_compile_options(ProjectAgamemnon_core PRIVATE
   -Wno-old-style-cast
   -Wno-useless-cast
   -Wno-conversion
@@ -137,7 +137,7 @@ target_include_directories(
     ${PROJECT_SOURCE_DIR}/src
 )
 
-target_link_libraries(${PROJECT_NAME}_server PRIVATE agamemnon_lib agamemnon_peer_discovery)
+target_link_libraries(${PROJECT_NAME}_server PRIVATE ProjectAgamemnon_core agamemnon_peer_discovery)
 
 # Suppress warnings from external headers on the server target
 target_compile_options(${PROJECT_NAME}_server PRIVATE

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,7 +3,6 @@ cmake_minimum_required(VERSION 3.20)
 find_package(GTest REQUIRED)
 find_package(Threads REQUIRED)
 find_package(httplib REQUIRED)
-find_package(nlohmann_json REQUIRED)
 find_package(OpenSSL REQUIRED)
 find_package(prometheus-cpp REQUIRED)
 
@@ -60,7 +59,6 @@ target_link_libraries(${PROJECT_NAME}_tests
     GTest::gtest_main
     GTest::gmock
     httplib::httplib
-    nlohmann_json::nlohmann_json
     nats_static
     OpenSSL::SSL
     OpenSSL::Crypto
@@ -97,7 +95,6 @@ target_link_libraries(${PROJECT_NAME}_routes_tests
     ProjectAgamemnon_core
     GTest::gtest_main
     httplib::httplib
-    nlohmann_json::nlohmann_json
     nats_static
     OpenSSL::SSL
     OpenSSL::Crypto
@@ -135,8 +132,7 @@ target_link_libraries(${PROJECT_NAME}_integration_tests
     ${PROJECT_NAME}::${PROJECT_NAME}
     ProjectAgamemnon_core
     GTest::gtest_main
-    httplib::httplib
-    nlohmann_json::nlohmann_json)
+    httplib::httplib)
 
 gtest_discover_tests(${PROJECT_NAME}_integration_tests
   PROPERTIES LABELS "integration")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -30,10 +30,6 @@ add_executable(${PROJECT_NAME}_tests
   src/test_orchestrator.cpp
   src/test_planning_breakdown.cpp
   src/test_state_machine.cpp
-  ${PROJECT_SOURCE_DIR}/src/routes.cpp
-  ${PROJECT_SOURCE_DIR}/src/store.cpp
-  ${PROJECT_SOURCE_DIR}/src/nats_client.cpp
-  ${PROJECT_SOURCE_DIR}/src/version_info.cpp
 )
 
 target_compile_features(${PROJECT_NAME}_tests PRIVATE cxx_std_20)
@@ -59,7 +55,7 @@ target_compile_options(${PROJECT_NAME}_tests PRIVATE
 target_link_libraries(${PROJECT_NAME}_tests
   PRIVATE
     ${PROJECT_NAME}::${PROJECT_NAME}
-    agamemnon_lib
+    ProjectAgamemnon_core
     agamemnon_peer_discovery
     GTest::gtest_main
     GTest::gmock
@@ -98,7 +94,7 @@ target_include_directories(${PROJECT_NAME}_routes_tests
 
 target_link_libraries(${PROJECT_NAME}_routes_tests
   PRIVATE
-    agamemnon_lib
+    ProjectAgamemnon_core
     GTest::gtest_main
     httplib::httplib
     nlohmann_json::nlohmann_json
@@ -137,7 +133,7 @@ target_compile_options(${PROJECT_NAME}_integration_tests PRIVATE
 target_link_libraries(${PROJECT_NAME}_integration_tests
   PRIVATE
     ${PROJECT_NAME}::${PROJECT_NAME}
-    agamemnon_lib
+    ProjectAgamemnon_core
     GTest::gtest_main
     httplib::httplib
     nlohmann_json::nlohmann_json)


### PR DESCRIPTION
Closes #189. Closes #182.

## Summary

Build-graph cleanup: rename `agamemnon_lib` → `ProjectAgamemnon_core` (canonical name) and remove the duplicate TUs that test/CMakeLists.txt was compiling redundantly. Then mark `nlohmann_json` as a PUBLIC dependency since `store.hpp` exposes `nlohmann::json` in its public API; remove the redundant explicit links/find_packages from test targets.

Two atomic commits:
- `refactor(build): extract ProjectAgamemnon_core STATIC library …` — #189
- `build(cmake): make nlohmann_json PUBLIC … via store.hpp` — #182

## Verification

- `pixi run -- cmake --preset debug` configures cleanly
- `pixi run -- cmake --build --preset debug` builds (TUs compiled once)
- `test/CMakeLists.txt` no longer duplicates `src/*.cpp` files

Unblocks #212 (nats coverage exclusion at library level) and #360 (coverage gate). Both will rebase on this in later waves.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>