### PR TITLE
chore: simple-sweep bundle 2 — build env wiring (justfile, pixi, _required.yml)

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -73,7 +73,7 @@ jobs:
         run: pip install mypy
 
       - name: Enforce Python client type check
-        run: mypy clients/python/ --ignore-missing-imports
+        run: mypy clients/python/
 
       - name: Check GitHub Actions workflow schemas
         run: actionlint

--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -75,6 +75,14 @@ jobs:
       - name: Enforce Python client type check
         run: mypy clients/python/
 
+      - name: Install actionlint
+        run: |
+          ACTIONLINT_VERSION=1.7.7
+          curl -sSfL "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
+            -o /tmp/actionlint.tar.gz
+          tar -xz -C /usr/local/bin -f /tmp/actionlint.tar.gz actionlint
+          actionlint --version
+
       - name: Check GitHub Actions workflow schemas
         run: actionlint
 

--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -69,11 +69,24 @@ jobs:
       - name: Build (runs clang-tidy)
         run: cmake --build --preset debug
 
-      - name: Install mypy
-        run: pip install mypy
+      - name: Restore pixi cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            clients/python/.pixi
+            ~/.cache/rattler/cache
+          key: pixi-lint-${{ runner.os }}-${{ hashFiles('clients/python/pixi.lock') }}
+          restore-keys: pixi-lint-${{ runner.os }}-
+
+      - name: Setup pixi
+        uses: prefix-dev/setup-pixi@v0.9.5
+        with:
+          pixi-version: v0.67.2
+          manifest-path: clients/python/pixi.toml
+          cache: false
 
       - name: Enforce Python client type check
-        run: mypy clients/python/
+        run: pixi run --manifest-path clients/python/pixi.toml typecheck
 
       - name: Install actionlint
         run: |

--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -75,6 +75,9 @@ jobs:
       - name: Enforce Python client type check
         run: mypy clients/python/ --ignore-missing-imports
 
+      - name: Check GitHub Actions workflow schemas
+        run: actionlint
+
   markdownlint:
     name: markdownlint
     runs-on: ubuntu-24.04

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -53,7 +53,7 @@ jobs:
         env:
           BUILD_TYPE: ${{ matrix.build_type }}
         run: |
-          BUILD_TYPE_CAP=$(echo "$BUILD_TYPE" | sed 's/./\u&/')
+          BUILD_TYPE_CAP="${BUILD_TYPE^}"
           conan install . --build=missing -s build_type="$BUILD_TYPE_CAP" \
             --output-folder "build/$BUILD_TYPE"
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -129,16 +129,38 @@ jobs:
           ASAN_OPTIONS: halt_on_error=1:detect_leaks=1
         run: ctest --preset asan --timeout 120 --parallel 4
 
+  python-orchestration:
+    name: python-orchestration
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: prefix-dev/setup-pixi@v0.9.5
+        with:
+          pixi-version: v0.67.2
+          cache: true
+
+      - name: Lint agamemnon/
+        run: cd agamemnon && pixi run lint
+
+      - name: Type check agamemnon/
+        run: cd agamemnon && pixi run typecheck
+
+      - name: Test agamemnon/
+        run: cd agamemnon && pixi run test
+
+
   check-all:
     name: All Build/Test Checks
     runs-on: ubuntu-24.04
-    needs: [build-test, asan]
+    needs: [build-test, asan, python-orchestration]
     if: always()
     steps:
       - name: Check all jobs passed
         env:
           BUILD_TEST_RESULT: ${{ needs.build-test.result }}
           ASAN_RESULT: ${{ needs.asan.result }}
+          PYTHON_ORCHESTRATION_RESULT: ${{ needs.python-orchestration.result }}
         run: |
           if [ "$BUILD_TEST_RESULT" != "success" ]; then
             echo "build-test failed"
@@ -146,6 +168,10 @@ jobs:
           fi
           if [ "$ASAN_RESULT" != "success" ]; then
             echo "asan failed"
+            exit 1
+          fi
+          if [ "$PYTHON_ORCHESTRATION_RESULT" != "success" ]; then
+            echo "python-orchestration failed"
             exit 1
           fi
           echo "All checks passed"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,11 @@
 # Security Policy
 
+## Supported Versions
+
+| Version | Status        |
+|---------|---------------|
+| 0.1.0   | Current       |
+
 ## Secrets Scanning Gate
 
 The `security/secrets-scan` CI job runs Gitleaks against the full git history

--- a/clients/python/pixi.lock
+++ b/clients/python/pixi.lock
@@ -5,8 +5,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -60,7 +58,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/e8/39/c61d193b8a1daaa8977f7dea9e8d8ba866e02ea7b65d32f6861693aa4c12/ruff-0.15.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
-      - pypi: ./
+      - pypi: .
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h500dc9f_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.4.22-hbd8a1cb_0.conda
@@ -107,7 +105,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ae/08/a317bc231fb9e7b93e4ef3089501e51922ff88d6936ce5cf870c4fe55419/ruff-0.15.12-py3-none-macosx_10_12_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
-      - pypi: ./
+      - pypi: .
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.4.22-hbd8a1cb_0.conda
@@ -153,7 +151,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/aa/a4/f828e9718d3dce1f5f11c39c4f65afd32783c8b2aebb2e3d259e492c47bd/ruff-0.15.12-py3-none-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
-      - pypi: ./
+      - pypi: .
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.4.22-h4c7d964_0.conda
@@ -202,14 +200,12 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
-      - pypi: ./
+      - pypi: .
   lint:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -273,7 +269,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
-      - pypi: ./
+      - pypi: .
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h500dc9f_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.4.22-hbd8a1cb_0.conda
@@ -330,7 +326,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
-      - pypi: ./
+      - pypi: .
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.4.22-hbd8a1cb_0.conda
@@ -386,7 +382,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
-      - pypi: ./
+      - pypi: .
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.4.22-h4c7d964_0.conda
@@ -444,7 +440,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
-      - pypi: ./
+      - pypi: .
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
   build_number: 20
@@ -659,10 +655,10 @@ packages:
   version: 0.16.0
   sha256: 63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86
   requires_python: '>=3.8'
-- pypi: ./
+- pypi: .
   name: homericintelligence-agamemnon
   version: 0.1.0
-  sha256: 9245d4f6d4f16ff53c3c1aed89a605a27c956695b75654f5598e41d3ff247e15
+  sha256: 8a33dc4820dbcb2a5a8a565f8ba08bf1a0e9fc5d427128f66df254f71abbc930
   requires_dist:
   - httpx>=0.27,<1
   - pydantic>=2.0,<3
@@ -677,6 +673,7 @@ packages:
   - ruff>=0.4,<1 ; extra == 'dev'
   - pyyaml>=6.0,<7 ; extra == 'dev'
   requires_python: '>=3.9'
+  editable: true
 - pypi: https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl
   name: httpcore
   version: 1.0.9
@@ -1456,7 +1453,7 @@ packages:
   - typing-extensions>=4.14.1
   - typing-inspection>=0.4.2
   - email-validator>=2.0.0 ; extra == 'email'
-  - tzdata ; python_full_version >= '3.9' and sys_platform == 'win32' and extra == 'timezone'
+  - tzdata ; python_full_version >= '3.9' and platform_system == 'Windows' and extra == 'timezone'
   requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/20/eb/59980e5f1ae54a3b86372bd9f0fa373ea2d402e8cdcd3459334430f91e91/pydantic_core-2.46.3-cp314-cp314-win_amd64.whl
   name: pydantic-core

--- a/clients/python/pixi.lock
+++ b/clients/python/pixi.lock
@@ -658,7 +658,7 @@ packages:
 - pypi: .
   name: homericintelligence-agamemnon
   version: 0.1.0
-  sha256: 8a33dc4820dbcb2a5a8a565f8ba08bf1a0e9fc5d427128f66df254f71abbc930
+  sha256: 9245d4f6d4f16ff53c3c1aed89a605a27c956695b75654f5598e41d3ff247e15
   requires_dist:
   - httpx>=0.27,<1
   - pydantic>=2.0,<3

--- a/clients/python/pixi.lock
+++ b/clients/python/pixi.lock
@@ -5,6 +5,8 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -58,7 +60,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/e8/39/c61d193b8a1daaa8977f7dea9e8d8ba866e02ea7b65d32f6861693aa4c12/ruff-0.15.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
-      - pypi: .
+      - pypi: ./
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h500dc9f_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.4.22-hbd8a1cb_0.conda
@@ -105,7 +107,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ae/08/a317bc231fb9e7b93e4ef3089501e51922ff88d6936ce5cf870c4fe55419/ruff-0.15.12-py3-none-macosx_10_12_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
-      - pypi: .
+      - pypi: ./
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.4.22-hbd8a1cb_0.conda
@@ -151,7 +153,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/aa/a4/f828e9718d3dce1f5f11c39c4f65afd32783c8b2aebb2e3d259e492c47bd/ruff-0.15.12-py3-none-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
-      - pypi: .
+      - pypi: ./
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.4.22-h4c7d964_0.conda
@@ -200,12 +202,14 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
-      - pypi: .
+      - pypi: ./
   lint:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -269,7 +273,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
-      - pypi: .
+      - pypi: ./
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h500dc9f_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.4.22-hbd8a1cb_0.conda
@@ -326,7 +330,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
-      - pypi: .
+      - pypi: ./
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.4.22-hbd8a1cb_0.conda
@@ -382,7 +386,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
-      - pypi: .
+      - pypi: ./
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.4.22-h4c7d964_0.conda
@@ -440,7 +444,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
-      - pypi: .
+      - pypi: ./
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
   build_number: 20
@@ -655,10 +659,10 @@ packages:
   version: 0.16.0
   sha256: 63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86
   requires_python: '>=3.8'
-- pypi: .
+- pypi: ./
   name: homericintelligence-agamemnon
   version: 0.1.0
-  sha256: 8a33dc4820dbcb2a5a8a565f8ba08bf1a0e9fc5d427128f66df254f71abbc930
+  sha256: 9245d4f6d4f16ff53c3c1aed89a605a27c956695b75654f5598e41d3ff247e15
   requires_dist:
   - httpx>=0.27,<1
   - pydantic>=2.0,<3
@@ -673,7 +677,6 @@ packages:
   - ruff>=0.4,<1 ; extra == 'dev'
   - pyyaml>=6.0,<7 ; extra == 'dev'
   requires_python: '>=3.9'
-  editable: true
 - pypi: https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl
   name: httpcore
   version: 1.0.9
@@ -1453,7 +1456,7 @@ packages:
   - typing-extensions>=4.14.1
   - typing-inspection>=0.4.2
   - email-validator>=2.0.0 ; extra == 'email'
-  - tzdata ; python_full_version >= '3.9' and platform_system == 'Windows' and extra == 'timezone'
+  - tzdata ; python_full_version >= '3.9' and sys_platform == 'win32' and extra == 'timezone'
   requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/20/eb/59980e5f1ae54a3b86372bd9f0fa373ea2d402e8cdcd3459334430f91e91/pydantic_core-2.46.3-cp314-cp314-win_amd64.whl
   name: pydantic-core

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -46,6 +46,13 @@ strict = true
 python_version = "3.9"
 packages = ["agamemnon_client", "agamemnon"]
 
+[[tool.mypy.overrides]]
+module = [
+    "nats.*",
+    "respx.*",
+]
+ignore_missing_imports = true
+
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]

--- a/clients/python/tests/test_bump_version.py
+++ b/clients/python/tests/test_bump_version.py
@@ -269,3 +269,62 @@ def test_direct_main_happy_path(
 
     assert 'version = "5.6.7"' in toml.read_text(encoding="utf-8")
     assert "bumped version to 5.6.7" in capsys.readouterr().out
+
+
+# ── sync_security_md direct-call tests (lines 57-69) ──────────────────────────
+
+
+SECURITY_MD_WITH_VERSION = """\
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 1.2.3   | :white_check_mark: |
+| 1.0.0   | :x:                |
+"""
+
+SECURITY_MD_NO_VERSION_ROW = """\
+# Security Policy
+
+## Supported Versions
+
+No versions listed yet.
+"""
+
+
+def test_sync_security_md_updates_version(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Lines 57-69: file exists with a version row — updates it and prints confirmation."""
+    security_md = tmp_path / "SECURITY.md"
+    security_md.write_text(SECURITY_MD_WITH_VERSION, encoding="utf-8")
+
+    bump_version_module.sync_security_md(security_md, "2.0.0")
+
+    content = security_md.read_text(encoding="utf-8")
+    assert "2.0.0" in content
+    assert "1.2.3" not in content
+    assert "synced SECURITY.md version to 2.0.0" in capsys.readouterr().out
+
+
+def test_sync_security_md_no_match_does_not_write(tmp_path: Path) -> None:
+    """Line 67: updated == text branch — file is not rewritten when no version row matches."""
+    security_md = tmp_path / "SECURITY.md"
+    security_md.write_text(SECURITY_MD_NO_VERSION_ROW, encoding="utf-8")
+    mtime_before = security_md.stat().st_mtime_ns
+
+    bump_version_module.sync_security_md(security_md, "3.0.0")
+
+    # File must be untouched (no write occurred).
+    assert security_md.stat().st_mtime_ns == mtime_before
+
+
+def test_sync_security_md_missing_file_is_noop(tmp_path: Path) -> None:
+    """Lines 54-55: file does not exist — function returns without error."""
+    missing = tmp_path / "SECURITY.md"
+    assert not missing.exists()
+
+    # Must not raise.
+    bump_version_module.sync_security_md(missing, "4.0.0")

--- a/justfile
+++ b/justfile
@@ -46,7 +46,7 @@ ci:
   cmake --preset ci && cmake --build --preset ci && ctest --preset ci
 
 # Cut a release: bump version, commit, tag, and push
-release VERSION:
+release VERSION push='true':
   #!/usr/bin/env bash
   set -euo pipefail
   if ! [[ "{{VERSION}}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
@@ -58,4 +58,6 @@ release VERSION:
   git add clients/python/pyproject.toml
   git commit -S -m "chore: bump version to v{{VERSION}}"
   git tag -s "v{{VERSION}}" -m "v{{VERSION}}"
-  git push --follow-tags
+  if [ "{{push}}" = "true" ]; then
+    git push --follow-tags
+  fi

--- a/justfile
+++ b/justfile
@@ -33,6 +33,15 @@ format-check:
 actionlint:
   actionlint
 
+agamemnon-test:
+  cd agamemnon && pixi run test
+
+agamemnon-lint:
+  cd agamemnon && pixi run lint
+
+agamemnon-typecheck:
+  cd agamemnon && pixi run typecheck
+
 coverage: deps-coverage
   cmake --preset coverage && cmake --build --preset coverage && ./scripts/coverage.sh
 

--- a/justfile
+++ b/justfile
@@ -30,6 +30,9 @@ format:
 format-check:
   ./scripts/format.sh --check
 
+actionlint:
+  actionlint
+
 coverage: deps-coverage
   cmake --preset coverage && cmake --build --preset coverage && ./scripts/coverage.sh
 

--- a/justfile
+++ b/justfile
@@ -5,21 +5,21 @@ default:
 
 # Install Conan dependencies (cpp-httplib, nlohmann_json, gtest)
 deps:
-  conan install . --output-folder=build/debug --profile=conan/profiles/debug --build=missing
+  pixi run -- conan install . --output-folder=build/debug --profile=conan/profiles/debug --build=missing
 
 # Install Conan dependencies for release
 deps-release:
-  conan install . --output-folder=build/release --profile=conan/profiles/default --build=missing
+  pixi run -- conan install . --output-folder=build/release --profile=conan/profiles/default --build=missing
 
 # Install Conan dependencies for the coverage build (separate output folder)
 deps-coverage:
-  conan install . --output-folder=build/coverage --profile=conan/profiles/debug --build=missing
+  pixi run -- conan install . --output-folder=build/coverage --profile=conan/profiles/debug --build=missing
 
 build: deps
-  cmake --preset debug && cmake --build --preset debug
+  pixi run -- cmake --preset debug && pixi run -- cmake --build --preset debug
 
 test:
-  ctest --preset debug --output-on-failure
+  pixi run -- ctest --preset debug --output-on-failure
 
 lint:
   ./scripts/lint.sh
@@ -43,7 +43,7 @@ agamemnon-typecheck:
   cd agamemnon && pixi run typecheck
 
 coverage: deps-coverage
-  cmake --preset coverage && cmake --build --preset coverage && ./scripts/coverage.sh
+  pixi run -- cmake --preset coverage && pixi run -- cmake --build --preset coverage && ./scripts/coverage.sh
 
 clean:
   rm -rf build install
@@ -52,7 +52,7 @@ docs-validate:
   ./scripts/validate-openapi.sh
 
 ci:
-  cmake --preset ci && cmake --build --preset ci && ctest --preset ci
+  pixi run -- cmake --preset ci && pixi run -- cmake --build --preset ci && pixi run -- ctest --preset ci
 
 # Cut a release: bump version, commit, tag, and push
 release VERSION push='true':

--- a/pixi.lock
+++ b/pixi.lock
@@ -8,6 +8,7 @@ environments:
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/actionlint-1.7.12-h8bc977c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.45.1-default_h4852527_102.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.45.1-default_hfdba357_102.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.45.1-default_h4852527_102.conda
@@ -126,6 +127,17 @@ packages:
   license_family: BSD
   size: 28948
   timestamp: 1770939786096
+- conda: https://conda.anaconda.org/conda-forge/linux-64/actionlint-1.7.12-h8bc977c_0.conda
+  sha256: 1fff5ee0d83045ef90104ca83f52b4c44feb4ab2036fc7903fe9733f50721209
+  md5: bab393750db08f50eebaf96f50d18734
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17
+  - __glibc >=2.17,<3.0.a0
+  license: MIT
+  license_family: MIT
+  size: 2131192
+  timestamp: 1774975766537
 - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.45.1-default_h4852527_102.conda
   sha256: 3c7c5580c1720206f28b7fa3d60d17986b3f32465e63009c14c9ae1ea64f926c
   md5: 212fe5f1067445544c99dc1c847d032c

--- a/pixi.toml
+++ b/pixi.toml
@@ -15,6 +15,7 @@ clang-tools = ">=17"
 gcovr = ">=7"
 pre-commit = ">=3"
 libcurl = ">=8.20.0,<9"
+actionlint = ">=1.6"
 
 [tasks]
 deps = "conan install . --output-folder=build/debug --profile=conan/profiles/debug --build=missing"
@@ -22,4 +23,5 @@ build = { cmd = "cmake --preset debug -DCMAKE_C_COMPILER=/usr/bin/gcc -DCMAKE_CX
 test = "ctest --preset debug --output-on-failure"
 lint = "./scripts/lint.sh"
 format = "./scripts/format.sh"
+actionlint = "actionlint"
 coverage = "conan install . --output-folder=build/coverage --profile=conan/profiles/debug --build=missing && cmake --preset coverage && cmake --build --preset coverage && ./scripts/coverage.sh"

--- a/pixi.toml
+++ b/pixi.toml
@@ -24,4 +24,5 @@ test = "ctest --preset debug --output-on-failure && python -m pytest clients/pyt
 lint = "./scripts/lint.sh"
 format = "./scripts/format.sh"
 actionlint = "actionlint"
+ci-smoke = "python -m pytest clients/python/tests/test_ci_workflows.py -v"
 coverage = "conan install . --output-folder=build/coverage --profile=conan/profiles/debug --build=missing && cmake --preset coverage && cmake --build --preset coverage && ./scripts/coverage.sh"

--- a/pixi.toml
+++ b/pixi.toml
@@ -20,7 +20,7 @@ actionlint = ">=1.6"
 [tasks]
 deps = "conan install . --output-folder=build/debug --profile=conan/profiles/debug --build=missing"
 build = { cmd = "cmake --preset debug -DCMAKE_C_COMPILER=/usr/bin/gcc -DCMAKE_CXX_COMPILER=/usr/bin/c++ -DProjectAgamemnon_ENABLE_CLANG_TIDY=OFF && cmake --build --preset debug", depends-on = ["deps"] }
-test = "ctest --preset debug --output-on-failure"
+test = "ctest --preset debug --output-on-failure && python -m pytest clients/python/tests/test_agents_md_consistency.py -v"
 lint = "./scripts/lint.sh"
 format = "./scripts/format.sh"
 actionlint = "actionlint"

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -46,6 +46,29 @@ def bump_version(toml_path: Path, new_version: str) -> None:
     print(f"bumped version to {new_version}")
 
 
+def sync_security_md(security_md_path: Path, new_version: str) -> None:
+    """Update the Supported Versions table in SECURITY.md.
+
+    Replaces the first version in the table with the new version and "Current" status.
+    """
+    if not security_md_path.exists():
+        return
+
+    text = security_md_path.read_text(encoding="utf-8")
+    # Replace the version in the first table row (assumes format: | X.Y.Z   | Status |)
+    updated = re.sub(
+        r"^\|\s+\d+\.\d+\.\d+\s+\|",
+        f"| {new_version}   |",
+        text,
+        count=1,
+        flags=re.MULTILINE,
+    )
+
+    if updated != text:
+        security_md_path.write_text(updated, encoding="utf-8")
+        print(f"synced SECURITY.md version to {new_version}")
+
+
 def main() -> None:
     if len(sys.argv) != 2:
         print(f"usage: {sys.argv[0]} VERSION", file=sys.stderr)
@@ -61,12 +84,14 @@ def main() -> None:
 
     repo_root = Path(__file__).resolve().parent.parent
     toml_path = repo_root / "clients" / "python" / "pyproject.toml"
+    security_md_path = repo_root / "SECURITY.md"
 
     if not toml_path.exists():
         print(f"error: {toml_path} does not exist", file=sys.stderr)
         sys.exit(1)
 
     bump_version(toml_path, new_version)
+    sync_security_md(security_md_path, new_version)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #90. Closes #101. Closes #102. Closes #107. Closes #112. Closes #151. Closes #194. Closes #225. Closes #232. Closes #261.

## Summary

10 build-environment wiring fixes touching justfile, root pixi.toml, .github/workflows/_required.yml/build-test.yml, conan profiles, and metadata files.

One signed commit per issue.

| # | What |
|---|---|
| 90 | actionlint pixi+just+CI step |
| 101 | SECURITY.md sync on version bump |
| 102 | just release --no-push dry-run flag |
| 107 | agamemnon/ pixi tasks to root justfile |
| 112 | python-orchestration CI lint+test job |
| 151 | AGENTS.md drift test in root pixi test task |
| 194 | just build uses pixi run -- cmake |
| 225 | pixi run ci-smoke task alias |
| 232 | Drop --ignore-missing-imports from mypy CI |
| 261 | just build works without ambient GCC 14 |

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>