### PR TITLE
fix(store): MEDIUM Wave 2 — thread-safety + correctness (5 issues)

### DIFF
--- a/include/projectagamemnon/store.hpp
+++ b/include/projectagamemnon/store.hpp
@@ -3,9 +3,12 @@
 #include "projectagamemnon/github_client.hpp"
 #include "projectagamemnon/hmas_types.hpp"
 
+#include <atomic>
 #include <cstdint>
 #include <limits>
 #include <memory>
+#include <mutex>
+#include <optional>
 #include <shared_mutex>
 #include <string>
 #include <unordered_map>
@@ -74,8 +77,12 @@ class Store {
 
   // ── HMAS typed tasks ───────────────────────────────────────────────────
   void create_hmas_task(const HmasTask& task);
-  HmasTask* get_hmas_task(const std::string& id);
+  /// Returns a value copy of the task; safe to use outside the mutex.
+  std::optional<HmasTask> get_hmas_task(const std::string& id);
   bool update_hmas_task_state(const std::string& id, TaskState state);
+  /// Atomically update the task state and append an escalation record.
+  bool update_hmas_task_state_and_record_escalation(const std::string& id, TaskState new_state,
+                                                    const EscalationRecord& escalation);
   bool update_hmas_task(const HmasTask& task);
   std::vector<HmasTask> list_hmas_tasks_by_layer(HmasLayer layer);
   std::vector<HmasTask> list_hmas_tasks_by_parent(const std::string& parent_id);
@@ -91,10 +98,15 @@ class Store {
   std::unordered_map<std::string, json> faults_;
   std::unordered_map<std::string, HmasTask> hmas_tasks_;
 
-  bool agents_loaded_{false};
-  bool teams_loaded_{false};
-  bool tasks_loaded_{false};
-  bool faults_loaded_{false};
+  // Atomic flags: checked outside the lock; once_flags guard the single fetch.
+  std::atomic<bool> agents_loaded_{false};
+  std::atomic<bool> teams_loaded_{false};
+  std::atomic<bool> tasks_loaded_{false};
+  std::atomic<bool> faults_loaded_{false};
+  mutable std::once_flag agents_once_;
+  mutable std::once_flag teams_once_;
+  mutable std::once_flag tasks_once_;
+  mutable std::once_flag faults_once_;
 
   // Called while holding mutex_; loads entity type from GitHub on first access.
   void ensure_agents_loaded_();

--- a/src/orchestrator.cpp
+++ b/src/orchestrator.cpp
@@ -22,19 +22,20 @@ std::string Orchestrator::submit(TaskBrief brief) {
 
   // Transition L0 root to Decomposing then immediately Delegated, then enqueue.
   if (!tasks.empty()) {
-    HmasTask* root = store_.get_hmas_task(tasks[0].id);
-    if (root) {
-      state_machine_.try_transition(*root, TaskEvent::Submit);    // Pending -> Decomposing
-      state_machine_.try_transition(*root, TaskEvent::Delegate);  // Decomposing -> Delegated
-      store_.update_hmas_task(*root);
+    auto root_opt = store_.get_hmas_task(tasks[0].id);
+    if (root_opt) {
+      auto root = std::move(*root_opt);
+      state_machine_.try_transition(root, TaskEvent::Submit);    // Pending -> Decomposing
+      state_machine_.try_transition(root, TaskEvent::Delegate);  // Decomposing -> Delegated
+      store_.update_hmas_task(root);
 
-      std::string subj = myrmidon_subject(HmasLayer::L0_ChiefArchitect, root->id);
-      json payload = hmas_task_to_json(*root);
+      std::string subj = myrmidon_subject(HmasLayer::L0_ChiefArchitect, root.id);
+      json payload = hmas_task_to_json(root);
       payload["brief_id"] = brief.id;
       nats_.publish(subj, payload.dump());
       nats_.publish_log(
           "hi.logs.agamemnon.brief_submitted", "info", "Brief submitted: " + brief.id,
-          {{"brief_id", brief.id}, {"root_task_id", root->id}, {"task_count", tasks.size()}});
+          {{"brief_id", brief.id}, {"root_task_id", root.id}, {"task_count", tasks.size()}});
     }
   }
 
@@ -42,49 +43,50 @@ std::string Orchestrator::submit(TaskBrief brief) {
 }
 
 bool Orchestrator::delegate(const std::string& task_id) {
-  HmasTask* task = store_.get_hmas_task(task_id);
-  if (!task) return false;
+  auto task_opt = store_.get_hmas_task(task_id);
+  if (!task_opt) return false;
 
-  bool ok = state_machine_.try_transition(*task, TaskEvent::Delegate);
+  auto task = std::move(*task_opt);
+  bool ok = state_machine_.try_transition(task, TaskEvent::Delegate);
   if (!ok) {
     // L3 leaf tasks transition Pending → Delegated; try again in case state is still Pending.
-    ok = state_machine_.try_transition(*task, TaskEvent::Delegate);
+    ok = state_machine_.try_transition(task, TaskEvent::Delegate);
   }
   if (!ok) return false;
 
-  store_.update_hmas_task(*task);
-  std::string subj = myrmidon_subject(task->layer, task->id);
-  nats_.publish(subj, hmas_task_to_json(*task).dump());
+  store_.update_hmas_task(task);
+  std::string subj = myrmidon_subject(task.layer, task.id);
+  nats_.publish(subj, hmas_task_to_json(task).dump());
   return true;
 }
 
 bool Orchestrator::escalate(const std::string& task_id, const std::string& reason) {
-  HmasTask* task = store_.get_hmas_task(task_id);
-  if (!task) return false;
+  auto task_opt = store_.get_hmas_task(task_id);
+  if (!task_opt) return false;
 
+  auto task = std::move(*task_opt);
   // Only InProgress tasks can be escalated.
-  if (!state_machine_.try_transition(*task, TaskEvent::Escalate)) return false;
+  if (!state_machine_.try_transition(task, TaskEvent::Escalate)) return false;
 
   EscalationRecord rec;
   rec.task_id = task_id;
   rec.reason = reason;
   rec.escalated_at = now_iso8601();
-  rec.from_layer = task->layer;
-  task->escalations.push_back(rec);
-  store_.update_hmas_task(*task);
+  rec.from_layer = task.layer;
+  task.escalations.push_back(rec);
+  store_.update_hmas_task(task);
 
   // Re-enqueue to parent layer's subject.
-  HmasLayer parent_layer = (task->layer == HmasLayer::L0_ChiefArchitect)
+  HmasLayer parent_layer = (task.layer == HmasLayer::L0_ChiefArchitect)
                                ? HmasLayer::L0_ChiefArchitect
-                               : static_cast<HmasLayer>(static_cast<int>(task->layer) - 1);
+                               : static_cast<HmasLayer>(static_cast<int>(task.layer) - 1);
 
-  json payload = hmas_task_to_json(*task);
+  json payload = hmas_task_to_json(task);
   payload["escalation_reason"] = reason;
-  nats_.publish(myrmidon_subject(parent_layer, task->id), payload.dump());
-  nats_.publish_log("hi.logs.agamemnon.task_escalated", "warn", "Task escalated: " + task_id,
-                    {{"task_id", task_id},
-                     {"reason", reason},
-                     {"from_layer", hmas_layer_to_string(task->layer)}});
+  nats_.publish(myrmidon_subject(parent_layer, task.id), payload.dump());
+  nats_.publish_log(
+      "hi.logs.agamemnon.task_escalated", "warn", "Task escalated: " + task_id,
+      {{"task_id", task_id}, {"reason", reason}, {"from_layer", hmas_layer_to_string(task.layer)}});
   return true;
 }
 
@@ -99,13 +101,14 @@ void Orchestrator::on_myrmidon_completion(const std::string& subject, const std:
 
     if (task_id.empty()) return;
 
-    HmasTask* task = store_.get_hmas_task(task_id);
-    if (!task) {
+    auto task_opt = store_.get_hmas_task(task_id);
+    if (!task_opt) {
       // Fall back to plain task completion for non-HMAS tasks.
       store_.mark_task_completed(task_id);
       return;
     }
 
+    auto task = std::move(*task_opt);
     // Drive the task through every transition required to reach InProgress before
     // attempting Complete.  A myrmidon may report completion faster than the
     // orchestrator's intermediate transitions (Submit/Delegate/Start) were applied,
@@ -121,23 +124,23 @@ void Orchestrator::on_myrmidon_completion(const std::string& subject, const std:
     // Each try_transition is a no-op when the event is not valid for the current
     // state, so the chained calls below safely advance the task toward InProgress
     // without ever moving past it, and Complete is only applied from InProgress.
-    if (task->state == TaskState::Escalated) {
-      state_machine_.try_transition(*task, TaskEvent::Retry);
+    if (task.state == TaskState::Escalated) {
+      state_machine_.try_transition(task, TaskEvent::Retry);
     }
-    if (task->state == TaskState::Pending) {
+    if (task.state == TaskState::Pending) {
       // L3 leaves go straight Pending -> Delegated; others must Submit first.
-      if (!state_machine_.try_transition(*task, TaskEvent::Delegate)) {
-        state_machine_.try_transition(*task, TaskEvent::Submit);
+      if (!state_machine_.try_transition(task, TaskEvent::Delegate)) {
+        state_machine_.try_transition(task, TaskEvent::Submit);
       }
     }
-    if (task->state == TaskState::Decomposing) {
-      state_machine_.try_transition(*task, TaskEvent::Delegate);
+    if (task.state == TaskState::Decomposing) {
+      state_machine_.try_transition(task, TaskEvent::Delegate);
     }
-    if (task->state == TaskState::Delegated) {
-      state_machine_.try_transition(*task, TaskEvent::Start);
+    if (task.state == TaskState::Delegated) {
+      state_machine_.try_transition(task, TaskEvent::Start);
     }
-    state_machine_.try_transition(*task, TaskEvent::Complete);
-    store_.update_hmas_task(*task);
+    state_machine_.try_transition(task, TaskEvent::Complete);
+    store_.update_hmas_task(task);
 
     std::cout << "[orchestrator] task completed via " << subject << ": " << task_id << "\n";
 
@@ -145,10 +148,10 @@ void Orchestrator::on_myrmidon_completion(const std::string& subject, const std:
     delegate_unblocked_children(task_id);
 
     // If this was the L0 root, log pipeline completion.
-    if (task->layer == HmasLayer::L0_ChiefArchitect) {
+    if (task.layer == HmasLayer::L0_ChiefArchitect) {
       nats_.publish_log("hi.logs.agamemnon.brief_completed", "info",
-                        "Brief completed: " + task->brief_id,
-                        {{"brief_id", task->brief_id}, {"root_task_id", task_id}});
+                        "Brief completed: " + task.brief_id,
+                        {{"brief_id", task.brief_id}, {"root_task_id", task_id}});
     }
   } catch (...) {
     // Ignore malformed payloads.
@@ -192,11 +195,11 @@ std::string Orchestrator::myrmidon_subject(HmasLayer layer, const std::string& t
 
 void Orchestrator::delegate_unblocked_children(const std::string& completed_task_id) {
   // Find the completed task to know its brief.
-  HmasTask* completed = store_.get_hmas_task(completed_task_id);
-  if (!completed) return;
+  auto completed_opt = store_.get_hmas_task(completed_task_id);
+  if (!completed_opt) return;
 
   // Get all tasks in this brief.
-  auto siblings = store_.list_hmas_tasks_by_brief(completed->brief_id);
+  auto siblings = store_.list_hmas_tasks_by_brief(completed_opt->brief_id);
 
   for (const auto& candidate : siblings) {
     if (candidate.state != TaskState::Pending) continue;
@@ -204,8 +207,8 @@ void Orchestrator::delegate_unblocked_children(const std::string& completed_task
     // Check if all blockers are now Completed.
     bool all_clear = true;
     for (const auto& blocker_id : candidate.blocked_by) {
-      HmasTask* blocker = store_.get_hmas_task(blocker_id);
-      if (!blocker || blocker->state != TaskState::Completed) {
+      auto blocker_opt = store_.get_hmas_task(blocker_id);
+      if (!blocker_opt || blocker_opt->state != TaskState::Completed) {
         all_clear = false;
         break;
       }

--- a/src/peer_discovery.cpp
+++ b/src/peer_discovery.cpp
@@ -58,13 +58,13 @@ bool tcp_connect_with_timeout(const std::string& ip, int port, int timeout_ms) {
   int sock = socket(AF_INET, SOCK_STREAM, 0);
   if (sock < 0) return false;
 
-  struct timeval tv {};
+  struct timeval tv{};
   tv.tv_sec = timeout_ms / 1000;
   tv.tv_usec = (timeout_ms % 1000) * 1000;
   setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
   setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
 
-  struct sockaddr_in addr {};
+  struct sockaddr_in addr{};
   addr.sin_family = AF_INET;
   addr.sin_port = htons(static_cast<uint16_t>(port));
   if (inet_pton(AF_INET, ip.c_str(), &addr.sin_addr) != 1) {
@@ -100,13 +100,13 @@ bool check_nats_monitoring(const std::string& ip, int monitor_port, int timeout_
   int sock = socket(AF_INET, SOCK_STREAM, 0);
   if (sock < 0) return false;
 
-  struct timeval tv {};
+  struct timeval tv{};
   tv.tv_sec = timeout_ms / 1000;
   tv.tv_usec = (timeout_ms % 1000) * 1000;
   setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
   setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
 
-  struct sockaddr_in addr {};
+  struct sockaddr_in addr{};
   addr.sin_family = AF_INET;
   addr.sin_port = htons(static_cast<uint16_t>(monitor_port));
   if (inet_pton(AF_INET, ip.c_str(), &addr.sin_addr) != 1) {

--- a/src/peer_discovery.cpp
+++ b/src/peer_discovery.cpp
@@ -58,13 +58,13 @@ bool tcp_connect_with_timeout(const std::string& ip, int port, int timeout_ms) {
   int sock = socket(AF_INET, SOCK_STREAM, 0);
   if (sock < 0) return false;
 
-  struct timeval tv{};
+  struct timeval tv {};
   tv.tv_sec = timeout_ms / 1000;
   tv.tv_usec = (timeout_ms % 1000) * 1000;
   setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
   setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
 
-  struct sockaddr_in addr{};
+  struct sockaddr_in addr {};
   addr.sin_family = AF_INET;
   addr.sin_port = htons(static_cast<uint16_t>(port));
   if (inet_pton(AF_INET, ip.c_str(), &addr.sin_addr) != 1) {
@@ -100,13 +100,13 @@ bool check_nats_monitoring(const std::string& ip, int monitor_port, int timeout_
   int sock = socket(AF_INET, SOCK_STREAM, 0);
   if (sock < 0) return false;
 
-  struct timeval tv{};
+  struct timeval tv {};
   tv.tv_sec = timeout_ms / 1000;
   tv.tv_usec = (timeout_ms % 1000) * 1000;
   setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
   setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
 
-  struct sockaddr_in addr{};
+  struct sockaddr_in addr {};
   addr.sin_family = AF_INET;
   addr.sin_port = htons(static_cast<uint16_t>(monitor_port));
   if (inet_pton(AF_INET, ip.c_str(), &addr.sin_addr) != 1) {

--- a/src/routes.cpp
+++ b/src/routes.cpp
@@ -807,8 +807,8 @@ void register_routes(httplib::Server& server, Store& store, NatsPublisher& nats,
   server.Get(R"(/v1/tasks/([^/]+)/state)",
              [sp](const httplib::Request& req, httplib::Response& res) {
                const std::string task_id = req.matches[1];
-               HmasTask* const task = sp->get_hmas_task(task_id);
-               if (task == nullptr) {
+               auto task = sp->get_hmas_task(task_id);  // std::optional<HmasTask> — value copy
+               if (!task.has_value()) {
                  reply_not_found(res, "task");
                  return;
                }

--- a/src/store.cpp
+++ b/src/store.cpp
@@ -278,12 +278,13 @@ json Store::get_agent_by_name(const std::string& name) {
 json Store::list_agents(std::size_t limit, std::size_t offset) {
   ensure_agents_loaded_();
   std::unique_lock<std::shared_mutex> lk(mutex_);
+  // #340: deterministic pagination — collect into sorted vector, then slice.
+  std::vector<std::pair<std::string, json>> sorted(agents_.begin(), agents_.end());
+  std::sort(sorted.begin(), sorted.end(),
+            [](const auto& a, const auto& b) { return a.first < b.first; });
   json arr = json::array();
-  std::size_t idx = 0;
-  for (auto& [id, agent] : agents_) {
-    if (idx++ < offset) continue;
-    if (arr.size() >= limit) break;
-    arr.push_back(agent);
+  for (std::size_t i = offset; i < sorted.size() && arr.size() < limit; ++i) {
+    arr.push_back(sorted[i].second);
   }
   return {{"agents", arr}, {"total", agents_.size()}, {"limit", limit}, {"offset", offset}};
 }
@@ -380,12 +381,13 @@ json Store::get_team(const std::string& id) {
 json Store::list_teams(std::size_t limit, std::size_t offset) {
   ensure_teams_loaded_();
   std::unique_lock<std::shared_mutex> lk(mutex_);
+  // #340: deterministic pagination — sort by key then slice.
+  std::vector<std::pair<std::string, json>> sorted(teams_.begin(), teams_.end());
+  std::sort(sorted.begin(), sorted.end(),
+            [](const auto& a, const auto& b) { return a.first < b.first; });
   json arr = json::array();
-  std::size_t idx = 0;
-  for (auto& [id, team] : teams_) {
-    if (idx++ < offset) continue;
-    if (arr.size() >= limit) break;
-    arr.push_back(team);
+  for (std::size_t i = offset; i < sorted.size() && arr.size() < limit; ++i) {
+    arr.push_back(sorted[i].second);
   }
   return {{"teams", arr}, {"total", teams_.size()}, {"limit", limit}, {"offset", offset}};
 }
@@ -496,15 +498,17 @@ json Store::update_task(const std::string& team_id, const std::string& task_id, 
 json Store::list_tasks_for_team(const std::string& team_id, std::size_t limit, std::size_t offset) {
   ensure_tasks_loaded_();
   std::unique_lock<std::shared_mutex> lk(mutex_);
-  json arr = json::array();
-  std::size_t total = 0;
-  std::size_t idx = 0;
+  // #340: deterministic pagination — collect team tasks, sort by key, then slice.
+  std::vector<std::pair<std::string, json>> team_tasks;
   for (auto& [id, task] : tasks_) {
-    if (task.value("teamId", "") != team_id) continue;
-    ++total;
-    if (idx++ < offset) continue;
-    if (arr.size() >= limit) continue;
-    arr.push_back(task);
+    if (task.value("teamId", "") == team_id) team_tasks.emplace_back(id, task);
+  }
+  std::sort(team_tasks.begin(), team_tasks.end(),
+            [](const auto& a, const auto& b) { return a.first < b.first; });
+  const std::size_t total = team_tasks.size();
+  json arr = json::array();
+  for (std::size_t i = offset; i < team_tasks.size() && arr.size() < limit; ++i) {
+    arr.push_back(team_tasks[i].second);
   }
   return {{"tasks", arr}, {"total", total}, {"limit", limit}, {"offset", offset}};
 }
@@ -512,12 +516,13 @@ json Store::list_tasks_for_team(const std::string& team_id, std::size_t limit, s
 json Store::list_all_tasks(std::size_t limit, std::size_t offset) {
   ensure_tasks_loaded_();
   std::unique_lock<std::shared_mutex> lk(mutex_);
+  // #340: deterministic pagination — sort by key then slice.
+  std::vector<std::pair<std::string, json>> sorted(tasks_.begin(), tasks_.end());
+  std::sort(sorted.begin(), sorted.end(),
+            [](const auto& a, const auto& b) { return a.first < b.first; });
   json arr = json::array();
-  std::size_t idx = 0;
-  for (auto& [id, task] : tasks_) {
-    if (idx++ < offset) continue;
-    if (arr.size() >= limit) break;
-    arr.push_back(task);
+  for (std::size_t i = offset; i < sorted.size() && arr.size() < limit; ++i) {
+    arr.push_back(sorted[i].second);
   }
   return {{"tasks", arr}, {"total", tasks_.size()}, {"limit", limit}, {"offset", offset}};
 }
@@ -543,12 +548,13 @@ void Store::mark_task_completed(const std::string& task_id) {
 json Store::list_faults(std::size_t limit, std::size_t offset) {
   ensure_faults_loaded_();
   std::unique_lock<std::shared_mutex> lk(mutex_);
+  // #340: deterministic pagination — sort by key then slice.
+  std::vector<std::pair<std::string, json>> sorted(faults_.begin(), faults_.end());
+  std::sort(sorted.begin(), sorted.end(),
+            [](const auto& a, const auto& b) { return a.first < b.first; });
   json arr = json::array();
-  std::size_t idx = 0;
-  for (auto& [id, fault] : faults_) {
-    if (idx++ < offset) continue;
-    if (arr.size() >= limit) break;
-    arr.push_back(fault);
+  for (std::size_t i = offset; i < sorted.size() && arr.size() < limit; ++i) {
+    arr.push_back(sorted[i].second);
   }
   return {{"faults", arr}, {"total", faults_.size()}, {"limit", limit}, {"offset", offset}};
 }

--- a/src/store.cpp
+++ b/src/store.cpp
@@ -605,9 +605,8 @@ std::optional<HmasTask> Store::get_hmas_task(const std::string& id) {
   return it->second;  // value copy — safe to use outside the lock
 }
 
-bool Store::update_hmas_task_state_and_record_escalation(const std::string& id,
-                                                          TaskState new_state,
-                                                          const EscalationRecord& escalation) {
+bool Store::update_hmas_task_state_and_record_escalation(const std::string& id, TaskState new_state,
+                                                         const EscalationRecord& escalation) {
   std::unique_lock<std::shared_mutex> lk(mutex_);
   auto it = hmas_tasks_.find(id);
   if (it == hmas_tasks_.end()) return false;

--- a/src/store.cpp
+++ b/src/store.cpp
@@ -453,11 +453,14 @@ json Store::create_task(const std::string& team_id, const json& body) {
 }
 
 json Store::get_task(const std::string& team_id, const std::string& task_id) {
+  // #222: require a non-empty team_id scope; empty team_id is not a valid
+  // wildcard — callers must provide the owning team for cross-team safety.
+  if (team_id.empty()) return nullptr;
   ensure_tasks_loaded_();
   std::unique_lock<std::shared_mutex> lk(mutex_);
   auto it = tasks_.find(task_id);
   if (it == tasks_.end()) return nullptr;
-  if (!team_id.empty() && it->second.value("teamId", "") != team_id) return nullptr;
+  if (it->second.value("teamId", "") != team_id) return nullptr;
   return it->second;
 }
 
@@ -465,11 +468,13 @@ json Store::update_task(const std::string& team_id, const std::string& task_id, 
   // Guard against null/non-object payloads from direct (non-route) callers;
   // body.items() throws type_error.306 on a null json. See #209.
   if (!body.is_object()) return nullptr;
+  // #222: require a non-empty team_id to prevent cross-team writes.
+  if (team_id.empty()) return nullptr;
   ensure_tasks_loaded_();
   std::unique_lock<std::shared_mutex> lk(mutex_);
   auto it = tasks_.find(task_id);
   if (it == tasks_.end()) return nullptr;
-  if (!team_id.empty() && it->second.value("teamId", "") != team_id) return nullptr;
+  if (it->second.value("teamId", "") != team_id) return nullptr;
   for (auto& [key, val] : body.items()) {
     if (key != "id" && key != "teamId" && key != "createdAt" && key != "_github_issue")
       it->second[key] = val;

--- a/src/store.cpp
+++ b/src/store.cpp
@@ -2,13 +2,17 @@
 
 #include "projectagamemnon/metrics.hpp"
 
+#include <algorithm>
 #include <chrono>
 #include <ctime>
 #include <iomanip>
 #include <iostream>
+#include <mutex>
+#include <optional>
 #include <random>
 #include <shared_mutex>
 #include <sstream>
+#include <utility>
 
 namespace projectagamemnon {
 
@@ -552,11 +556,22 @@ void Store::create_hmas_task(const HmasTask& task) {
   hmas_tasks_[task.id] = task;
 }
 
-HmasTask* Store::get_hmas_task(const std::string& id) {
+std::optional<HmasTask> Store::get_hmas_task(const std::string& id) {
   std::shared_lock<std::shared_mutex> lk(mutex_);
   auto it = hmas_tasks_.find(id);
-  if (it == hmas_tasks_.end()) return nullptr;
-  return &it->second;
+  if (it == hmas_tasks_.end()) return std::nullopt;
+  return it->second;  // value copy — safe to use outside the lock
+}
+
+bool Store::update_hmas_task_state_and_record_escalation(const std::string& id,
+                                                          TaskState new_state,
+                                                          const EscalationRecord& escalation) {
+  std::unique_lock<std::shared_mutex> lk(mutex_);
+  auto it = hmas_tasks_.find(id);
+  if (it == hmas_tasks_.end()) return false;
+  it->second.state = new_state;
+  it->second.escalations.push_back(escalation);
+  return true;
 }
 
 bool Store::update_hmas_task_state(const std::string& id, TaskState state) {

--- a/src/store.cpp
+++ b/src/store.cpp
@@ -93,112 +93,143 @@ json Store::parse_issue_entity_(const json& issue) {
   }
 }
 
-// ensure_*_loaded_ helpers — must be called while holding mutex_
+// ensure_*_loaded_ helpers (#161 — drop mutex during GitHub HTTP fetch)
+//
+// IMPORTANT: These functions MUST be called WITHOUT holding mutex_. They use
+// std::call_once to guarantee exactly one network fetch across all racing
+// threads, then acquire mutex_ internally to merge results. After returning,
+// the caller re-acquires mutex_ for map operations. The atomic flags allow
+// a cheap early-exit on the hot (already-loaded) path.
 void Store::ensure_agents_loaded_() {
-  if (agents_loaded_ || !gh_) {
-    agents_loaded_ = true;
-    return;
-  }
-  agents_loaded_ = true;
-  std::vector<json> issues;
-  try {
-    issues = gh_->list_issues("agamemnon-agent");
-  } catch (const std::exception& e) {
-    std::cerr << "[agamemnon] hydration error (agents): " << e.what() << "\n";
-    return;
-  }
-  for (auto& issue : issues) {
-    json entity = parse_issue_entity_(issue);
-    if (entity.is_null() || !entity.contains("id")) {
-      std::cerr << "[agamemnon] skipping malformed agent issue\n";
-      continue;
-    }
-    if (issue.contains("number"))
-      entity["_github_issue"] = std::to_string(issue["number"].get<int>());
-    agents_[entity["id"].get<std::string>()] = entity;
+  // Fast-path: already loaded (atomic, no lock needed).
+  if (agents_loaded_.load(std::memory_order_acquire)) return;
+
+  if (gh_) {
+    std::call_once(agents_once_, [this]() {
+      std::vector<json> issues;
+      try {
+        issues = gh_->list_issues("agamemnon-agent");
+      } catch (const std::exception& e) {
+        std::cerr << "[agamemnon] hydration error (agents): " << e.what() << "\n";
+        agents_loaded_.store(true, std::memory_order_release);
+        return;
+      }
+      std::unique_lock<std::shared_mutex> lk(mutex_);
+      for (auto& issue : issues) {
+        json entity = parse_issue_entity_(issue);
+        if (entity.is_null() || !entity.contains("id")) {
+          std::cerr << "[agamemnon] skipping malformed agent issue\n";
+          continue;
+        }
+        if (issue.contains("number"))
+          entity["_github_issue"] = std::to_string(issue["number"].get<int>());
+        agents_[entity["id"].get<std::string>()] = entity;
+      }
+      agents_loaded_.store(true, std::memory_order_release);
+    });
+  } else {
+    agents_loaded_.store(true, std::memory_order_release);
   }
 }
 
 void Store::ensure_teams_loaded_() {
-  if (teams_loaded_ || !gh_) {
-    teams_loaded_ = true;
-    return;
-  }
-  teams_loaded_ = true;
-  std::vector<json> issues;
-  try {
-    issues = gh_->list_issues("agamemnon-team");
-  } catch (const std::exception& e) {
-    std::cerr << "[agamemnon] hydration error (teams): " << e.what() << "\n";
-    return;
-  }
-  for (auto& issue : issues) {
-    json entity = parse_issue_entity_(issue);
-    if (entity.is_null() || !entity.contains("id")) {
-      std::cerr << "[agamemnon] skipping malformed team issue\n";
-      continue;
-    }
-    if (issue.contains("number"))
-      entity["_github_issue"] = std::to_string(issue["number"].get<int>());
-    teams_[entity["id"].get<std::string>()] = entity;
+  if (teams_loaded_.load(std::memory_order_acquire)) return;
+
+  if (gh_) {
+    std::call_once(teams_once_, [this]() {
+      std::vector<json> issues;
+      try {
+        issues = gh_->list_issues("agamemnon-team");
+      } catch (const std::exception& e) {
+        std::cerr << "[agamemnon] hydration error (teams): " << e.what() << "\n";
+        teams_loaded_.store(true, std::memory_order_release);
+        return;
+      }
+      std::unique_lock<std::shared_mutex> lk(mutex_);
+      for (auto& issue : issues) {
+        json entity = parse_issue_entity_(issue);
+        if (entity.is_null() || !entity.contains("id")) {
+          std::cerr << "[agamemnon] skipping malformed team issue\n";
+          continue;
+        }
+        if (issue.contains("number"))
+          entity["_github_issue"] = std::to_string(issue["number"].get<int>());
+        teams_[entity["id"].get<std::string>()] = entity;
+      }
+      teams_loaded_.store(true, std::memory_order_release);
+    });
+  } else {
+    teams_loaded_.store(true, std::memory_order_release);
   }
 }
 
 void Store::ensure_tasks_loaded_() {
-  if (tasks_loaded_ || !gh_) {
-    tasks_loaded_ = true;
-    return;
-  }
-  tasks_loaded_ = true;
-  std::vector<json> issues;
-  try {
-    issues = gh_->list_issues("agamemnon-task");
-  } catch (const std::exception& e) {
-    std::cerr << "[agamemnon] hydration error (tasks): " << e.what() << "\n";
-    return;
-  }
-  for (auto& issue : issues) {
-    json entity = parse_issue_entity_(issue);
-    if (entity.is_null() || !entity.contains("id")) {
-      std::cerr << "[agamemnon] skipping malformed task issue\n";
-      continue;
-    }
-    if (issue.contains("number"))
-      entity["_github_issue"] = std::to_string(issue["number"].get<int>());
-    tasks_[entity["id"].get<std::string>()] = entity;
+  if (tasks_loaded_.load(std::memory_order_acquire)) return;
+
+  if (gh_) {
+    std::call_once(tasks_once_, [this]() {
+      std::vector<json> issues;
+      try {
+        issues = gh_->list_issues("agamemnon-task");
+      } catch (const std::exception& e) {
+        std::cerr << "[agamemnon] hydration error (tasks): " << e.what() << "\n";
+        tasks_loaded_.store(true, std::memory_order_release);
+        return;
+      }
+      std::unique_lock<std::shared_mutex> lk(mutex_);
+      for (auto& issue : issues) {
+        json entity = parse_issue_entity_(issue);
+        if (entity.is_null() || !entity.contains("id")) {
+          std::cerr << "[agamemnon] skipping malformed task issue\n";
+          continue;
+        }
+        if (issue.contains("number"))
+          entity["_github_issue"] = std::to_string(issue["number"].get<int>());
+        tasks_[entity["id"].get<std::string>()] = entity;
+      }
+      tasks_loaded_.store(true, std::memory_order_release);
+    });
+  } else {
+    tasks_loaded_.store(true, std::memory_order_release);
   }
 }
 
 void Store::ensure_faults_loaded_() {
-  if (faults_loaded_ || !gh_) {
-    faults_loaded_ = true;
-    return;
-  }
-  faults_loaded_ = true;
-  std::vector<json> issues;
-  try {
-    issues = gh_->list_issues("agamemnon-fault");
-  } catch (const std::exception& e) {
-    std::cerr << "[agamemnon] hydration error (faults): " << e.what() << "\n";
-    return;
-  }
-  for (auto& issue : issues) {
-    json entity = parse_issue_entity_(issue);
-    if (entity.is_null() || !entity.contains("id")) {
-      std::cerr << "[agamemnon] skipping malformed fault issue\n";
-      continue;
-    }
-    if (issue.contains("number"))
-      entity["_github_issue"] = std::to_string(issue["number"].get<int>());
-    faults_[entity["id"].get<std::string>()] = entity;
+  if (faults_loaded_.load(std::memory_order_acquire)) return;
+
+  if (gh_) {
+    std::call_once(faults_once_, [this]() {
+      std::vector<json> issues;
+      try {
+        issues = gh_->list_issues("agamemnon-fault");
+      } catch (const std::exception& e) {
+        std::cerr << "[agamemnon] hydration error (faults): " << e.what() << "\n";
+        faults_loaded_.store(true, std::memory_order_release);
+        return;
+      }
+      std::unique_lock<std::shared_mutex> lk(mutex_);
+      for (auto& issue : issues) {
+        json entity = parse_issue_entity_(issue);
+        if (entity.is_null() || !entity.contains("id")) {
+          std::cerr << "[agamemnon] skipping malformed fault issue\n";
+          continue;
+        }
+        if (issue.contains("number"))
+          entity["_github_issue"] = std::to_string(issue["number"].get<int>());
+        faults_[entity["id"].get<std::string>()] = entity;
+      }
+      faults_loaded_.store(true, std::memory_order_release);
+    });
+  } else {
+    faults_loaded_.store(true, std::memory_order_release);
   }
 }
 
 // ── Agents ────────────────────────────────────────────────────────────────────
 
 json Store::create_agent(const json& body) {
+  ensure_agents_loaded_();  // hydrate before acquiring mutex_ (#161)
   std::unique_lock<std::shared_mutex> lk(mutex_);
-  ensure_agents_loaded_();
   std::string id = generate_uuid();
   json agent;
   agent["id"] = id;
@@ -228,16 +259,16 @@ json Store::create_agent(const json& body) {
 }
 
 json Store::get_agent(const std::string& id) {
-  std::unique_lock<std::shared_mutex> lk(mutex_);
   ensure_agents_loaded_();
+  std::unique_lock<std::shared_mutex> lk(mutex_);
   auto it = agents_.find(id);
   if (it == agents_.end()) return nullptr;
   return it->second;
 }
 
 json Store::get_agent_by_name(const std::string& name) {
-  std::unique_lock<std::shared_mutex> lk(mutex_);
   ensure_agents_loaded_();
+  std::unique_lock<std::shared_mutex> lk(mutex_);
   for (auto& [id, agent] : agents_) {
     if (agent.value("name", "") == name) return agent;
   }
@@ -245,8 +276,8 @@ json Store::get_agent_by_name(const std::string& name) {
 }
 
 json Store::list_agents(std::size_t limit, std::size_t offset) {
-  std::unique_lock<std::shared_mutex> lk(mutex_);
   ensure_agents_loaded_();
+  std::unique_lock<std::shared_mutex> lk(mutex_);
   json arr = json::array();
   std::size_t idx = 0;
   for (auto& [id, agent] : agents_) {
@@ -261,8 +292,8 @@ json Store::update_agent(const std::string& id, const json& fields) {
   // Guard against null/non-object payloads from direct (non-route) callers;
   // body.items() throws type_error.306 on a null json. See #209.
   if (!fields.is_object()) return nullptr;
-  std::unique_lock<std::shared_mutex> lk(mutex_);
   ensure_agents_loaded_();
+  std::unique_lock<std::shared_mutex> lk(mutex_);
   auto it = agents_.find(id);
   if (it == agents_.end()) return nullptr;
   for (auto& [key, val] : fields.items()) {
@@ -276,8 +307,8 @@ json Store::update_agent(const std::string& id, const json& fields) {
 }
 
 bool Store::delete_agent(const std::string& id) {
-  std::unique_lock<std::shared_mutex> lk(mutex_);
   ensure_agents_loaded_();
+  std::unique_lock<std::shared_mutex> lk(mutex_);
   auto it = agents_.find(id);
   if (it == agents_.end()) return false;
   if (gh_ && it->second.contains("_github_issue")) {
@@ -289,8 +320,8 @@ bool Store::delete_agent(const std::string& id) {
 }
 
 json Store::start_agent(const std::string& id) {
-  std::unique_lock<std::shared_mutex> lk(mutex_);
   ensure_agents_loaded_();
+  std::unique_lock<std::shared_mutex> lk(mutex_);
   auto it = agents_.find(id);
   if (it == agents_.end()) return nullptr;
   it->second["status"] = "online";
@@ -302,8 +333,8 @@ json Store::start_agent(const std::string& id) {
 }
 
 json Store::stop_agent(const std::string& id) {
-  std::unique_lock<std::shared_mutex> lk(mutex_);
   ensure_agents_loaded_();
+  std::unique_lock<std::shared_mutex> lk(mutex_);
   auto it = agents_.find(id);
   if (it == agents_.end()) return nullptr;
   it->second["status"] = "offline";
@@ -317,8 +348,8 @@ json Store::stop_agent(const std::string& id) {
 // ── Teams ─────────────────────────────────────────────────────────────────────
 
 json Store::create_team(const json& body) {
-  std::unique_lock<std::shared_mutex> lk(mutex_);
   ensure_teams_loaded_();
+  std::unique_lock<std::shared_mutex> lk(mutex_);
   std::string id = generate_uuid();
   json team;
   team["id"] = id;
@@ -339,16 +370,16 @@ json Store::create_team(const json& body) {
 }
 
 json Store::get_team(const std::string& id) {
-  std::unique_lock<std::shared_mutex> lk(mutex_);
   ensure_teams_loaded_();
+  std::unique_lock<std::shared_mutex> lk(mutex_);
   auto it = teams_.find(id);
   if (it == teams_.end()) return nullptr;
   return it->second;
 }
 
 json Store::list_teams(std::size_t limit, std::size_t offset) {
-  std::unique_lock<std::shared_mutex> lk(mutex_);
   ensure_teams_loaded_();
+  std::unique_lock<std::shared_mutex> lk(mutex_);
   json arr = json::array();
   std::size_t idx = 0;
   for (auto& [id, team] : teams_) {
@@ -360,8 +391,8 @@ json Store::list_teams(std::size_t limit, std::size_t offset) {
 }
 
 json Store::update_team(const std::string& id, const json& body) {
-  std::unique_lock<std::shared_mutex> lk(mutex_);
   ensure_teams_loaded_();
+  std::unique_lock<std::shared_mutex> lk(mutex_);
   auto it = teams_.find(id);
   if (it == teams_.end()) return nullptr;
   if (body.contains("agentIds"))
@@ -377,8 +408,8 @@ json Store::update_team(const std::string& id, const json& body) {
 }
 
 bool Store::delete_team(const std::string& id) {
-  std::unique_lock<std::shared_mutex> lk(mutex_);
   ensure_teams_loaded_();
+  std::unique_lock<std::shared_mutex> lk(mutex_);
   auto it = teams_.find(id);
   if (it == teams_.end()) return false;
   if (gh_ && it->second.contains("_github_issue")) {
@@ -391,8 +422,8 @@ bool Store::delete_team(const std::string& id) {
 // ── Tasks ─────────────────────────────────────────────────────────────────────
 
 json Store::create_task(const std::string& team_id, const json& body) {
-  std::unique_lock<std::shared_mutex> lk(mutex_);
   ensure_tasks_loaded_();
+  std::unique_lock<std::shared_mutex> lk(mutex_);
   std::string id = generate_uuid();
   json task;
   task["id"] = id;
@@ -422,8 +453,8 @@ json Store::create_task(const std::string& team_id, const json& body) {
 }
 
 json Store::get_task(const std::string& team_id, const std::string& task_id) {
-  std::unique_lock<std::shared_mutex> lk(mutex_);
   ensure_tasks_loaded_();
+  std::unique_lock<std::shared_mutex> lk(mutex_);
   auto it = tasks_.find(task_id);
   if (it == tasks_.end()) return nullptr;
   if (!team_id.empty() && it->second.value("teamId", "") != team_id) return nullptr;
@@ -434,8 +465,8 @@ json Store::update_task(const std::string& team_id, const std::string& task_id, 
   // Guard against null/non-object payloads from direct (non-route) callers;
   // body.items() throws type_error.306 on a null json. See #209.
   if (!body.is_object()) return nullptr;
-  std::unique_lock<std::shared_mutex> lk(mutex_);
   ensure_tasks_loaded_();
+  std::unique_lock<std::shared_mutex> lk(mutex_);
   auto it = tasks_.find(task_id);
   if (it == tasks_.end()) return nullptr;
   if (!team_id.empty() && it->second.value("teamId", "") != team_id) return nullptr;
@@ -458,8 +489,8 @@ json Store::update_task(const std::string& team_id, const std::string& task_id, 
 }
 
 json Store::list_tasks_for_team(const std::string& team_id, std::size_t limit, std::size_t offset) {
-  std::unique_lock<std::shared_mutex> lk(mutex_);
   ensure_tasks_loaded_();
+  std::unique_lock<std::shared_mutex> lk(mutex_);
   json arr = json::array();
   std::size_t total = 0;
   std::size_t idx = 0;
@@ -474,8 +505,8 @@ json Store::list_tasks_for_team(const std::string& team_id, std::size_t limit, s
 }
 
 json Store::list_all_tasks(std::size_t limit, std::size_t offset) {
-  std::unique_lock<std::shared_mutex> lk(mutex_);
   ensure_tasks_loaded_();
+  std::unique_lock<std::shared_mutex> lk(mutex_);
   json arr = json::array();
   std::size_t idx = 0;
   for (auto& [id, task] : tasks_) {
@@ -487,8 +518,8 @@ json Store::list_all_tasks(std::size_t limit, std::size_t offset) {
 }
 
 void Store::mark_task_completed(const std::string& task_id) {
-  std::unique_lock<std::shared_mutex> lk(mutex_);
   ensure_tasks_loaded_();
+  std::unique_lock<std::shared_mutex> lk(mutex_);
   auto it = tasks_.find(task_id);
   if (it != tasks_.end()) {
     std::string old_status = it->second.value("status", "pending");
@@ -505,8 +536,8 @@ void Store::mark_task_completed(const std::string& task_id) {
 // ── Chaos faults ──────────────────────────────────────────────────────────────
 
 json Store::list_faults(std::size_t limit, std::size_t offset) {
-  std::unique_lock<std::shared_mutex> lk(mutex_);
   ensure_faults_loaded_();
+  std::unique_lock<std::shared_mutex> lk(mutex_);
   json arr = json::array();
   std::size_t idx = 0;
   for (auto& [id, fault] : faults_) {
@@ -518,8 +549,8 @@ json Store::list_faults(std::size_t limit, std::size_t offset) {
 }
 
 json Store::create_fault(const std::string& type) {
-  std::unique_lock<std::shared_mutex> lk(mutex_);
   ensure_faults_loaded_();
+  std::unique_lock<std::shared_mutex> lk(mutex_);
   std::string id = generate_uuid();
   json fault;
   fault["id"] = id;
@@ -538,8 +569,8 @@ json Store::create_fault(const std::string& type) {
 }
 
 bool Store::remove_fault(const std::string& id) {
-  std::unique_lock<std::shared_mutex> lk(mutex_);
   ensure_faults_loaded_();
+  std::unique_lock<std::shared_mutex> lk(mutex_);
   auto it = faults_.find(id);
   if (it == faults_.end()) return false;
   if (gh_ && it->second.contains("_github_issue")) {

--- a/test/src/test_orchestrator.cpp
+++ b/test/src/test_orchestrator.cpp
@@ -82,23 +82,24 @@ TEST_F(OrchestratorTest, EscalateTransitionsToEscalated) {
   auto tasks = store_.list_hmas_tasks_by_brief(brief_id);
 
   // Find L0 root — it is Delegated after submit.
-  HmasTask* root = nullptr;
+  std::optional<HmasTask> root_opt;
   for (auto& t : tasks) {
     if (t.layer == HmasLayer::L0_ChiefArchitect) {
-      root = store_.get_hmas_task(t.id);
+      root_opt = store_.get_hmas_task(t.id);
       break;
     }
   }
-  ASSERT_NE(root, nullptr);
+  ASSERT_TRUE(root_opt.has_value());
+  HmasTask root = *root_opt;
 
   // Manually move to InProgress so we can escalate.
   TaskStateMachine sm;
-  sm.try_transition(*root, TaskEvent::Start);
-  store_.update_hmas_task(*root);
+  sm.try_transition(root, TaskEvent::Start);
+  store_.update_hmas_task(root);
 
-  EXPECT_TRUE(orch_->escalate(root->id, "blocked"));
-  HmasTask* updated = store_.get_hmas_task(root->id);
-  ASSERT_NE(updated, nullptr);
+  EXPECT_TRUE(orch_->escalate(root.id, "blocked"));
+  auto updated = store_.get_hmas_task(root.id);
+  ASSERT_TRUE(updated.has_value());
   EXPECT_EQ(updated->state, TaskState::Escalated);
   ASSERT_EQ(updated->escalations.size(), 1u);
   EXPECT_EQ(updated->escalations[0].reason, "blocked");
@@ -113,26 +114,27 @@ TEST_F(OrchestratorTest, OnMyrmidonCompletionMarksTaskCompleted) {
   auto tasks = store_.list_hmas_tasks_by_brief(brief_id);
 
   // Find an L3 leaf task.
-  HmasTask* leaf = nullptr;
+  std::optional<HmasTask> leaf_opt;
   for (auto& t : tasks) {
     if (t.layer == HmasLayer::L3_TaskAgent) {
-      leaf = store_.get_hmas_task(t.id);
+      leaf_opt = store_.get_hmas_task(t.id);
       break;
     }
   }
-  ASSERT_NE(leaf, nullptr);
+  ASSERT_TRUE(leaf_opt.has_value());
+  HmasTask leaf = *leaf_opt;
 
   // Move leaf to InProgress.
   TaskStateMachine sm;
-  if (leaf->state == TaskState::Pending) sm.try_transition(*leaf, TaskEvent::Delegate);
-  sm.try_transition(*leaf, TaskEvent::Start);
-  store_.update_hmas_task(*leaf);
+  if (leaf.state == TaskState::Pending) sm.try_transition(leaf, TaskEvent::Delegate);
+  sm.try_transition(leaf, TaskEvent::Start);
+  store_.update_hmas_task(leaf);
 
-  json payload = {{"task_id", leaf->id}};
+  json payload = {{"task_id", leaf.id}};
   orch_->on_myrmidon_completion("hi.tasks.t.t.completed", payload.dump());
 
-  HmasTask* after = store_.get_hmas_task(leaf->id);
-  ASSERT_NE(after, nullptr);
+  auto after = store_.get_hmas_task(leaf.id);
+  ASSERT_TRUE(after.has_value());
   EXPECT_EQ(after->state, TaskState::Completed);
   EXPECT_FALSE(after->completed_at.empty());
 }

--- a/test/src/test_pagination.cpp
+++ b/test/src/test_pagination.cpp
@@ -1,5 +1,9 @@
 #include "projectagamemnon/store.hpp"
 
+#include <set>
+#include <string>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 namespace projectagamemnon::test {
@@ -143,6 +147,67 @@ TEST(PaginationTeams, DefaultEnvelope) {
   EXPECT_EQ(r["teams"].size(), 3);
   EXPECT_TRUE(r.contains("limit"));
   EXPECT_TRUE(r.contains("offset"));
+}
+
+// ── #340 Deterministic pagination (no dups / full coverage) ──────────────────
+
+TEST(PaginationDeterminism, AgentPagesNoDuplicatesFullCoverage) {
+  Store s;
+  constexpr int N = 10;
+  for (int i = 0; i < N; ++i) s.create_agent(make_agent("agent" + std::to_string(i)));
+
+  constexpr std::size_t kLimit = 3;
+  std::set<std::string> seen_ids;
+  std::size_t total_seen = 0;
+
+  for (std::size_t offset = 0; offset < N; offset += kLimit) {
+    auto r = s.list_agents(kLimit, offset);
+    const auto& agents = r["agents"];
+    for (const auto& a : agents) {
+      std::string id = a["id"].get<std::string>();
+      EXPECT_EQ(seen_ids.count(id), 0u) << "Duplicate agent id: " << id;
+      seen_ids.insert(id);
+      ++total_seen;
+    }
+  }
+  EXPECT_EQ(total_seen, static_cast<std::size_t>(N));
+}
+
+TEST(PaginationDeterminism, AgentPageOrderIsStable) {
+  Store s;
+  constexpr int N = 6;
+  for (int i = 0; i < N; ++i) s.create_agent(make_agent("a" + std::to_string(i)));
+
+  // Two calls with the same parameters must return the same order.
+  auto r1 = s.list_agents(N, 0);
+  auto r2 = s.list_agents(N, 0);
+  ASSERT_EQ(r1["agents"].size(), r2["agents"].size());
+  for (std::size_t i = 0; i < r1["agents"].size(); ++i) {
+    EXPECT_EQ(r1["agents"][i]["id"], r2["agents"][i]["id"]);
+  }
+}
+
+TEST(PaginationDeterminism, TaskPagesNoDuplicatesFullCoverage) {
+  Store s;
+  auto t = s.create_team({{"name", "det-team"}});
+  std::string tid = t["team"]["id"].get<std::string>();
+  constexpr int N = 10;
+  for (int i = 0; i < N; ++i) s.create_task(tid, make_task("t" + std::to_string(i)));
+
+  constexpr std::size_t kLimit = 3;
+  std::set<std::string> seen_ids;
+  std::size_t total_seen = 0;
+
+  for (std::size_t offset = 0; offset < N; offset += kLimit) {
+    auto r = s.list_tasks_for_team(tid, kLimit, offset);
+    for (const auto& task : r["tasks"]) {
+      std::string id = task["id"].get<std::string>();
+      EXPECT_EQ(seen_ids.count(id), 0u) << "Duplicate task id: " << id;
+      seen_ids.insert(id);
+      ++total_seen;
+    }
+  }
+  EXPECT_EQ(total_seen, static_cast<std::size_t>(N));
 }
 
 }  // namespace projectagamemnon::test

--- a/test/src/test_store.cpp
+++ b/test/src/test_store.cpp
@@ -259,9 +259,10 @@ TEST_F(StoreTaskTest, GetTaskWrongTeam) {
 TEST_F(StoreTaskTest, GetTaskEmptyTeamId) {
   json result = store.create_task(team_id, {{"subject", "x"}});
   std::string task_id = result["task"]["id"];
-  // Empty team_id skips the team check
+  // #222: empty team_id is not a valid wildcard — must return null to prevent
+  // cross-team access. Callers must provide the owning team_id.
   json task = store.get_task("", task_id);
-  EXPECT_FALSE(task.is_null());
+  EXPECT_TRUE(task.is_null());
 }
 
 TEST_F(StoreTaskTest, GetTaskNotFound) {

--- a/test/src/test_store.cpp
+++ b/test/src/test_store.cpp
@@ -2,6 +2,8 @@
 
 #include <regex>
 #include <string>
+#include <thread>
+#include <vector>
 
 #include <gtest/gtest.h>
 
@@ -356,5 +358,98 @@ TEST_F(StoreFaultTest, RemoveFault) {
 }
 
 TEST_F(StoreFaultTest, RemoveFaultNotFound) { EXPECT_FALSE(store.remove_fault("bad-id")); }
+
+// ── HMAS tasks ────────────────────────────────────────────────────────────────
+
+class StoreHmasTest : public ::testing::Test {
+ protected:
+  Store store;
+};
+
+TEST_F(StoreHmasTest, GetHmasTaskReturnsOptional) {
+  HmasTask task;
+  task.id = "hmas-1";
+  task.brief_id = "brief-1";
+  task.layer = HmasLayer::L1_ComponentLead;
+  task.state = TaskState::Pending;
+  store.create_hmas_task(task);
+
+  auto result = store.get_hmas_task("hmas-1");
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result->id, "hmas-1");
+  EXPECT_EQ(result->state, TaskState::Pending);
+}
+
+TEST_F(StoreHmasTest, GetHmasTaskNotFound) {
+  auto result = store.get_hmas_task("nonexistent");
+  EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(StoreHmasTest, UpdateHmasTaskStateAndRecordEscalation) {
+  HmasTask task;
+  task.id = "hmas-2";
+  task.brief_id = "brief-2";
+  task.layer = HmasLayer::L2_ModuleLead;
+  task.state = TaskState::Pending;
+  store.create_hmas_task(task);
+
+  EscalationRecord rec;
+  rec.task_id = "hmas-2";
+  rec.reason = "timeout";
+  rec.escalated_at = now_iso8601();
+  rec.from_layer = HmasLayer::L2_ModuleLead;
+
+  bool ok = store.update_hmas_task_state_and_record_escalation("hmas-2", TaskState::Escalated, rec);
+  EXPECT_TRUE(ok);
+
+  auto updated = store.get_hmas_task("hmas-2");
+  ASSERT_TRUE(updated.has_value());
+  EXPECT_EQ(updated->state, TaskState::Escalated);
+  ASSERT_EQ(updated->escalations.size(), 1u);
+  EXPECT_EQ(updated->escalations[0].reason, "timeout");
+}
+
+// #155 — concurrent stress test: 4 threads simultaneously get and update the same HmasTask.
+TEST_F(StoreHmasTest, HmasTaskConcurrentGetAndUpdate) {
+  HmasTask task;
+  task.id = "stress-1";
+  task.brief_id = "brief-stress";
+  task.layer = HmasLayer::L3_TaskAgent;
+  task.state = TaskState::Pending;
+  store.create_hmas_task(task);
+
+  constexpr int kThreads = 4;
+  constexpr int kIterations = 100;
+  std::vector<std::thread> threads;
+  threads.reserve(kThreads * 2);
+
+  // 4 reader threads
+  for (int t = 0; t < kThreads; ++t) {
+    threads.emplace_back([&]() {
+      for (int i = 0; i < kIterations; ++i) {
+        auto got = store.get_hmas_task("stress-1");
+        // The task always exists; we just verify no data race or crash.
+        (void)got;
+      }
+    });
+  }
+
+  // 4 writer threads cycling through states
+  const TaskState states[] = {TaskState::InProgress, TaskState::Delegated, TaskState::Pending,
+                               TaskState::Completed};
+  for (int t = 0; t < kThreads; ++t) {
+    threads.emplace_back([&, t]() {
+      for (int i = 0; i < kIterations; ++i) {
+        store.update_hmas_task_state("stress-1", states[t % 4]);
+      }
+    });
+  }
+
+  for (auto& th : threads) th.join();
+
+  // After all updates, the task must still be accessible with no crash.
+  auto final_task = store.get_hmas_task("stress-1");
+  EXPECT_TRUE(final_task.has_value());
+}
 
 }  // namespace projectagamemnon::test

--- a/test/src/test_store.cpp
+++ b/test/src/test_store.cpp
@@ -437,7 +437,7 @@ TEST_F(StoreHmasTest, HmasTaskConcurrentGetAndUpdate) {
 
   // 4 writer threads cycling through states
   const TaskState states[] = {TaskState::InProgress, TaskState::Delegated, TaskState::Pending,
-                               TaskState::Completed};
+                              TaskState::Completed};
   for (int t = 0; t < kThreads; ++t) {
     threads.emplace_back([&, t]() {
       for (int i = 0; i < kIterations; ++i) {

--- a/test/src/test_store_edge_cases.cpp
+++ b/test/src/test_store_edge_cases.cpp
@@ -263,15 +263,49 @@ TEST_F(StoreEdgeCases, GetTaskWrongTeamId) {
   EXPECT_TRUE(not_found.is_null());
 }
 
-TEST_F(StoreEdgeCases, GetTaskEmptyTeamIdBypassesCheck) {
+// #222 — team_id scope enforcement on update_task
+TEST_F(StoreEdgeCases, UpdateTaskEmptyTeamIdReturnsNull) {
   auto team_result = store_.create_team({{"name", "t"}});
   std::string team_id = team_result["team"]["id"];
   auto task_result = store_.create_task(team_id, {{"subject", "s"}});
   std::string task_id = task_result["task"]["id"];
 
-  // Empty team_id skips team check, returns task by ID only
+  // Empty team_id must return null — cannot update without scoping to a team.
+  json result = store_.update_task("", task_id, {{"subject", "new"}});
+  EXPECT_TRUE(result.is_null());
+}
+
+TEST_F(StoreEdgeCases, UpdateTaskWrongTeamIdReturnsNull) {
+  auto team_result = store_.create_team({{"name", "t"}});
+  std::string team_id = team_result["team"]["id"];
+  auto task_result = store_.create_task(team_id, {{"subject", "s"}});
+  std::string task_id = task_result["task"]["id"];
+
+  json result = store_.update_task("wrong-team", task_id, {{"subject", "new"}});
+  EXPECT_TRUE(result.is_null());
+}
+
+TEST_F(StoreEdgeCases, GetTaskCorrectTeamIdReturnsTask) {
+  auto team_result = store_.create_team({{"name", "t"}});
+  std::string team_id = team_result["team"]["id"];
+  auto task_result = store_.create_task(team_id, {{"subject", "s"}});
+  std::string task_id = task_result["task"]["id"];
+
+  // Correct team_id must still find the task.
+  json result = store_.get_task(team_id, task_id);
+  EXPECT_FALSE(result.is_null());
+  EXPECT_EQ(result["id"], task_id);
+}
+
+TEST_F(StoreEdgeCases, GetTaskEmptyTeamIdEnforcesScope) {
+  auto team_result = store_.create_team({{"name", "t"}});
+  std::string team_id = team_result["team"]["id"];
+  auto task_result = store_.create_task(team_id, {{"subject", "s"}});
+  std::string task_id = task_result["task"]["id"];
+
+  // #222: empty team_id must return null — no longer a wildcard bypass.
   json found = store_.get_task("", task_id);
-  EXPECT_FALSE(found.is_null());
+  EXPECT_TRUE(found.is_null());
 }
 
 }  // namespace projectagamemnon::test

--- a/test/src/test_store_edge_cases.cpp
+++ b/test/src/test_store_edge_cases.cpp
@@ -208,6 +208,44 @@ TEST_F(StoreEdgeCases, GetAgentByNameEmptyName) {
   EXPECT_TRUE(store_.get_agent_by_name("").is_null());
 }
 
+// ── Null-json guards (#209) ───────────────────────────────────────────────────
+
+TEST_F(StoreEdgeCases, UpdateTaskNullJsonReturnsNull) {
+  auto team_result = store_.create_team({{"name", "guard-team"}});
+  std::string team_id = team_result["team"]["id"];
+  auto task_result = store_.create_task(team_id, {{"subject", "s"}});
+  std::string task_id = task_result["task"]["id"];
+
+  // nlohmann::json{} is a null json value — must not throw and must return null.
+  EXPECT_NO_THROW({
+    json result = store_.update_task(team_id, task_id, nlohmann::json{});
+    EXPECT_TRUE(result.is_null());
+  });
+}
+
+TEST_F(StoreEdgeCases, UpdateTaskNullJsonArray) {
+  auto team_result = store_.create_team({{"name", "guard-team2"}});
+  std::string team_id = team_result["team"]["id"];
+  auto task_result = store_.create_task(team_id, {{"subject", "s"}});
+  std::string task_id = task_result["task"]["id"];
+
+  // An array is not an object — must return null without throwing.
+  EXPECT_NO_THROW({
+    json result = store_.update_task(team_id, task_id, json::array());
+    EXPECT_TRUE(result.is_null());
+  });
+}
+
+TEST_F(StoreEdgeCases, UpdateAgentNullJsonReturnsNull) {
+  auto agent_result = store_.create_agent({{"name", "guard-agent"}});
+  std::string id = agent_result["id"];
+
+  EXPECT_NO_THROW({
+    json result = store_.update_agent(id, nlohmann::json{});
+    EXPECT_TRUE(result.is_null());
+  });
+}
+
 // ── Task team_id mismatch ─────────────────────────────────────────────────────
 
 TEST_F(StoreEdgeCases, GetTaskWrongTeamId) {

--- a/test/src/test_store_hydration.cpp
+++ b/test/src/test_store_hydration.cpp
@@ -419,4 +419,67 @@ TEST(HydrationTest, ConcurrentListAgentsOnlyFetchesOnce) {
   EXPECT_EQ(list_calls, 1);
 }
 
+// ── Write + Read Tests (#162) ─────────────────────────────────────────────────
+
+TEST(GitHub162Test, WriteToGitHubSucceedsAndReadsReturnSameData) {
+  auto mock = std::make_shared<MockGitHubClient>();
+  Store store(mock);
+
+  // Create agent
+  auto created = store.create_agent({{"name", "write-test"}, {"role", "worker"}});
+  std::string id = created["id"];
+
+  // Verify the data written to GitHub can be read back
+  auto retrieved = store.get_agent(id);
+  ASSERT_FALSE(retrieved.is_null());
+  EXPECT_EQ(retrieved["id"], id);
+  EXPECT_EQ(retrieved["name"], "write-test");
+  EXPECT_EQ(retrieved["role"], "worker");
+}
+
+TEST(GitHub162Test, GitHubNotFoundTriggsInMemoryFallback) {
+  auto mock = std::make_shared<MockGitHubClient>();
+  mock->fail_list_on_label = "agamemnon-agent";  // Simulate GitHub 404
+  Store store(mock);
+
+  // Create an agent — should succeed with in-memory storage
+  auto created = store.create_agent({{"name", "fallback-test"}, {"role", "worker"}});
+  std::string id = created["id"];
+
+  // Should still be readable from in-memory store despite GitHub failure
+  auto retrieved = store.get_agent(id);
+  ASSERT_FALSE(retrieved.is_null());
+  EXPECT_EQ(retrieved["id"], id);
+  EXPECT_EQ(retrieved["name"], "fallback-test");
+}
+
+TEST(GitHub162Test, RehydrateOnStartupPopulatesFromPaginatedList) {
+  auto mock = std::make_shared<MockGitHubClient>();
+  // Seed agents across multiple paginated results
+  json agent1 = sample_agent("id-page-1", "agent-one");
+  json agent2 = sample_agent("id-page-2", "agent-two");
+  json agent3 = sample_agent("id-page-3", "agent-three");
+  mock->seed_issues["agamemnon-agent"] = {
+      make_agent_issue(100, agent1),
+      make_agent_issue(101, agent2),
+      make_agent_issue(102, agent3),
+  };
+
+  Store store(mock);
+
+  // List should return all agents (simulating pagination handling)
+  auto result = store.list_agents();
+  ASSERT_TRUE(result.contains("agents"));
+  EXPECT_EQ(result["agents"].size(), 3u);
+
+  // Verify all agents are present
+  auto names = json::array();
+  for (const auto& agent : result["agents"]) {
+    names.push_back(agent["name"]);
+  }
+  EXPECT_NE(std::find(names.begin(), names.end(), json("agent-one")), names.end());
+  EXPECT_NE(std::find(names.begin(), names.end(), json("agent-two")), names.end());
+  EXPECT_NE(std::find(names.begin(), names.end(), json("agent-three")), names.end());
+}
+
 }  // namespace projectagamemnon::test

--- a/test/src/test_store_hydration.cpp
+++ b/test/src/test_store_hydration.cpp
@@ -4,6 +4,8 @@
 #include <algorithm>
 #include <memory>
 #include <string>
+#include <thread>
+#include <vector>
 
 #include <gtest/gtest.h>
 
@@ -395,67 +397,26 @@ TEST(IsolationTest, HydratedEntitiesVisibleToSubsequentReads) {
   EXPECT_EQ(result["name"], "seeded-agent");
 }
 
-// ── Write + Read Tests (#162) ─────────────────────────────────────────────────
-
-TEST(GitHub162Test, WriteToGitHubSucceedsAndReadsReturnSameData) {
+// #161 — concurrent list_agents from 2 threads must trigger exactly ONE GitHub fetch.
+TEST(HydrationTest, ConcurrentListAgentsOnlyFetchesOnce) {
   auto mock = std::make_shared<MockGitHubClient>();
-  Store store(mock);
-
-  // Create agent
-  auto created = store.create_agent({{"name", "write-test"}, {"role", "worker"}});
-  std::string id = created["id"];
-
-  // Verify the data written to GitHub can be read back
-  auto retrieved = store.get_agent(id);
-  ASSERT_FALSE(retrieved.is_null());
-  EXPECT_EQ(retrieved["id"], id);
-  EXPECT_EQ(retrieved["name"], "write-test");
-  EXPECT_EQ(retrieved["role"], "worker");
-}
-
-TEST(GitHub162Test, GitHubNotFoundTriggsInMemoryFallback) {
-  auto mock = std::make_shared<MockGitHubClient>();
-  mock->fail_list_on_label = "agamemnon-agent";  // Simulate GitHub 404
-  Store store(mock);
-
-  // Create an agent — should succeed with in-memory storage
-  auto created = store.create_agent({{"name", "fallback-test"}, {"role", "worker"}});
-  std::string id = created["id"];
-
-  // Should still be readable from in-memory store despite GitHub failure
-  auto retrieved = store.get_agent(id);
-  ASSERT_FALSE(retrieved.is_null());
-  EXPECT_EQ(retrieved["id"], id);
-  EXPECT_EQ(retrieved["name"], "fallback-test");
-}
-
-TEST(GitHub162Test, RehydrateOnStartupPopulatesFromPaginatedList) {
-  auto mock = std::make_shared<MockGitHubClient>();
-  // Seed agents across multiple paginated results
-  json agent1 = sample_agent("id-page-1", "agent-one");
-  json agent2 = sample_agent("id-page-2", "agent-two");
-  json agent3 = sample_agent("id-page-3", "agent-three");
-  mock->seed_issues["agamemnon-agent"] = {
-      make_agent_issue(100, agent1),
-      make_agent_issue(101, agent2),
-      make_agent_issue(102, agent3),
-  };
+  mock->seed_issues["agamemnon-agent"] = {make_agent_issue(1, sample_agent("id-concurrent"))};
 
   Store store(mock);
 
-  // List should return all agents (simulating pagination handling)
-  auto result = store.list_agents();
-  ASSERT_TRUE(result.contains("agents"));
-  EXPECT_EQ(result["agents"].size(), 3u);
-
-  // Verify all agents are present
-  auto names = json::array();
-  for (const auto& agent : result["agents"]) {
-    names.push_back(agent["name"]);
+  constexpr int kThreads = 2;
+  std::vector<std::thread> threads;
+  threads.reserve(kThreads);
+  for (int i = 0; i < kThreads; ++i) {
+    threads.emplace_back([&]() { store.list_agents(); });
   }
-  EXPECT_NE(std::find(names.begin(), names.end(), json("agent-one")), names.end());
-  EXPECT_NE(std::find(names.begin(), names.end(), json("agent-two")), names.end());
-  EXPECT_NE(std::find(names.begin(), names.end(), json("agent-three")), names.end());
+  for (auto& t : threads) t.join();
+
+  long list_calls = std::count_if(mock->calls.begin(), mock->calls.end(), [](const auto& c) {
+    return c.method == "list_issues" && c.arg1 == "agamemnon-agent";
+  });
+  // call_once guarantees exactly one fetch regardless of concurrent callers.
+  EXPECT_EQ(list_calls, 1);
 }
 
 }  // namespace projectagamemnon::test


### PR DESCRIPTION
Closes #155. Closes #161. Closes #209. Closes #222. Closes #340.

## Summary

MEDIUM Wave 2 bundle: 5 atomic commits on `src/store.cpp` for thread-safety and correctness. Bundled in one PR because all 5 touch the same file and cannot run as independent parallel agents.

| # | What | Risk |
|---|---|---|
| 155 | HmasTask thread-safety: value-return (`std::optional`) + atomic update method | HIGH |
| 161 | `call_once` hydration; release mutex during GitHub HTTP fetch | MEDIUM |
| 209 | Null-json guard in `update_task` / `update_agent` — tests added | LOW |
| 222 | Enforce non-empty `team_id` scope on `get_task` / `update_task` | LOW |
| 340 | Deterministic pagination order via sorted vector slice | LOW |

Each commit is bisectable via `git revert <sha>`.

## Key design decisions

**#155**: `get_hmas_task` now returns `std::optional<HmasTask>` (value copy under shared lock). A new `update_hmas_task_state_and_record_escalation` method atomically mutates state and appends an escalation under unique lock. `src/routes.cpp` updated to use the `optional` API.

**#161**: `ensure_*_loaded_()` functions now use `std::atomic<bool>` flags (fast-path, no lock) + `std::call_once` (single fetch across all racing threads). The lock is acquired *inside* the once lambda, after the HTTP fetch completes. All public methods now call `ensure_*_loaded_()` **before** acquiring `mutex_` to prevent lock inversion.

**#222**: Empty `team_id` is now an error rather than a wildcard bypass. Existing tests that documented the old bypass behavior have been updated to assert the new contract.

**#340**: All list methods collect into `std::vector<pair<string,V>>`, `std::sort` by key, then slice `[offset, offset+limit)` — all under the mutex.

## Verification (CI)

- TSan preset will exercise #155 + #161 race detection
- Existing unit + integration tests pass (updated where behavior changed for #222)
- New tests added per issue in `test_store.cpp`, `test_store_edge_cases.cpp`, `test_store_hydration.cpp`, `test_pagination.cpp`

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>