### PR TITLE
fix(mock): add MockGitHubClient::fail_list_on_label field (unblocks main CI)

### DIFF
--- a/include/projectagamemnon/github_client.hpp
+++ b/include/projectagamemnon/github_client.hpp
@@ -43,6 +43,10 @@ class MockGitHubClient : public IGitHubClient {
 
   std::vector<json> list_issues(std::string_view label) override {
     calls.push_back({"list_issues", std::string(label), {}, {}});
+    if (!fail_list_on_label.empty() && label == fail_list_on_label) {
+      throw std::runtime_error("MockGitHubClient: simulated list_issues failure for label '" +
+                               fail_list_on_label + "'");
+    }
     auto it = seed_issues.find(std::string(label));
     if (it == seed_issues.end()) return {};
     return it->second;
@@ -71,6 +75,10 @@ class MockGitHubClient : public IGitHubClient {
 
   /// Seed data: map label -> list of full issue JSON objects (with "body" field).
   std::unordered_map<std::string, std::vector<json>> seed_issues;
+
+  /// When non-empty, list_issues() throws std::runtime_error whenever called
+  /// with this label (simulates a GitHub 404 / network failure for that label).
+  std::string fail_list_on_label;
 
   std::vector<Call> calls;
   std::unordered_map<std::string, json> created_issues;


### PR DESCRIPTION
## Summary

Adds the missing `fail_list_on_label` field to `MockGitHubClient` that was referenced by a test added in #386 but never declared, causing a `clang-diagnostic-error` that broke every build/test/coverage check on `main`.

## Root cause

`test/src/test_store_hydration.cpp:418` does:
```cpp
mock->fail_list_on_label = "agamemnon-agent";
```
But `MockGitHubClient` (in `include/projectagamemnon/github_client.hpp`) did not declare any such member, so every translation unit that includes the header failed to compile.

## Fix

- Adds `std::string fail_list_on_label` (default empty) as a public member.
- Wires `list_issues()` to throw `std::runtime_error` when called with the matching label. `Store::list_*` already wraps `gh_->list_issues(...)` in a `try/catch(const std::exception&)` block and falls back to in-memory storage, which is exactly what the `GitHubNotFoundTriggsInMemoryFallback` test asserts.

## Impact

- Unblocks Bucket-E failures on open PRs #387, #388, #389 (and others queued).
- No behavior change for callers that don't set the field (empty string short-circuits the throw).
- Diff is laser-focused: 8 added lines, single file (`include/projectagamemnon/github_client.hpp`).

## Test plan

- [ ] Coverage / build / clang-tidy / unit-tests / integration-tests go green on this PR.
- [ ] Once merged, rebasing #387, #388, #389 should re-green their CI.

Generated with [Claude Code](https://claude.com/claude-code)