### PR TITLE
build(deps): pin nats.c FetchContent GIT_TAG to commit SHA (#252)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,8 +32,7 @@ include(FetchContent)
 FetchContent_Declare(
   nats_c
   GIT_REPOSITORY https://github.com/nats-io/nats.c.git
-  GIT_TAG        v3.12.0
-  GIT_SHALLOW    TRUE
+  GIT_TAG        aed20fe4227a99c6ae3dc97fc35469cc24f081e7 # v3.12.0
 )
 set(NATS_BUILD_STREAMING OFF CACHE BOOL "" FORCE)
 set(NATS_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)


### PR DESCRIPTION
Closes #252.

## Summary
- Replaces `GIT_TAG=v3.12.0` with the full commit SHA (`aed20fe4227a99c6ae3dc97fc35469cc24f081e7`) for that tag
- Removes `GIT_SHALLOW TRUE` which is incompatible with fetching by full commit SHA (shallow clones cannot fetch arbitrary commits)
- Human-readable tag preserved in a comment: `# v3.12.0`
- Makes the pin cryptographically verifiable and immune to upstream tag force-pushes

## Test plan
- [ ] FetchContent still resolves nats.c successfully
- [ ] Build proceeds normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)