### PR TITLE
docs(security): formalize gitleaks allowlist quarterly review process

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# CODEOWNERS — HomericIntelligence/ProjectAgamemnon
+#
+# Each line is a pattern followed by one or more owners.
+# Owners are notified and must approve PRs that touch matching paths.
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Security-sensitive allowlist: any change to the gitleaks configuration
+# requires review from the security owner to prevent inadvertently silencing
+# real secret detections.
+.gitleaks.toml @mvillmow
+
+# Security policy documents live alongside the gitleaks config review cadence.
+docs/security/ @mvillmow

--- a/.github/workflows/gitleaks-audit.yml
+++ b/.github/workflows/gitleaks-audit.yml
@@ -1,0 +1,38 @@
+name: Gitleaks Allowlist Audit
+
+on:
+  schedule:
+    # Run on the 1st of every month at 06:00 UTC
+    - cron: "0 6 1 * *"
+  push:
+    branches: [main]
+    paths:
+      - ".gitleaks.toml"
+  workflow_dispatch: {}
+
+jobs:
+  audit:
+    name: Gitleaks audit scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run gitleaks audit
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: detect --config .gitleaks.toml --report-format json --report-path gitleaks-report.json
+
+      - name: Upload report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gitleaks-report-${{ github.run_id }}
+          path: gitleaks-report.json
+          retention-days: 90

--- a/docs/security/gitleaks-allowlist-audit.md
+++ b/docs/security/gitleaks-allowlist-audit.md
@@ -1,0 +1,74 @@
+# Gitleaks Allowlist Quarterly Audit
+
+## Purpose
+
+The `.gitleaks.toml` file allowlists specific paths and regex patterns that are known
+to produce false positives (test fixtures, example keys, localhost URLs).  As the
+repository grows, new paths or patterns may be added without review, inadvertently
+silencing real secret detections.  This document prescribes the mandatory quarterly
+review that keeps the allowlist accurate and minimal.
+
+## Cadence
+
+| Quarter | Target date |
+|---------|-------------|
+| Q1      | First week of January  |
+| Q2      | First week of April    |
+| Q3      | First week of July     |
+| Q4      | First week of October  |
+
+## Reviewer
+
+`@mvillmow` is the designated allowlist owner (see `.github/CODEOWNERS`).  If a
+dedicated security team is formed in the future, transfer ownership to
+`@HomericIntelligence/security` in both `CODEOWNERS` and this document.
+
+## Audit procedure
+
+1. **Run gitleaks in audit mode** against the full commit history:
+
+   ```bash
+   gitleaks detect \
+     --source . \
+     --config .gitleaks.toml \
+     --report-format json \
+     --report-path /tmp/gitleaks-audit-$(date +%Y-Q%q).json \
+     --no-git false
+   ```
+
+   > Tip: The monthly CI job (`.github/workflows/gitleaks-audit.yml`) uploads this
+   > report as a workflow artifact — download the latest artifact instead of running
+   > locally if preferred.
+
+2. **Review the JSON report** for any findings that are suppressed by allowlist paths
+   or regexes.  For each suppressed match, confirm one of:
+   - It is genuinely a test fixture or generated file (path allowlist is correct).
+   - It matches a well-known placeholder pattern (regex allowlist is correct).
+   - It would be flagged by the base ruleset if the allowlist were removed — if so,
+     open a security incident immediately rather than extending the allowlist.
+
+3. **Prune stale entries** — if a previously allowlisted path no longer exists in the
+   repository, remove it from `.gitleaks.toml`.
+
+4. **Document findings** — open a GitHub Issue tagged `security` and `gitleaks-audit`
+   summarising:
+   - Number of findings reviewed
+   - Any stale paths removed
+   - Any new paths or patterns proposed (with justification)
+   - Sign-off by the reviewer
+
+5. **Any change to `.gitleaks.toml`** must be reviewed by the CODEOWNERS before merge.
+
+## Automated monthly scan
+
+`.github/workflows/gitleaks-audit.yml` runs on the 1st of each month and on every
+push to `main`.  It uploads the gitleaks JSON report as a workflow artifact named
+`gitleaks-report-YYYY-MM`.  Download the artifact from the Actions tab to obtain the
+latest scan results without running locally.
+
+## References
+
+- [Gitleaks documentation](https://github.com/gitleaks/gitleaks)
+- Current allowlist configuration: `.gitleaks.toml`
+- Origin issue: HomericIntelligence/ProjectAgamemnon#268
+- Follow-up from: HomericIntelligence/ProjectAgamemnon#66


### PR DESCRIPTION
Closes #268.

## Summary

- **CODEOWNERS**: `.gitleaks.toml` and `docs/security/` now require `@mvillmow` approval on all PRs (no `HomericIntelligence/security` team exists — only `Developers` team found via API; defaulted to `@mvillmow` per instructions)
- **docs/security/gitleaks-allowlist-audit.md**: written policy with quarterly cadence (Q1–Q4 target dates), step-by-step audit procedure, reviewer responsibilities, and pruning guidance
- **gitleaks-audit.yml**: scheduled CI job runs on the 1st of each month at 06:00 UTC and on pushes to `main` touching `.gitleaks.toml`; uploads the gitleaks JSON report as a 90-day artifact

`.gitleaks.toml` itself is unchanged — this PR is process-only.

## Test plan

- [ ] CODEOWNERS file is well-formed: `gh api repos/HomericIntelligence/ProjectAgamemnon/contents/.github/CODEOWNERS`
- [ ] Scheduled workflow appears in Actions tab after merge
- [ ] Trigger `workflow_dispatch` manually to verify the gitleaks scan runs and artifact is uploaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)