### PR TITLE
build(cmake): add asan preset (#220)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -77,18 +77,75 @@ jobs:
           BUILD_TYPE: ${{ matrix.build_type }}
         run: ctest --preset "$BUILD_TYPE" --timeout 120 --parallel 4
 
+  # AddressSanitizer job -- catches dangling-reference / use-after-free regressions
+  # introduced by incorrect lambda captures in routes.cpp (see #220).
+  asan:
+    name: ubuntu-24.04-clang-asan
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Restore Conan cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.conan2
+          key: conan-${{ runner.os }}-asan-${{ hashFiles('conanfile.py') }}
+          restore-keys: |
+            conan-${{ runner.os }}-asan-
+            conan-${{ runner.os }}-
+
+      - name: Restore FetchContent cache
+        uses: actions/cache@v4
+        with:
+          path: build/_deps
+          key: fetchcontent-${{ runner.os }}-clang-asan-${{ hashFiles('CMakeLists.txt', 'cmake/**/*.cmake') }}
+          restore-keys: |
+            fetchcontent-${{ runner.os }}-clang-asan-
+            fetchcontent-${{ runner.os }}-clang-
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ninja-build clang
+          pip install conan
+          conan profile detect --force
+
+      - name: Install Conan dependencies
+        run: |
+          conan install . --build=missing -s build_type=Debug \
+            --output-folder build/asan
+
+      - name: Configure (clang, asan)
+        run: |
+          export CC=clang CXX=clang++
+          cmake --preset asan
+
+      - name: Build
+        run: cmake --build --preset asan
+
+      - name: Test
+        env:
+          ASAN_OPTIONS: halt_on_error=1:detect_leaks=1
+        run: ctest --preset asan --timeout 120 --parallel 4
+
   check-all:
     name: All Build/Test Checks
     runs-on: ubuntu-24.04
-    needs: [build-test]
+    needs: [build-test, asan]
     if: always()
     steps:
       - name: Check all jobs passed
         env:
           BUILD_TEST_RESULT: ${{ needs.build-test.result }}
+          ASAN_RESULT: ${{ needs.asan.result }}
         run: |
           if [ "$BUILD_TEST_RESULT" != "success" ]; then
             echo "build-test failed"
+            exit 1
+          fi
+          if [ "$ASAN_RESULT" != "success" ]; then
+            echo "asan failed"
             exit 1
           fi
           echo "All checks passed"

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -53,6 +53,16 @@
       "cacheVariables": {
         "ProjectAgamemnon_WARNINGS_AS_ERRORS": "ON"
       }
+    },
+    {
+      "name": "asan",
+      "displayName": "AddressSanitizer",
+      "inherits": "base",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "ProjectAgamemnon_BUILD_TESTING": "ON",
+        "ProjectAgamemnon_ENABLE_ASAN": "ON"
+      }
     }
   ],
   "buildPresets": [
@@ -71,6 +81,10 @@
     {
       "name": "ci",
       "configurePreset": "ci"
+    },
+    {
+      "name": "asan",
+      "configurePreset": "asan"
     }
   ],
   "testPresets": [
@@ -98,6 +112,13 @@
     {
       "name": "coverage",
       "configurePreset": "coverage",
+      "output": {
+        "outputOnFailure": true
+      }
+    },
+    {
+      "name": "asan",
+      "configurePreset": "asan",
       "output": {
         "outputOnFailure": true
       }

--- a/cmake/StandardSettings.cmake
+++ b/cmake/StandardSettings.cmake
@@ -1,10 +1,20 @@
 option(${PROJECT_NAME}_BUILD_TESTING "Build tests" ON)
 option(${PROJECT_NAME}_ENABLE_DOXYGEN "Enable Doxygen documentation" OFF)
 option(${PROJECT_NAME}_ENABLE_SANITIZERS "Enable sanitizers" OFF)
+option(${PROJECT_NAME}_ENABLE_ASAN "Enable AddressSanitizer (ASAN)" OFF)
 option(${PROJECT_NAME}_ENABLE_COVERAGE "Enable coverage reporting" OFF)
 option(${PROJECT_NAME}_WARNINGS_AS_ERRORS "Treat warnings as errors" ON)
 
 if(${PROJECT_NAME}_ENABLE_COVERAGE)
   add_compile_options(-O0 --coverage)
   add_link_options(--coverage)
+endif()
+
+# AddressSanitizer -- catches dangling-reference / use-after-free regressions.
+# Intended to guard against lambda captures of raw references in routes.cpp
+# (see register_routes comment: raw Store*/NatsPublisher* are captured by value
+# precisely to avoid this UB).
+if(${PROJECT_NAME}_ENABLE_ASAN)
+  add_compile_options(-fsanitize=address -fno-omit-frame-pointer -O1 -g)
+  add_link_options(-fsanitize=address)
 endif()


### PR DESCRIPTION
Closes #220.

## Summary
- Adds `ProjectAgamemnon_ENABLE_ASAN` CMake option to `cmake/StandardSettings.cmake` with flags `-fsanitize=address -fno-omit-frame-pointer -O1 -g`
- Adds `asan` configure/build/test presets to `CMakePresets.json` (mirrors the existing preset structure)
- Adds a dedicated `asan` CI job in `.github/workflows/build-test.yml` (clang, ubuntu-24.04) and wires it into `check-all`

Intended to catch regressions where a route handler lambda captures a dangling reference instead of the raw `Store*`/`NatsPublisher*` pointer (see `routes.cpp:186-195` comment).

## Test plan
- [ ] `cmake --preset asan` configures cleanly
- [ ] `cmake --build --preset asan` builds
- [ ] `ctest --preset asan` runs without false positives