### PR TITLE
feat(github-client): retry with backoff on transient failures (#163)

### DIFF
--- a/include/projectagamemnon/github_client.hpp
+++ b/include/projectagamemnon/github_client.hpp
@@ -89,6 +89,16 @@ class MockGitHubClient : public IGitHubClient {
 
 /// Real GitHub client using libcurl to call the GitHub REST API v3.
 /// Requires GITHUB_TOKEN env var and a repo in "owner/repo" format.
+///
+/// Retry contract: do_get / do_post / do_patch automatically retry up to
+/// kMaxRetries times with exponential backoff (1 s -> 2 s -> 4 s) on:
+///   - transport errors (CURLcode != CURLE_OK)
+///   - HTTP 5xx responses
+///   - HTTP 429 responses (honors the Retry-After header when present)
+///
+/// 4xx responses other than 429 are NOT retried; they indicate client bugs.
+/// Callers may observe up to ~7 seconds of total elapsed time per call in the
+/// worst case (3 retries x (1 + 2 + 4) s backoff ceiling).
 class CurlGitHubClient : public IGitHubClient {
  public:
   CurlGitHubClient(std::string repo, std::string token);
@@ -100,14 +110,27 @@ class CurlGitHubClient : public IGitHubClient {
   void update_issue_body(std::string_view issue_number, std::string_view body) override;
   void close_issue(std::string_view issue_number) override;
 
- private:
-  std::string repo_;
-  std::string token_;
+  // Retry / backoff constants (exposed for testing).
+  static constexpr int kMaxRetries = 3;
+  static constexpr int kBaseRetryMs = 1000;  // 1 s -> 2 s -> 4 s
 
+  /// Parsed result of a single HTTP attempt (also used as the retry unit).
   struct Response {
     long status{0};
     std::string body;
+    std::string retry_after;  // raw value of Retry-After response header, if any
   };
+
+  /// Execute op with retry / exponential-backoff on transient failures.
+  /// sleep_fn is called instead of std::this_thread::sleep_for (injectable for tests).
+  /// label is used only for log messages (e.g. "GET", "POST").
+  static Response with_retry(const std::string& label, const std::string& url,
+                             std::function<Response()> op,
+                             std::function<void(int /*ms*/)> sleep_fn = {});
+
+ private:
+  std::string repo_;
+  std::string token_;
 
   Response do_get(const std::string& url) const;
   Response do_post(const std::string& url, const std::string& payload) const;

--- a/src/github_client.cpp
+++ b/src/github_client.cpp
@@ -1,9 +1,13 @@
 #include "projectagamemnon/github_client.hpp"
 
+#include <algorithm>
+#include <cctype>
+#include <chrono>
 #include <curl/curl.h>
 #include <iostream>
 #include <stdexcept>
 #include <string>
+#include <thread>
 #include <vector>
 
 namespace projectagamemnon {
@@ -14,6 +18,34 @@ size_t write_callback(char* ptr, size_t size, size_t nmemb, void* userdata) {
   auto* buf = static_cast<std::string*>(userdata);
   buf->append(ptr, size * nmemb);
   return size * nmemb;
+}
+
+/// Header callback — captures the value of the Retry-After header.
+size_t header_callback(char* buffer, size_t size, size_t nitems, void* userdata) {
+  auto* retry_after = static_cast<std::string*>(userdata);
+  std::string line(buffer, size * nitems);
+
+  // Header lines look like "Retry-After: 30\r\n"
+  static constexpr std::string_view kPrefix = "retry-after:";
+  std::string lower = line;
+  std::transform(lower.begin(), lower.end(), lower.begin(),
+                 [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+  if (lower.rfind(kPrefix, 0) == 0) {
+    std::string val = line.substr(kPrefix.size());
+    // Strip leading/trailing whitespace and CRLF.
+    auto start = val.find_first_not_of(" \t\r\n");
+    auto end = val.find_last_not_of(" \t\r\n");
+    if (start != std::string::npos) {
+      *retry_after = val.substr(start, end - start + 1);
+    }
+  }
+  return size * nitems;
+}
+
+/// Returns true when the HTTP status should be retried.
+bool is_transient_status(long status) noexcept {
+  // 429 Too Many Requests and all 5xx Server Errors are transient.
+  return status == 429 || (status >= 500 && status < 600);
 }
 
 }  // namespace
@@ -27,100 +59,192 @@ CurlGitHubClient::CurlGitHubClient(std::string repo, std::string token)
 
 CurlGitHubClient::~CurlGitHubClient() { curl_global_cleanup(); }
 
-CurlGitHubClient::Response CurlGitHubClient::do_get(const std::string& url) const {
-  CURL* curl = curl_easy_init();
-  if (!curl) throw std::runtime_error("curl_easy_init failed");
+// ── with_retry ────────────────────────────────────────────────────────────────
 
-  Response resp;
-  struct curl_slist* headers = nullptr;
-  std::string auth_header = "Authorization: Bearer " + token_;
-  headers = curl_slist_append(headers, "Accept: application/vnd.github+json");
-  headers = curl_slist_append(headers, "X-GitHub-Api-Version: 2022-11-28");
-  headers = curl_slist_append(headers, auth_header.c_str());
-  headers = curl_slist_append(headers, "User-Agent: ProjectAgamemnon/1.0");
+// static
+CurlGitHubClient::Response CurlGitHubClient::with_retry(const std::string& label,
+                                                        const std::string& url,
+                                                        std::function<Response()> op,
+                                                        std::function<void(int)> sleep_fn) {
+  // Default sleep implementation: real wall-clock sleep.
+  if (!sleep_fn) {
+    sleep_fn = [](int ms) { std::this_thread::sleep_for(std::chrono::milliseconds(ms)); };
+  }
 
-  curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
-  curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
-  curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_callback);
-  curl_easy_setopt(curl, CURLOPT_WRITEDATA, &resp.body);
-  curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+  int delay_ms = kBaseRetryMs;
+  for (int attempt = 1; attempt <= kMaxRetries; ++attempt) {
+    Response resp;
+    bool transport_error = false;
+    std::string transport_what;
 
-  CURLcode rc = curl_easy_perform(curl);
-  if (rc == CURLE_OK) curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &resp.status);
+    try {
+      resp = op();
+    } catch (const std::exception& e) {
+      transport_error = true;
+      transport_what = e.what();
+    }
 
-  curl_slist_free_all(headers);
-  curl_easy_cleanup(curl);
+    if (transport_error) {
+      if (attempt == kMaxRetries) {
+        throw std::runtime_error(transport_what);
+      }
+      std::cerr << "[agamemnon] GitHub " << label << " " << url << " transport error (attempt "
+                << attempt << "/" << kMaxRetries << "): " << transport_what << " — retrying in "
+                << delay_ms << " ms\n";
+      sleep_fn(delay_ms);
+      delay_ms *= 2;
+      continue;
+    }
 
-  if (rc != CURLE_OK)
-    throw std::runtime_error(std::string("curl GET failed: ") + curl_easy_strerror(rc));
+    if (!is_transient_status(resp.status)) {
+      // Success or a non-retryable error (4xx other than 429).
+      return resp;
+    }
 
-  return resp;
+    if (attempt == kMaxRetries) {
+      std::cerr << "[agamemnon] GitHub " << label << " " << url << " HTTP " << resp.status
+                << " — all retries exhausted\n";
+      return resp;
+    }
+
+    // Determine sleep duration: honor Retry-After if present, else exponential backoff.
+    int sleep_ms = delay_ms;
+    if (!resp.retry_after.empty()) {
+      try {
+        int secs = std::stoi(resp.retry_after);
+        if (secs > 0) {
+          sleep_ms = secs * 1000;
+        }
+      } catch (...) {
+        // Ignore malformed Retry-After; fall back to backoff.
+      }
+    }
+
+    std::cerr << "[agamemnon] GitHub " << label << " " << url << " HTTP " << resp.status
+              << " (attempt " << attempt << "/" << kMaxRetries << ") — retrying in " << sleep_ms
+              << " ms\n";
+    sleep_fn(sleep_ms);
+    delay_ms *= 2;
+  }
+
+  // Unreachable, but satisfies compiler.
+  return {};
 }
+
+// ── do_get ────────────────────────────────────────────────────────────────────
+
+CurlGitHubClient::Response CurlGitHubClient::do_get(const std::string& url) const {
+  return CurlGitHubClient::with_retry("GET", url, [&]() -> Response {
+    CURL* curl = curl_easy_init();
+    if (!curl) throw std::runtime_error("curl_easy_init failed");
+
+    Response resp;
+    struct curl_slist* headers = nullptr;
+    std::string auth_header = "Authorization: Bearer " + token_;
+    headers = curl_slist_append(headers, "Accept: application/vnd.github+json");
+    headers = curl_slist_append(headers, "X-GitHub-Api-Version: 2022-11-28");
+    headers = curl_slist_append(headers, auth_header.c_str());
+    headers = curl_slist_append(headers, "User-Agent: ProjectAgamemnon/1.0");
+
+    curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_callback);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &resp.body);
+    curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, header_callback);
+    curl_easy_setopt(curl, CURLOPT_HEADERDATA, &resp.retry_after);
+    curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+
+    CURLcode rc = curl_easy_perform(curl);
+    if (rc == CURLE_OK) curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &resp.status);
+
+    curl_slist_free_all(headers);
+    curl_easy_cleanup(curl);
+
+    if (rc != CURLE_OK)
+      throw std::runtime_error(std::string("curl GET failed: ") + curl_easy_strerror(rc));
+
+    return resp;
+  });
+}
+
+// ── do_post ───────────────────────────────────────────────────────────────────
 
 CurlGitHubClient::Response CurlGitHubClient::do_post(const std::string& url,
                                                      const std::string& payload) const {
-  CURL* curl = curl_easy_init();
-  if (!curl) throw std::runtime_error("curl_easy_init failed");
+  return CurlGitHubClient::with_retry("POST", url, [&]() -> Response {
+    CURL* curl = curl_easy_init();
+    if (!curl) throw std::runtime_error("curl_easy_init failed");
 
-  Response resp;
-  struct curl_slist* headers = nullptr;
-  std::string auth_header = "Authorization: Bearer " + token_;
-  headers = curl_slist_append(headers, "Accept: application/vnd.github+json");
-  headers = curl_slist_append(headers, "X-GitHub-Api-Version: 2022-11-28");
-  headers = curl_slist_append(headers, auth_header.c_str());
-  headers = curl_slist_append(headers, "Content-Type: application/json");
-  headers = curl_slist_append(headers, "User-Agent: ProjectAgamemnon/1.0");
+    Response resp;
+    struct curl_slist* headers = nullptr;
+    std::string auth_header = "Authorization: Bearer " + token_;
+    headers = curl_slist_append(headers, "Accept: application/vnd.github+json");
+    headers = curl_slist_append(headers, "X-GitHub-Api-Version: 2022-11-28");
+    headers = curl_slist_append(headers, auth_header.c_str());
+    headers = curl_slist_append(headers, "Content-Type: application/json");
+    headers = curl_slist_append(headers, "User-Agent: ProjectAgamemnon/1.0");
 
-  curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
-  curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
-  curl_easy_setopt(curl, CURLOPT_POSTFIELDS, payload.c_str());
-  curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_callback);
-  curl_easy_setopt(curl, CURLOPT_WRITEDATA, &resp.body);
+    curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, payload.c_str());
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_callback);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &resp.body);
+    curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, header_callback);
+    curl_easy_setopt(curl, CURLOPT_HEADERDATA, &resp.retry_after);
 
-  CURLcode rc = curl_easy_perform(curl);
-  if (rc == CURLE_OK) curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &resp.status);
+    CURLcode rc = curl_easy_perform(curl);
+    if (rc == CURLE_OK) curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &resp.status);
 
-  curl_slist_free_all(headers);
-  curl_easy_cleanup(curl);
+    curl_slist_free_all(headers);
+    curl_easy_cleanup(curl);
 
-  if (rc != CURLE_OK)
-    throw std::runtime_error(std::string("curl POST failed: ") + curl_easy_strerror(rc));
+    if (rc != CURLE_OK)
+      throw std::runtime_error(std::string("curl POST failed: ") + curl_easy_strerror(rc));
 
-  return resp;
+    return resp;
+  });
 }
+
+// ── do_patch ──────────────────────────────────────────────────────────────────
 
 CurlGitHubClient::Response CurlGitHubClient::do_patch(const std::string& url,
                                                       const std::string& payload) const {
-  CURL* curl = curl_easy_init();
-  if (!curl) throw std::runtime_error("curl_easy_init failed");
+  return CurlGitHubClient::with_retry("PATCH", url, [&]() -> Response {
+    CURL* curl = curl_easy_init();
+    if (!curl) throw std::runtime_error("curl_easy_init failed");
 
-  Response resp;
-  struct curl_slist* headers = nullptr;
-  std::string auth_header = "Authorization: Bearer " + token_;
-  headers = curl_slist_append(headers, "Accept: application/vnd.github+json");
-  headers = curl_slist_append(headers, "X-GitHub-Api-Version: 2022-11-28");
-  headers = curl_slist_append(headers, auth_header.c_str());
-  headers = curl_slist_append(headers, "Content-Type: application/json");
-  headers = curl_slist_append(headers, "User-Agent: ProjectAgamemnon/1.0");
+    Response resp;
+    struct curl_slist* headers = nullptr;
+    std::string auth_header = "Authorization: Bearer " + token_;
+    headers = curl_slist_append(headers, "Accept: application/vnd.github+json");
+    headers = curl_slist_append(headers, "X-GitHub-Api-Version: 2022-11-28");
+    headers = curl_slist_append(headers, auth_header.c_str());
+    headers = curl_slist_append(headers, "Content-Type: application/json");
+    headers = curl_slist_append(headers, "User-Agent: ProjectAgamemnon/1.0");
 
-  curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
-  curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
-  curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "PATCH");
-  curl_easy_setopt(curl, CURLOPT_POSTFIELDS, payload.c_str());
-  curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_callback);
-  curl_easy_setopt(curl, CURLOPT_WRITEDATA, &resp.body);
+    curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+    curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "PATCH");
+    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, payload.c_str());
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_callback);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &resp.body);
+    curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, header_callback);
+    curl_easy_setopt(curl, CURLOPT_HEADERDATA, &resp.retry_after);
 
-  CURLcode rc = curl_easy_perform(curl);
-  if (rc == CURLE_OK) curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &resp.status);
+    CURLcode rc = curl_easy_perform(curl);
+    if (rc == CURLE_OK) curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &resp.status);
 
-  curl_slist_free_all(headers);
-  curl_easy_cleanup(curl);
+    curl_slist_free_all(headers);
+    curl_easy_cleanup(curl);
 
-  if (rc != CURLE_OK)
-    throw std::runtime_error(std::string("curl PATCH failed: ") + curl_easy_strerror(rc));
+    if (rc != CURLE_OK)
+      throw std::runtime_error(std::string("curl PATCH failed: ") + curl_easy_strerror(rc));
 
-  return resp;
+    return resp;
+  });
 }
+
+// ── Public API ────────────────────────────────────────────────────────────────
 
 std::vector<json> CurlGitHubClient::list_issues(std::string_view label) {
   std::vector<json> results;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -29,6 +29,7 @@ add_executable(${PROJECT_NAME}_tests
   src/test_orchestrator.cpp
   src/test_planning_breakdown.cpp
   src/test_state_machine.cpp
+  src/test_github_client.cpp
 )
 
 target_compile_features(${PROJECT_NAME}_tests PRIVATE cxx_std_20)

--- a/test/src/test_github_client.cpp
+++ b/test/src/test_github_client.cpp
@@ -1,0 +1,246 @@
+#include "projectagamemnon/github_client.hpp"
+
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+// Tests for CurlGitHubClient::with_retry().
+//
+// All tests inject a no-op sleep function so the suite runs in milliseconds
+// without requiring a live network connection or GitHub token.
+
+namespace projectagamemnon::test {
+
+using Response = CurlGitHubClient::Response;
+
+// Helper: build a no-op sleep function and a counter of how many times it was called.
+struct SleepSpy {
+  int calls{0};
+  std::vector<int> delays;
+
+  std::function<void(int)> fn() {
+    return [this](int ms) {
+      ++calls;
+      delays.push_back(ms);
+    };
+  }
+};
+
+// ── Transient-status classification ──────────────────────────────────────────
+
+TEST(GitHubClientRetryTest, SuccessOnFirstAttemptNoRetry) {
+  SleepSpy spy;
+  int call_count = 0;
+
+  Response result = CurlGitHubClient::with_retry(
+      "GET", "https://example.com",
+      [&]() -> Response {
+        ++call_count;
+        return {200, R"({"ok":true})", ""};
+      },
+      spy.fn());
+
+  EXPECT_EQ(result.status, 200);
+  EXPECT_EQ(call_count, 1);
+  EXPECT_EQ(spy.calls, 0) << "No sleep should occur on first-attempt success";
+}
+
+// ── 5xx retry (happy path: fails twice, succeeds on third) ───────────────────
+
+TEST(GitHubClientRetryTest, RetriesOn5xxAndEventuallySucceeds) {
+  SleepSpy spy;
+  int call_count = 0;
+
+  Response result = CurlGitHubClient::with_retry(
+      "POST", "https://example.com/issues",
+      [&]() -> Response {
+        ++call_count;
+        if (call_count < 3) return {503, "Service Unavailable", ""};
+        return {201, R"({"number":42})", ""};
+      },
+      spy.fn());
+
+  EXPECT_EQ(result.status, 201);
+  EXPECT_EQ(call_count, 3);
+  EXPECT_EQ(spy.calls, 2) << "Two sleeps for two retries";
+}
+
+// ── 5xx error path: all retries exhausted ────────────────────────────────────
+
+TEST(GitHubClientRetryTest, ReturnsLastResponseAfterAllRetriesExhausted) {
+  SleepSpy spy;
+  int call_count = 0;
+
+  Response result = CurlGitHubClient::with_retry(
+      "PATCH", "https://example.com/issues/1",
+      [&]() -> Response {
+        ++call_count;
+        return {500, "Internal Server Error", ""};
+      },
+      spy.fn());
+
+  EXPECT_EQ(result.status, 500);
+  EXPECT_EQ(call_count, CurlGitHubClient::kMaxRetries);
+  EXPECT_EQ(spy.calls, CurlGitHubClient::kMaxRetries - 1);
+}
+
+// ── Transport-error retry (happy path: fails once, then succeeds) ─────────────
+
+TEST(GitHubClientRetryTest, RetriesOnTransportErrorAndSucceeds) {
+  SleepSpy spy;
+  int call_count = 0;
+
+  Response result = CurlGitHubClient::with_retry(
+      "GET", "https://example.com",
+      [&]() -> Response {
+        ++call_count;
+        if (call_count == 1) throw std::runtime_error("curl GET failed: Could not resolve host");
+        return {200, R"([])", ""};
+      },
+      spy.fn());
+
+  EXPECT_EQ(result.status, 200);
+  EXPECT_EQ(call_count, 2);
+  EXPECT_EQ(spy.calls, 1);
+}
+
+// ── Transport-error path: all retries exhausted → throws ─────────────────────
+
+TEST(GitHubClientRetryTest, ThrowsAfterAllTransportRetriesExhausted) {
+  SleepSpy spy;
+  int call_count = 0;
+
+  EXPECT_THROW(CurlGitHubClient::with_retry(
+                   "GET", "https://example.com",
+                   [&]() -> Response {
+                     ++call_count;
+                     throw std::runtime_error("connection refused");
+                   },
+                   spy.fn()),
+               std::runtime_error);
+
+  EXPECT_EQ(call_count, CurlGitHubClient::kMaxRetries);
+  EXPECT_EQ(spy.calls, CurlGitHubClient::kMaxRetries - 1);
+}
+
+// ── 4xx (other than 429) is NOT retried ──────────────────────────────────────
+
+TEST(GitHubClientRetryTest, DoesNotRetryOn4xx) {
+  SleepSpy spy;
+  int call_count = 0;
+
+  Response result = CurlGitHubClient::with_retry(
+      "POST", "https://example.com/issues",
+      [&]() -> Response {
+        ++call_count;
+        return {422, "Unprocessable Entity", ""};
+      },
+      spy.fn());
+
+  EXPECT_EQ(result.status, 422);
+  EXPECT_EQ(call_count, 1) << "4xx (non-429) must not be retried";
+  EXPECT_EQ(spy.calls, 0) << "No sleep should occur for non-retryable errors";
+}
+
+TEST(GitHubClientRetryTest, DoesNotRetryOn401) {
+  SleepSpy spy;
+  int call_count = 0;
+
+  Response result = CurlGitHubClient::with_retry(
+      "GET", "https://example.com",
+      [&]() -> Response {
+        ++call_count;
+        return {401, "Unauthorized", ""};
+      },
+      spy.fn());
+
+  EXPECT_EQ(result.status, 401);
+  EXPECT_EQ(call_count, 1);
+  EXPECT_EQ(spy.calls, 0);
+}
+
+TEST(GitHubClientRetryTest, DoesNotRetryOn404) {
+  SleepSpy spy;
+  int call_count = 0;
+
+  Response result = CurlGitHubClient::with_retry(
+      "GET", "https://example.com/issues/9999",
+      [&]() -> Response {
+        ++call_count;
+        return {404, "Not Found", ""};
+      },
+      spy.fn());
+
+  EXPECT_EQ(result.status, 404);
+  EXPECT_EQ(call_count, 1);
+  EXPECT_EQ(spy.calls, 0);
+}
+
+// ── 429 with Retry-After header honored ──────────────────────────────────────
+
+TEST(GitHubClientRetryTest, Honors429WithRetryAfterHeader) {
+  SleepSpy spy;
+  int call_count = 0;
+
+  Response result = CurlGitHubClient::with_retry(
+      "POST", "https://example.com/issues",
+      [&]() -> Response {
+        ++call_count;
+        if (call_count == 1) return {429, "Too Many Requests", "5"};
+        return {201, R"({"number":7})", ""};
+      },
+      spy.fn());
+
+  EXPECT_EQ(result.status, 201);
+  EXPECT_EQ(call_count, 2);
+  ASSERT_EQ(spy.delays.size(), 1u);
+  EXPECT_EQ(spy.delays[0], 5000) << "Retry-After:5 should sleep 5000 ms";
+}
+
+// ── 429 without Retry-After falls back to exponential backoff ────────────────
+
+TEST(GitHubClientRetryTest, FallsBackToExponentialBackoffOn429WithoutRetryAfter) {
+  SleepSpy spy;
+  int call_count = 0;
+
+  Response result = CurlGitHubClient::with_retry(
+      "GET", "https://example.com",
+      [&]() -> Response {
+        ++call_count;
+        if (call_count < 3) return {429, "Too Many Requests", ""};
+        return {200, R"([])", ""};
+      },
+      spy.fn());
+
+  EXPECT_EQ(result.status, 200);
+  ASSERT_EQ(spy.delays.size(), 2u);
+  EXPECT_EQ(spy.delays[0], CurlGitHubClient::kBaseRetryMs);
+  EXPECT_EQ(spy.delays[1], CurlGitHubClient::kBaseRetryMs * 2);
+}
+
+// ── Exponential-backoff schedule verification ─────────────────────────────────
+
+TEST(GitHubClientRetryTest, ExponentialBackoffScheduleIsDoubling) {
+  SleepSpy spy;
+
+  // Trigger all kMaxRetries-1 sleeps by failing with 503 until the last attempt succeeds.
+  int call_count = 0;
+  CurlGitHubClient::with_retry(
+      "GET", "https://example.com",
+      [&]() -> Response {
+        ++call_count;
+        if (call_count < CurlGitHubClient::kMaxRetries) return {503, "", ""};
+        return {200, "", ""};
+      },
+      spy.fn());
+
+  ASSERT_EQ(static_cast<int>(spy.delays.size()), CurlGitHubClient::kMaxRetries - 1);
+  for (int i = 0; i < static_cast<int>(spy.delays.size()); ++i) {
+    int expected = CurlGitHubClient::kBaseRetryMs * (1 << i);
+    EXPECT_EQ(spy.delays[i], expected) << "delay[" << i << "] should be " << expected << " ms";
+  }
+}
+
+}  // namespace projectagamemnon::test


### PR DESCRIPTION
Closes #163.

## Summary
- `CurlGitHubClient` gains a `with_retry()` static helper that wraps every `do_get` / `do_post` / `do_patch` call with exponential-backoff retry logic (1 s -> 2 s -> 4 s, max 3 attempts).
- Retries on HTTP 5xx, HTTP 429 (honors `Retry-After` header), and transport errors (curl != CURLE_OK).
- Does NOT retry 4xx other than 429 — those indicate client bugs.
- Sleep function is injectable (`std::function<void(int)>`) so tests run in zero wall-clock time.
- New `CURLOPT_HEADERFUNCTION` callback captures the `Retry-After` response header.

## Test plan
- [x] New unit test covers retry-on-5xx happy path (fails twice, succeeds on third)
- [x] New unit test covers retry-on-5xx error path (all retries exhausted, last response returned)
- [x] New unit test covers retry-on-transport-error happy path
- [x] New unit test confirms transport error throws after all retries exhausted
- [x] New unit tests confirm 4xx (401, 404, 422) is NOT retried
- [x] 429 with Retry-After header honors the header value
- [x] 429 without Retry-After falls back to exponential backoff
- [x] Backoff schedule is verified to be strictly doubling