### PR TITLE
fix(lint): markdownlint cleanup (CHANGELOG MD024, ROADMAP MD033/MD034)

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -11,6 +11,9 @@ MD013:
   headings: true
   code_blocks: true
 
+MD024:
+  siblings_only: true
+
 MD033:
   allowed_elements: [T, img, br, details, summary]
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,7 +22,7 @@ The following are genuinely implemented and tested:
 ## Project Board
 
 Work is tracked on the HomericIntelligence organization GitHub Projects board:
-https://github.com/orgs/HomericIntelligence/projects/<TBD>
+<https://github.com/orgs/HomericIntelligence/projects/TBD>
 
 This board is shared across all HomericIntelligence repositories and provides
 visibility into cross-project planning, dependency tracking, and sprint cycles.


### PR DESCRIPTION
## Summary

Fixes markdownlint failures on main that block PRs #388, #400, #401, #402.

- **CHANGELOG.md**: Configure MD024 with `siblings_only: true` in `.markdownlint.yaml` to allow Keep-a-Changelog's repeated Added/Changed/Fixed subheadings under different version sections.
- **ROADMAP.md**: Replace `<TBD>` with plain text and wrap bare GitHub URL in autolink syntax to fix MD033 (inline HTML) and MD034 (bare URL).

## Test plan

- [x] pre-commit markdownlint passes locally on CHANGELOG.md and ROADMAP.md
- [ ] CI green