### PR TITLE
feat(tools): import reconciler from Myrmidons

### DIFF
--- a/tools/reconciler/.github/workflows/apply.yml
+++ b/tools/reconciler/.github/workflows/apply.yml
@@ -1,0 +1,111 @@
+name: Apply Agent Definitions
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'agents/**'
+      - 'fleets/**'
+      - 'pixi.toml'
+      - 'pixi.lock'
+
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  apply:
+    name: Reconcile Desired State
+    # Self-hosted runner required: Agamemnon is on the local network and is not
+    # reachable from GitHub-hosted runners. Register a runner on the same host
+    # (or LAN segment) as Agamemnon. See docs/self-hosted-runner.md for setup.
+    runs-on: [self-hosted, linux]
+    # Gate on vars.AGAMEMNON_URL (repository variable, not secret) — the URL
+    # is not sensitive and secrets context is unavailable in job-level if:.
+    # Set AGAMEMNON_URL as a repository *variable* (Settings > Variables) and
+    # AGAMEMNON_API_KEY as a repository *secret* to enable reconciliation.
+    if: ${{ vars.AGAMEMNON_URL != '' }}
+    timeout-minutes: 15
+    env:
+      AGAMEMNON_URL: ${{ vars.AGAMEMNON_URL }}
+      AGAMEMNON_API_KEY: ${{ secrets.AGAMEMNON_API_KEY }}
+      AGAMEMNON_CA_CERT_B64: ${{ secrets.AGAMEMNON_CA_CERT_B64 }}
+      AGAMEMNON_CLIENT_CERT_B64: ${{ secrets.AGAMEMNON_CLIENT_CERT_B64 }}
+      AGAMEMNON_CLIENT_KEY_B64: ${{ secrets.AGAMEMNON_CLIENT_KEY_B64 }}
+    steps:
+      - name: Mask secrets
+        run: |
+          if [[ -n "$AGAMEMNON_API_KEY" ]]; then
+            echo "::add-mask::$AGAMEMNON_API_KEY"
+          fi
+
+      - uses: actions/checkout@v4
+
+      - name: Configure TLS
+        if: ${{ env.AGAMEMNON_CA_CERT_B64 != '' }}
+        run: |
+          echo "$AGAMEMNON_CA_CERT_B64" | base64 -d > /tmp/agamemnon-ca.pem
+          echo "AGAMEMNON_CA_CERT=/tmp/agamemnon-ca.pem" >> "$GITHUB_ENV"
+          if [[ -n "$AGAMEMNON_CLIENT_CERT_B64" ]]; then
+            echo "$AGAMEMNON_CLIENT_CERT_B64" | base64 -d > /tmp/agamemnon-client.pem
+            echo "$AGAMEMNON_CLIENT_KEY_B64" | base64 -d > /tmp/agamemnon-client.key
+            echo "AGAMEMNON_CLIENT_CERT=/tmp/agamemnon-client.pem" >> "$GITHUB_ENV"
+            echo "AGAMEMNON_CLIENT_KEY=/tmp/agamemnon-client.key" >> "$GITHUB_ENV"
+          fi
+
+      - name: Set up pixi
+        # jq and yq (go-yq) versions are pinned in pixi.lock:
+        #   jq    = 1.8.1  (conda-forge, issue #74)
+        #   go-yq = 4.53.2 (conda-forge, mikefarah/yq v4, issue #133)
+        # Run `pixi update` to bump these pins.
+        uses: ./.github/actions/setup-pixi
+
+      - name: Plan — show what will change
+        run: |
+          set -euo pipefail
+          chmod +x scripts/plan.sh scripts/lib/api.sh scripts/lib/reconcile.sh
+          # plan.sh is advisory in this informational step — its rc carries
+          # "drift / no drift" semantics depending on the script version. Log
+          # the rc to stdout so a regression in plan.sh is visible without
+          # blocking the subsequent apply step. Per Bucket F (see
+          # docs/runbooks/no-silent-failures.md), we use a plain stdout
+          # "WARN:" line rather than the advisory workflow annotation
+          # so the forbid-advisory-warnings lint rule is not tripped.
+          plan_rc=0
+          ./scripts/plan.sh || plan_rc=$?
+          if [ "$plan_rc" -ne 0 ]; then
+            echo "WARN: plan.sh exited $plan_rc (informational — apply step follows)"
+          fi
+
+      - name: Apply — reconcile desired state
+        run: |
+          chmod +x scripts/apply.sh
+          ./scripts/apply.sh --yes
+
+      - name: Convergence — verify all agents reached desired state
+        run: |
+          # Re-run in dry-run mode: if converged, plan.sh should report zero
+          # changes (no CREATE / UPDATE / WAKE / HIBERNATE actions).
+          chmod +x scripts/plan.sh
+          plan_output="$(./scripts/plan.sh 2>&1)"
+          echo "$plan_output"
+          if echo "$plan_output" | grep -qE '^\[(\+|~|!|z)\]'; then
+            echo "ERROR: Convergence check failed — drift after apply." >&2
+            echo "$plan_output" | grep -E '^\[(\+|~|!|z)\]' >&2
+            exit 1
+          fi
+          echo "Convergence verified: no drift detected."
+
+      - name: Status — verify no drift remains
+        run: |
+          chmod +x scripts/status.sh
+          ./scripts/status.sh
+
+      - name: Upload snapshots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: myrmidons-snapshots-${{ github.run_id }}
+          path: .myrmidons/snapshots/
+          if-no-files-found: ignore
+          retention-days: 30

--- a/tools/reconciler/.github/workflows/runner-health.yml
+++ b/tools/reconciler/.github/workflows/runner-health.yml
@@ -1,0 +1,37 @@
+name: Runner and Agamemnon Health Check
+
+on:
+  schedule:
+    # Run every 6 hours so failures surface well before a real apply is needed.
+    - cron: '0 */6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  health:
+    name: Health Check
+    runs-on: [self-hosted, linux]
+    # Skip if AGAMEMNON_URL is not configured — same gate as apply.yml.
+    if: ${{ vars.AGAMEMNON_URL != '' }}
+    timeout-minutes: 5
+    env:
+      AGAMEMNON_URL: ${{ vars.AGAMEMNON_URL }}
+      AGAMEMNON_API_KEY: ${{ secrets.AGAMEMNON_API_KEY }}
+    steps:
+      - name: Mask secrets
+        run: |
+          if [[ -n "$AGAMEMNON_API_KEY" ]]; then
+            echo "::add-mask::$AGAMEMNON_API_KEY"
+          fi
+
+      - uses: actions/checkout@v4
+
+      - name: Set up pixi
+        uses: ./.github/actions/setup-pixi
+
+      - name: Doctor — verify runner can reach Agamemnon
+        run: |
+          chmod +x scripts/doctor.sh
+          pixi run bash scripts/doctor.sh --skip-hooks

--- a/tools/reconciler/README.md
+++ b/tools/reconciler/README.md
@@ -1,0 +1,78 @@
+# Reconciler
+
+GitOps reconciler that drives ProjectAgamemnon's REST API from the agent
+definitions in `HomericIntelligence/Myrmidons`.
+
+## Why this lives here (not in Myrmidons)
+
+`HomericIntelligence/Myrmidons` is **a dataset repo** — YAML schema, agent
+and fleet descriptions, dataset validators, dataset docs, and the CI wrappers
+that run those validators. Nothing else.
+
+Anything that *executes* against Agamemnon's API to converge actual → desired
+state is consumer-side and lives here, where Agamemnon already runs.
+
+This directory was ported from `HomericIntelligence/Myrmidons:scripts/` and
+`HomericIntelligence/Myrmidons:tests/` on 2026-05-17. See the migration
+manifest in ProjectAgamemnon#403 and the matching deletion PR in Myrmidons.
+
+## Contents
+
+| Path | Role |
+| ---- | ---- |
+| `scripts/apply.sh` | Reconcile actual → desired by calling Agamemnon's API |
+| `scripts/plan.sh` | Dry-run: print diff (drift) between YAML and Agamemnon |
+| `scripts/status.sh` | Table of desired vs actual + drift |
+| `scripts/export.sh` | Bootstrap: pull current Agamemnon state down into YAML |
+| `scripts/diff.sh`, `rollback.sh`, `new-agent.sh`, `doctor.sh` | Ops helpers |
+| `scripts/lib/api.sh` | Agamemnon REST API client + URL validation + xtrace guards |
+| `scripts/lib/reconcile.sh` | `compute_drift`, `verify_convergence`, prune logic |
+| `scripts/lib/report.sh` | JSON / webhook reporting |
+| `scripts/lib/prompt.sh` | TTY confirmation helpers |
+| `scripts/lib/config.sh` | Env var defaults (AGAMEMNON_*, MYRMIDONS_*, etc.) |
+| `scripts/lib/git-safety.sh`, `log.sh` | Shared infra |
+| `tests/` | bats unit + integration tests, fixtures, mock server |
+| `.github/workflows/apply.yml` | Auto-apply on merge (needs secrets re-pointed) |
+| `.github/workflows/runner-health.yml` | Self-hosted runner health |
+| `docs/adr/ADR-007-*.md` | Nomad integration strategy |
+| `docs/adr/ADR-009-*.md` | `compute_drift` positional-parameter interface |
+
+## How it consumes Myrmidons
+
+The reconciler still reads YAML from `HomericIntelligence/Myrmidons`. It
+expects `agents/<host>/*.yaml` and `fleets/*.yaml` to conform to the schemas
+defined in that repo (`schemas/agent-v1.schema.json` etc.).
+
+The recommended runtime pattern is for `apply.yml` (here) to clone Myrmidons
+as a submodule or fetch-on-demand, then run `scripts/apply.sh` against the
+checked-out dataset.
+
+## Open work
+
+See ProjectAgamemnon#403 for the migration manifest. ~83 reconciler-related
+issues were closed in Myrmidons during the narrow-to-charter pass; triage
+them and refile here as needed if they describe live bugs.
+
+## Env vars
+
+| Variable | Default | Description |
+| -------- | ------- | ----------- |
+| `AGAMEMNON_URL` | `http://localhost:8080` | ProjectAgamemnon base URL |
+| `AGAMEMNON_API_KEY` | _(unset)_ | Bearer token / API key |
+| `AGAMEMNON_TIMEOUT` | `10` | HTTP timeout (s) |
+| `AGAMEMNON_CA_CERT` | _(unset)_ | PEM CA cert path |
+| `AGAMEMNON_CLIENT_CERT` | _(unset)_ | PEM client cert (mTLS) |
+| `AGAMEMNON_CLIENT_KEY` | _(unset)_ | PEM client key (mTLS) |
+| `AGAMEMNON_TLS_VERIFY` | _(true)_ | Set `false` to skip TLS verify |
+| `AIM_LOCK_FILE` | `.myrmidons.lock` | Apply lock file path |
+| `HIBERNATE_SETTLE_SECONDS` | `2` | Wait after hibernate |
+| `MYRMIDONS_DEFAULT_OWNER` | `$(whoami)` | Fallback owner during export |
+| `MYRMIDONS_YES` | _(unset)_ | Skip interactive prompts |
+| `SNAPSHOT_DIR` | `${REPO_ROOT}/.myrmidons/snapshots` | Pre-apply snapshot dir |
+
+## Security notes
+
+`AGAMEMNON_URL` is passed directly to `curl` — point only at trusted
+Agamemnon instances. In CI, source from a secret.
+
+`AGAMEMNON_API_KEY` must NEVER be committed. Use env vars or GitHub secrets.

--- a/tools/reconciler/README.md
+++ b/tools/reconciler/README.md
@@ -58,16 +58,16 @@ them and refile here as needed if they describe live bugs.
 | Variable | Default | Description |
 | -------- | ------- | ----------- |
 | `AGAMEMNON_URL` | `http://localhost:8080` | ProjectAgamemnon base URL |
-| `AGAMEMNON_API_KEY` | _(unset)_ | Bearer token / API key |
+| `AGAMEMNON_API_KEY` | *(unset)* | Bearer token / API key |
 | `AGAMEMNON_TIMEOUT` | `10` | HTTP timeout (s) |
-| `AGAMEMNON_CA_CERT` | _(unset)_ | PEM CA cert path |
-| `AGAMEMNON_CLIENT_CERT` | _(unset)_ | PEM client cert (mTLS) |
-| `AGAMEMNON_CLIENT_KEY` | _(unset)_ | PEM client key (mTLS) |
-| `AGAMEMNON_TLS_VERIFY` | _(true)_ | Set `false` to skip TLS verify |
+| `AGAMEMNON_CA_CERT` | *(unset)* | PEM CA cert path |
+| `AGAMEMNON_CLIENT_CERT` | *(unset)* | PEM client cert (mTLS) |
+| `AGAMEMNON_CLIENT_KEY` | *(unset)* | PEM client key (mTLS) |
+| `AGAMEMNON_TLS_VERIFY` | *(true)* | Set `false` to skip TLS verify |
 | `AIM_LOCK_FILE` | `.myrmidons.lock` | Apply lock file path |
 | `HIBERNATE_SETTLE_SECONDS` | `2` | Wait after hibernate |
 | `MYRMIDONS_DEFAULT_OWNER` | `$(whoami)` | Fallback owner during export |
-| `MYRMIDONS_YES` | _(unset)_ | Skip interactive prompts |
+| `MYRMIDONS_YES` | *(unset)* | Skip interactive prompts |
 | `SNAPSHOT_DIR` | `${REPO_ROOT}/.myrmidons/snapshots` | Pre-apply snapshot dir |
 
 ## Security notes

--- a/tools/reconciler/docs/adr/ADR-007-nomad-integration-strategy.md
+++ b/tools/reconciler/docs/adr/ADR-007-nomad-integration-strategy.md
@@ -1,0 +1,112 @@
+# ADR-007: Nomad Integration Strategy for Multi-Host Deployments
+
+**Status:** Accepted
+**Date:** 2026-04-10
+**Accepted:** 2026-05-03
+**Author:** mvillmow
+
+---
+
+## Context
+
+`Architecture.md` in the HomericIntelligence ecosystem (Odysseus repo) depicts
+"Myrmidons + Nomad" as the solution to Gap #3 — multi-host agent scheduling —
+and includes a diagram showing Myrmidons driving a Nomad cluster.
+
+However, no Nomad integration code exists in Myrmidons. The `apply.sh` script
+calls only the ProjectAgamemnon REST API. The `spec.deployment.type` field
+supports `local` (tmux on a single host) and `docker` (container on a single
+host). There is no Nomad job submission, no HCL generation, and no Nomad API
+client anywhere in this repository.
+
+This creates a documentation overclaim: the architecture diagram implies an
+active capability that has not been implemented.
+
+---
+
+## Decision
+
+Treat Nomad integration as a **deferred future phase**, not a current capability.
+
+- Do **not** add Nomad integration code to resolve this inconsistency. No design
+  exists for it; implementing it now would be scope creep without a backing spec.
+- Do **not** remove Nomad from the roadmap entirely. The multi-host scheduling
+  gap is real and worth tracking.
+- **Update documentation** to accurately reflect current scope: Myrmidons drives
+  a single host via the ProjectAgamemnon REST API. Multi-host scheduling via
+  Nomad is planned for a future phase.
+- Add a **drift-detection test** (`tests/detect-doc-drift.sh`) that fails CI if
+  any documentation file in this repo re-introduces overclaiming language that
+  implies an active Nomad integration.
+- File a **cross-repo issue** in `HomericIntelligence/Odysseus` to update
+  `Architecture.md` so the ecosystem diagram accurately reflects the current
+  implementation state.
+
+---
+
+## Consequences
+
+### Positive
+- Documentation accurately reflects what `apply.sh` and the YAML schema actually do.
+- The CI drift-detection test prevents future docs from silently re-introducing
+  the overclaim without a corresponding code change.
+- No phantom capability is advertised to users who read the architecture docs.
+
+### Negative / Trade-offs
+- Gap #3 (multi-host scheduling) remains open. Anyone expecting Nomad integration
+  today will need to rely on the roadmap/future ADR instead of existing code.
+
+### Neutral
+- When Nomad integration work actually begins, a new ADR (ADR-008 or similar)
+  should document the design: how Myrmidons generates Nomad job files, which
+  Nomad API endpoints it calls, and how `spec.deployment.type: nomad` would work.
+
+---
+
+## Alternatives Considered
+
+### A. Implement Nomad integration now
+**Rejected.** No design spec exists. The `spec.deployment.type` validation in
+`validate-schemas.sh` explicitly rejects any value other than `local` or
+`docker`. Implementing Nomad scheduling is a substantial, multi-week effort
+requiring Nomad cluster provisioning, HCL job template design, Nomad API client
+code, and changes to the agent YAML schema — none of which have been designed.
+
+### B. Remove Nomad from the roadmap entirely
+**Rejected.** The multi-host scheduling gap is a real architectural limitation.
+Removing it from the roadmap would discard useful context for future planning
+and make it harder to revive the work later.
+
+### C. Do nothing
+**Rejected.** Overclaiming documentation erodes trust. When a reader encounters
+the Architecture.md diagram and then finds no Nomad code, they cannot tell
+whether the integration exists somewhere they haven't looked, was removed, or
+was never built. Explicit documentation of "planned, not implemented" is
+unambiguous.
+
+---
+
+## Implementation Scope (this ADR)
+
+| File | Change |
+|------|--------|
+| `docs/adr/ADR-007-nomad-integration-strategy.md` | This file — documents the gap and deferral decision |
+| `README.md` | Adds a "Deployment scope" section clarifying supported types and linking to this ADR |
+| `tests/detect-doc-drift.sh` | Drift-detection test: fails if docs imply active Nomad integration |
+| `justfile` | Adds `test-drift` target; adds drift check to `validate` |
+| `.github/workflows/validate.yml` | Adds drift-detection step to CI |
+
+---
+
+## Future Work
+
+**Note:** ADR-008 (Fleet ref Resolution by Filename Stem) has been accepted. Future
+Nomad integration work should be covered in a subsequent ADR after the necessary
+design is completed.
+
+When multi-host scheduling work begins:
+1. Write a new ADR covering the Nomad integration design.
+2. Add `spec.deployment.type: nomad` to the agent schema.
+3. Update `apply.sh` to generate Nomad job files and call the Nomad API.
+4. Update `tests/validate-schemas.sh` to accept `nomad` as a valid deployment type.
+5. Update this ADR status to `Superseded by ADR-<N>`.

--- a/tools/reconciler/docs/adr/ADR-007-nomad-integration-strategy.md
+++ b/tools/reconciler/docs/adr/ADR-007-nomad-integration-strategy.md
@@ -47,16 +47,19 @@ Treat Nomad integration as a **deferred future phase**, not a current capability
 ## Consequences
 
 ### Positive
+
 - Documentation accurately reflects what `apply.sh` and the YAML schema actually do.
 - The CI drift-detection test prevents future docs from silently re-introducing
   the overclaim without a corresponding code change.
 - No phantom capability is advertised to users who read the architecture docs.
 
 ### Negative / Trade-offs
+
 - Gap #3 (multi-host scheduling) remains open. Anyone expecting Nomad integration
   today will need to rely on the roadmap/future ADR instead of existing code.
 
 ### Neutral
+
 - When Nomad integration work actually begins, a new ADR (ADR-008 or similar)
   should document the design: how Myrmidons generates Nomad job files, which
   Nomad API endpoints it calls, and how `spec.deployment.type: nomad` would work.
@@ -66,6 +69,7 @@ Treat Nomad integration as a **deferred future phase**, not a current capability
 ## Alternatives Considered
 
 ### A. Implement Nomad integration now
+
 **Rejected.** No design spec exists. The `spec.deployment.type` validation in
 `validate-schemas.sh` explicitly rejects any value other than `local` or
 `docker`. Implementing Nomad scheduling is a substantial, multi-week effort
@@ -73,11 +77,13 @@ requiring Nomad cluster provisioning, HCL job template design, Nomad API client
 code, and changes to the agent YAML schema — none of which have been designed.
 
 ### B. Remove Nomad from the roadmap entirely
+
 **Rejected.** The multi-host scheduling gap is a real architectural limitation.
 Removing it from the roadmap would discard useful context for future planning
 and make it harder to revive the work later.
 
 ### C. Do nothing
+
 **Rejected.** Overclaiming documentation erodes trust. When a reader encounters
 the Architecture.md diagram and then finds no Nomad code, they cannot tell
 whether the integration exists somewhere they haven't looked, was removed, or
@@ -89,7 +95,7 @@ unambiguous.
 ## Implementation Scope (this ADR)
 
 | File | Change |
-|------|--------|
+| --- | --- |
 | `docs/adr/ADR-007-nomad-integration-strategy.md` | This file — documents the gap and deferral decision |
 | `README.md` | Adds a "Deployment scope" section clarifying supported types and linking to this ADR |
 | `tests/detect-doc-drift.sh` | Drift-detection test: fails if docs imply active Nomad integration |
@@ -105,6 +111,7 @@ Nomad integration work should be covered in a subsequent ADR after the necessary
 design is completed.
 
 When multi-host scheduling work begins:
+
 1. Write a new ADR covering the Nomad integration design.
 2. Add `spec.deployment.type: nomad` to the agent schema.
 3. Update `apply.sh` to generate Nomad job files and call the Nomad API.

--- a/tools/reconciler/docs/adr/ADR-009-compute-drift-positional-parameters.md
+++ b/tools/reconciler/docs/adr/ADR-009-compute-drift-positional-parameters.md
@@ -1,0 +1,175 @@
+# ADR-009: compute_drift Positional Parameter Interface
+
+**Status:** Accepted
+**Date:** 2026-04-28
+**Accepted:** 2026-05-03
+**Author:** mvillmow
+
+---
+
+## Context
+
+The `compute_drift` function (`scripts/lib/reconcile.sh:350-427`) compares the
+desired state of an agent (from its YAML file) against its live state (from the
+ProjectAgamemnon REST API JSON). To perform the comparison it needs:
+
+- The agent name (for context / error messages)
+- The desired `desiredState` (`active` or `hibernated`)
+- The full actual agent JSON blob from the API
+- Ten desired field values: `label`, `program`, `workingDirectory`,
+  `programArgs`, `taskDescription`, `tags`, `model`, `owner`, `role`,
+  `deployment.type`
+
+That is 13 inputs in total. Shell functions have no named-parameter mechanism;
+the available options are positional parameters, associative arrays, or a
+serialized intermediate format.
+
+The function is called from three callers: `apply.sh`, `plan.sh`, and
+`status.sh`. Each caller already reads the YAML fields into local shell
+variables before calling `compute_drift`.
+
+---
+
+## Decision
+
+Use **13 discrete positional parameters** in a fixed documented order:
+
+```
+$1  name               — agent name (for context)
+$2  desired_state      — "active" | "hibernated"
+$3  actual_json        — full agent JSON from the API
+$4  desired_label
+$5  desired_program
+$6  desired_workdir
+$7  desired_args
+$8  desired_desc
+$9  desired_tags_csv
+$10 desired_model
+$11 desired_owner
+$12 desired_role
+$13 desired_deploy_type
+```
+
+The function outputs one of:
+
+- `UNCHANGED` — no drift detected
+- `WAKE` — agent is offline but desired state is `active`
+- `HIBERNATE` — agent is active/online but desired state is `hibernated`
+- `UPDATE:<field1>,<field2>,...` — one or more fields differ
+
+---
+
+## Consequences
+
+### Positive
+
+- No runtime dependencies beyond POSIX shell. No `bash 4+` associativity, no
+  `declare -A`, no `nameref`.
+- Callers are already reading YAML fields into local variables; passing them
+  positionally requires no additional serialization step.
+- The fixed order is fully documented in the function header comment, making
+  the interface self-describing without requiring callers to look up key names.
+
+### Negative / Trade-offs
+
+- The call sites are positionally sensitive. Adding a new field requires
+  incrementing the parameter count and updating all three callers in lockstep.
+  A missing or reordered argument produces a silent wrong-value bug rather than
+  a named-parameter error.
+- 13 parameters is at the upper end of what is readable at a call site.
+  Callers pass values in a column-aligned block to compensate, but the
+  interface is inherently fragile to future extension.
+
+### Neutral
+
+- The function header comment (`scripts/lib/reconcile.sh:335-349`) enumerates
+  all 13 parameters. Any future change must update both the comment and every
+  caller.
+
+---
+
+## Alternatives Considered
+
+### A. Pass desired state as a JSON blob
+
+**Rejected.** Callers (`apply.sh`, `plan.sh`, `status.sh`) read YAML fields
+into local shell variables via `yq`. Serializing those variables back into a
+JSON blob on every call adds unnecessary `jq` round-trips and makes the call
+site opaque — the reader cannot see which fields are being passed without
+inspecting the serialization logic. The positional interface is verbose but
+transparent.
+
+### B. Use bash associative arrays
+
+**Rejected.** Associative arrays require `bash 4+` and `declare -A` at both
+definition and call sites. Passing an associative array to a function requires
+either a `nameref` (`declare -n`, bash 4.3+) or serialization to a string.
+`nameref` behaves unexpectedly across subshells (the array is not visible in a
+subprocess), which is a real risk since callers may invoke `compute_drift` in a
+pipeline. The positional interface works identically in all execution contexts.
+
+### C. Source a shared environment file
+
+**Rejected.** Writing desired-state variables to a temp file and sourcing it
+inside `compute_drift` would defeat function isolation and make parallel
+invocations unsafe (multiple agents reconciled concurrently would race on the
+same file). It also adds I/O for every drift computation.
+
+---
+
+## How to extend compute_drift (lockstep checklist)
+
+Adding a new drifted field requires updating the function **and** all three
+callers in lockstep. Missing any step produces a silent wrong-value bug because
+shell positional parameters bind by position, not name.
+
+1. **Add the parameter to `compute_drift`** (`scripts/lib/reconcile.sh`):
+   - Append `$14` (or the next slot) to the function body with a `local` binding.
+   - Update the header comment's parameter table (lines 335–349).
+   - Add a drift comparison line (e.g. `[[ "$actual_foo" != "$desired_foo" ]] && drifted_fields+=("foo")`).
+
+2. **Bump the arity guard**: change the `13` in `[[ $# -ne 13 ]]` to the new
+   count. This is the authoritative number that `check-compute-drift-callers.sh`
+   reads.
+
+3. **Update all three callers** (`apply.sh`, `plan.sh`, `status.sh`) to pass
+   the new argument in the matching position. All three call sites must change
+   together — a partial update causes a positional shift for every argument that
+   follows.
+
+4. **Add a row to the drift-detection table in CLAUDE.md** so operators know
+   the field is tracked.
+
+5. **Write a new UPDATE test** in `tests/unit/test_drift_owner_role_tags.bats`
+   (or a new test file) asserting that drift is detected when the new field
+   changes and is absent from the result when the field is unchanged.
+
+6. **Run the caller consistency check** — must exit 0 before committing:
+   ```bash
+   ./scripts/check-compute-drift-callers.sh
+   ```
+   This script is also wired as a pre-commit hook and fires automatically
+   whenever `reconcile.sh` or any of the three callers is staged.
+
+7. **Run the full unit test suite** — all drift tests (including the arity
+   guard tests) must pass:
+   ```bash
+   pixi run test-unit
+   ```
+
+**Caution:** This is inherently fragile due to the positional nature. Consider
+proposing a higher-level refactor (e.g., a structured parameter format) if you
+find yourself adding a fourth or fifth extension.
+
+---
+
+## Implementation Scope (this ADR)
+
+| File | Role |
+|------|------|
+| `scripts/lib/reconcile.sh:335-431` | `compute_drift` definition, parameter comment block, and arity guard |
+| `scripts/apply.sh` | Primary caller — passes all 13 parameters |
+| `scripts/plan.sh` | Caller — dry-run drift check |
+| `scripts/status.sh` | Caller — status table drift column |
+| `scripts/check-compute-drift-callers.sh` | Pre-commit / CI arity consistency check |
+| `tests/unit/test_compute_drift_arity.bats` | Arity guard unit tests |

--- a/tools/reconciler/docs/adr/ADR-009-compute-drift-positional-parameters.md
+++ b/tools/reconciler/docs/adr/ADR-009-compute-drift-positional-parameters.md
@@ -145,14 +145,17 @@ shell positional parameters bind by position, not name.
    changes and is absent from the result when the field is unchanged.
 
 6. **Run the caller consistency check** — must exit 0 before committing:
+
    ```bash
    ./scripts/check-compute-drift-callers.sh
    ```
+
    This script is also wired as a pre-commit hook and fires automatically
    whenever `reconcile.sh` or any of the three callers is staged.
 
 7. **Run the full unit test suite** — all drift tests (including the arity
    guard tests) must pass:
+
    ```bash
    pixi run test-unit
    ```
@@ -166,7 +169,7 @@ find yourself adding a fourth or fifth extension.
 ## Implementation Scope (this ADR)
 
 | File | Role |
-|------|------|
+| --- | --- |
 | `scripts/lib/reconcile.sh:335-431` | `compute_drift` definition, parameter comment block, and arity guard |
 | `scripts/apply.sh` | Primary caller — passes all 13 parameters |
 | `scripts/plan.sh` | Caller — dry-run drift check |

--- a/tools/reconciler/scripts/apply.sh
+++ b/tools/reconciler/scripts/apply.sh
@@ -1,0 +1,1009 @@
+#!/usr/bin/env bash
+# scripts/apply.sh — Reconcile desired state → actual via Agamemnon API
+#
+# The core GitOps reconciliation loop. Reads agent YAML files and ensures
+# Agamemnon matches the desired state. All changes go through the REST API.
+#
+# Usage:
+#   ./scripts/apply.sh                         # Apply all agents on all hosts
+#   ./scripts/apply.sh hermes                  # Apply agents for a specific host
+#   ./scripts/apply.sh --fleet dev-mesh
+#   ./scripts/apply.sh --prune                 # Also hibernate+delete unmanaged agents
+#   ./scripts/apply.sh --dry-run               # Same as plan.sh
+#   ./scripts/apply.sh --yes                   # Skip interactive confirmation prompt
+#   ./scripts/apply.sh --output json           # Emit JSON reconciliation report to stdout
+#   ./scripts/apply.sh --webhook <url>         # POST report to webhook URL after apply
+#   ./scripts/apply.sh --fail-fast             # Stop on first error
+#   ./scripts/apply.sh --retry                 # Re-apply only agents from failed-agents.txt
+#
+# Safety:
+#   - Never auto-deletes agents without --prune flag
+#   - Always hibernates before deleting
+#   - Prints a summary of what was done
+#   - Acquires a lock file to prevent concurrent runs (AIM_LOCK_FILE env var)
+#   - Prompts for confirmation before destructive changes unless --yes is passed
+#   - Verifies convergence after apply and reports any agents that didn't converge
+#
+# Exit codes:
+#   0 = all agents applied successfully
+#   1 = partial failure (some agents failed)
+#   2 = total failure (all processed agents failed)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# shellcheck source=scripts/lib/config.sh
+source "${SCRIPT_DIR}/lib/config.sh"
+# shellcheck source=scripts/lib/api.sh
+source "${SCRIPT_DIR}/lib/api.sh"
+# shellcheck source=scripts/lib/reconcile.sh
+source "${SCRIPT_DIR}/lib/reconcile.sh"
+# shellcheck source=scripts/lib/report.sh
+source "${SCRIPT_DIR}/lib/report.sh"
+# shellcheck source=scripts/lib/prompt.sh
+source "${SCRIPT_DIR}/lib/prompt.sh"
+
+load_config
+
+HOST=""
+FLEET_NAME=""
+PRUNE=0
+DRY_RUN=0
+FAIL_FAST=0
+RETRY=0
+RETRY_FILE=""
+YES=0
+OUTPUT_FORMAT="text"   # "text" | "json"
+WEBHOOK_URL=""
+AIM_LOCK_FILE="${AIM_LOCK_FILE:-.myrmidons.lock}"
+AIM_LOCK_TIMEOUT="${AIM_LOCK_TIMEOUT:-60}"
+# Seconds to wait after hibernating an unmanaged agent before issuing DELETE.
+# Allows the Agamemnon API to record the state transition before DELETE arrives.
+# Override via env var: HIBERNATE_SETTLE_SECONDS=0 ./scripts/apply.sh --prune
+HIBERNATE_SETTLE_SECONDS="${HIBERNATE_SETTLE_SECONDS:-2}"
+SNAPSHOT_DIR=""
+SNAPSHOT_KEEP="${SNAPSHOT_KEEP:-10}"
+# File descriptor used for flock (9)
+_LOCK_FD=9
+
+CREATED=0
+UPDATED=0
+WOKEN=0
+HIBERNATED=0
+UNCHANGED=0
+PRUNED=0
+ERRORS=0
+_PRUNED_NAMES=()   # names of agents pruned during this run (for convergence check)
+
+# Per-agent error tracking: structured entries "name\x01http_status\x01message"
+# Uses ASCII unit separator (0x01) as delimiter — safe against agent names, HTTP codes, and error messages.
+FAILED_AGENTS_INFO=()
+FAILED_AGENT_NAMES=()  # agent names (metadata.name) that failed; written to RETRY_FILE by _write_failed_agents_file
+
+# Directory for state files
+MYRMIDONS_STATE_DIR="${REPO_ROOT}/.myrmidons"
+FAILED_AGENTS_FILE="${MYRMIDONS_STATE_DIR}/failed-agents.txt"
+
+# Arrays tracking modified agents for convergence verification (#41)
+_MODIFIED_NAMES=()
+_MODIFIED_DESIRED=()
+
+# Set by apply_agent on successful CREATE; cleared at the top of each apply_agent call.
+_LAST_CREATED_AGENT_JSON=""
+
+# Counts of destructive operations pending — used by confirmation prompt (#48)
+_DESTRUCTIVE_COUNT=0
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --prune)            PRUNE=1; shift ;;
+            --dry-run)          DRY_RUN=1; shift ;;
+            --fail-fast)        FAIL_FAST=1; shift ;;
+            --retry)            RETRY=1; shift ;;
+            --retry-file)       RETRY_FILE="$2"; shift 2 ;;
+            --fleet)            FLEET_NAME="$2"; shift 2 ;;
+            --failed-agents-file) FAILED_AGENTS_FILE="$2"; shift 2 ;;
+            --yes|-y)           YES=1; shift ;;
+            --lock-timeout)     AIM_LOCK_TIMEOUT="$2"; shift 2 ;;
+            --output)           OUTPUT_FORMAT="$2"; shift 2 ;;
+            --webhook)          WEBHOOK_URL="$2"; shift 2 ;;
+            --snapshot-dir)     SNAPSHOT_DIR="$2"; shift 2 ;;
+            --force)            shift ;;  # Consume --force (applies during actual apply, not dry-run)
+            -h|--help)          usage; exit 0 ;;
+            *) HOST="$1"; shift ;;
+        esac
+    done
+}
+
+usage() {
+    cat <<EOF
+Usage: $0 [host] [--fleet <name>] [--prune] [--dry-run] [--yes] [--force] [--fail-fast] [--retry] [--retry-file FILE] [--lock-timeout SECONDS] [--output json] [--webhook <url>]
+
+Reconciles agent YAML definitions against Agamemnon's actual state.
+
+Options:
+  host                       Only apply agents for this host (default: all)
+  --fleet NAME               Only apply agents belonging to the named fleet
+  --prune                    Hibernate and delete unmanaged agents (agents in Agamemnon
+                             but not in YAML). DEFAULT: warn only.
+  --dry-run                  Show what would happen, make no changes (same as plan.sh)
+  --fail-fast                Stop on first error (default: continue processing all agents)
+  --retry                    Re-apply only agents listed in .myrmidons/failed-agents.txt.
+                             File is self-managing: updated on partial success, cleared on
+                             full success. Operators need not manually manage this file.
+  --retry-file FILE          Path to the retry file (default: .myrmidons/failed-agents.txt).
+  --failed-agents-file PATH  Path to the failed-agents file (default: .myrmidons/failed-agents.txt).
+  --yes, -y                  Skip the interactive confirmation prompt for destructive
+                             changes (WAKE, HIBERNATE, DELETE/PRUNE). Required in
+                             non-interactive (CI) environments unless already non-tty.
+  --force                    Force apply even if lock acquisition times out.
+  --lock-timeout SECS        Set lock acquisition timeout in seconds (default: 60).
+                             Also configurable via AIM_LOCK_TIMEOUT env var.
+  --output json              Emit a JSON reconciliation report to stdout instead of
+                             human-readable text. Also saves to reports/last-reconciliation.json.
+  --webhook URL              POST the JSON report to URL after reconciliation completes.
+  --snapshot-dir DIR         Directory for pre-apply snapshots (default: .myrmidons/snapshots).
+                             Also configurable via SNAPSHOT_DIR env var.
+  -h, --help                 Show this help
+
+Environment variables:
+  AIM_LOCK_FILE              Path to the apply lock file (default: .myrmidons.lock).
+                             Set to a workspace-scoped path in parallel CI environments.
+  AIM_LOCK_TIMEOUT           Lock acquisition timeout in seconds (default: 60).
+  HIBERNATE_SETTLE_SECONDS   Seconds to wait after hibernating an unmanaged agent before
+                             issuing DELETE (default: 2). Set to 0 to skip the wait in CI:
+                             HIBERNATE_SETTLE_SECONDS=0 ./scripts/apply.sh --prune
+
+Examples:
+  $0                              # Reconcile everything
+  $0 hermes                       # Reconcile hermes only
+  $0 --fleet dev-mesh             # Reconcile agents in the dev-mesh fleet
+  $0 --prune                      # Reconcile + remove unmanaged agents
+  $0 --yes                        # Skip confirmation prompt (e.g. in CI)
+  $0 --yes --prune                # Reconcile + prune without confirmation prompt
+  $0 --dry-run --force            # Dry-run (force is handled correctly)
+  $0 --fail-fast                  # Stop on first error
+  $0 --retry                      # Re-attempt agents from last failure
+  $0 --retry --retry-file failed-agents.txt  # Retry only previously failed agents
+  $0 --lock-timeout 120           # Reconcile with 120s lock timeout
+  $0 --output json | jq .         # Machine-readable report
+  $0 --webhook http://host/hook   # Post report to webhook
+EOF
+}
+
+# Guard against writing snapshots to a dangerous or out-of-tree path (#391).
+# Args: <dir> <"set"|""> — second arg non-empty means SNAPSHOT_DIR was explicitly set.
+_guard_snapshot_dir() {
+    local dir="$1"
+    local explicitly_set="${2:-}"
+
+    # Always block the known dangerous fallback regardless of how it was derived.
+    if [[ "$dir" == "/.myrmidons/snapshots" ]]; then
+        echo "ERROR: snapshot dir resolved to '/.myrmidons/snapshots'." >&2
+        echo "  This usually means REPO_ROOT is empty or unset." >&2
+        echo "  Set SNAPSHOT_DIR explicitly or ensure REPO_ROOT is defined." >&2
+        exit 1
+    fi
+
+    # Block derived out-of-repo paths (only when SNAPSHOT_DIR was not explicitly set).
+    # Strip any trailing slash from REPO_ROOT (#487) so the glob below does not silently
+    # fail when REPO_ROOT is set to something like "/home/user/repo/" — the resulting
+    # pattern "/home/user/repo//*" would not match the legitimate default
+    # "/home/user/repo/.myrmidons/snapshots".
+    # NOTE: variable name avoids the lowercase "repo_root" substring (issue #370 invariant
+    # enforced by tests/unit/test_apply_sc2154.bats).
+    local REPO_ROOT_NOSLASH="${REPO_ROOT%/}"
+    if [[ -z "$explicitly_set" && "$dir" != "${REPO_ROOT_NOSLASH}"/* ]]; then
+        echo "ERROR: snapshot dir '${dir}' is outside the repo tree '${REPO_ROOT}'." >&2
+        echo "  REPO_ROOT may be empty or unset. Set SNAPSHOT_DIR explicitly to override." >&2
+        exit 1
+    fi
+}
+
+# Record a per-agent failure and increment error counter.
+# Usage: record_failure <agent_name> <http_status> <error_message>
+record_failure() {
+    local agent_name="$1"
+    local http_status="$2"
+    local error_message="$3"
+
+    local _sep=$'\x01'
+    ERRORS=$((ERRORS + 1))
+    FAILED_AGENTS_INFO+=("${agent_name}${_sep}${http_status}${_sep}${error_message}")
+}
+
+# Print a detailed per-agent error summary.
+print_error_summary() {
+    echo ""
+    echo "================================================"
+    echo "FAILED AGENTS (${ERRORS}):"
+    echo ""
+    local entry agent_name http_status error_msg
+    for entry in "${FAILED_AGENTS_INFO[@]}"; do
+        IFS=$'\x01' read -r agent_name http_status error_msg <<< "$entry"
+        echo "  [FAIL] ${agent_name}"
+        if [[ -n "$http_status" ]]; then
+            echo "         HTTP status: ${http_status}"
+        fi
+        if [[ -n "$error_msg" ]]; then
+            echo "         Error: ${error_msg}"
+        fi
+    done
+    echo ""
+    echo "Failed agents written to: ${FAILED_AGENTS_FILE}"
+    echo "Run 'just retry' to re-apply only failed agents."
+}
+
+# ---------------------------------------------------------------------------
+# #54 — Lock file: prevent concurrent apply runs
+# ---------------------------------------------------------------------------
+
+# acquire_lock — open AIM_LOCK_FILE on fd 9 and obtain an exclusive flock.
+# Waits up to AIM_LOCK_TIMEOUT seconds. Exits with error if it times out.
+# Release happens automatically when the fd is closed (i.e. process exits).
+acquire_lock() {
+    # Open (or create) the lock file on the dedicated fd.
+    # eval is the portable way to open a file on a dynamic fd number in bash.
+    eval "exec ${_LOCK_FD}>> \"\${AIM_LOCK_FILE}\""
+
+    if ! flock -w "${AIM_LOCK_TIMEOUT}" "${_LOCK_FD}"; then
+        echo "ERROR: Could not acquire apply lock '${AIM_LOCK_FILE}' within ${AIM_LOCK_TIMEOUT}s." >&2
+        echo "  Another apply.sh may be running. If not, remove the lock file and retry." >&2
+        echo "  Lock file: $(pwd)/${AIM_LOCK_FILE}" >&2
+        exit 1
+    fi
+}
+
+# release_lock — explicitly release the flock and close the fd.
+# Called from the EXIT trap so it runs even on error exit.
+release_lock() {
+    # Close the fd — flock is released automatically.
+    # Failure to close the fd is non-fatal (the EXIT trap will be called once
+    # only, so a missing fd is safe) but should be surfaced for debugging.
+    if ! eval "exec ${_LOCK_FD}>&-" 2>/dev/null; then
+        echo "warn: failed to close lock fd ${_LOCK_FD} (already closed?)" >&2
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# #48 — Confirmation prompt: count pending destructive ops and ask user
+# ---------------------------------------------------------------------------
+
+# count_destructive_ops — scan YAML files for agents that will need WAKE,
+# HIBERNATE, DELETE (PRUNE), or CREATE against current Agamemnon state.
+# Sets global _DESTRUCTIVE_COUNT.
+count_destructive_ops() {
+    local agents_json="$1"
+    shift
+    local yaml_files=("$@")
+    _DESTRUCTIVE_COUNT=0
+
+    for yaml_file in "${yaml_files[@]}"; do
+        local name desired_state actual_json actual_status
+        name="$(yq eval '.metadata.name' "$yaml_file")"
+        desired_state="$(yq eval '.spec.desiredState // "active"' "$yaml_file")"
+        actual_json="$(echo "$agents_json" | jq -r --arg n "$name" '.[] | select(.name == $n)')"
+
+        if [[ -z "$actual_json" ]]; then
+            # CREATE is destructive (new agent + potentially WAKE)
+            _DESTRUCTIVE_COUNT=$((_DESTRUCTIVE_COUNT + 1))
+            continue
+        fi
+
+        actual_status="$(echo "$actual_json" | jq -r '.status // "unknown"')"
+
+        if [[ "$desired_state" == "active" && "$actual_status" == "offline" ]]; then
+            _DESTRUCTIVE_COUNT=$((_DESTRUCTIVE_COUNT + 1))
+        elif [[ "$desired_state" == "hibernated" ]] && \
+             [[ "$actual_status" == "active" || "$actual_status" == "online" ]]; then
+            _DESTRUCTIVE_COUNT=$((_DESTRUCTIVE_COUNT + 1))
+        fi
+    done
+
+    # PRUNE operations are also destructive
+    if [[ $PRUNE -eq 1 ]]; then
+        local managed_names=()
+        for yaml_file in "${yaml_files[@]}"; do
+            managed_names+=("$(yq eval '.metadata.name' "$yaml_file")")
+        done
+        while IFS= read -r actual_name; do
+            local is_managed=0
+            for mn in "${managed_names[@]}"; do
+                [[ "$mn" == "$actual_name" ]] && is_managed=1 && break
+            done
+            [[ $is_managed -eq 0 ]] && _DESTRUCTIVE_COUNT=$((_DESTRUCTIVE_COUNT + 1))
+        done < <(echo "$agents_json" | jq -r '.[].name')
+    fi
+}
+
+# confirm_destructive — prompt the user if there are destructive ops pending
+# and --yes was not passed. Returns 0 if proceed, exits 0 if user declines.
+confirm_destructive() {
+    local total_changes="$1"
+
+    # Non-interactive or --yes: skip prompt
+    if [[ $YES -eq 1 ]] || [[ "${MYRMIDONS_YES:-}" == "true" ]] || [[ ! -t 0 ]]; then
+        return 0
+    fi
+
+    if [[ $_DESTRUCTIVE_COUNT -eq 0 ]]; then
+        return 0
+    fi
+
+    echo ""
+    echo "Pending changes: ${total_changes} total, ${_DESTRUCTIVE_COUNT} destructive (WAKE/HIBERNATE/CREATE/PRUNE)"
+    if ! confirm_with_timeout "Apply ${total_changes} change(s) to ${AGAMEMNON_URL}? [y/N]"; then
+        echo "Aborted."
+        exit 0
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# #41 — Convergence verification: re-check state after apply loop
+# ---------------------------------------------------------------------------
+
+# verify_convergence — re-fetch agent states for all modified agents and
+# confirm desired == actual. Reports any that did not converge.
+# Returns 1 if any agent failed to converge (caller should increment ERRORS).
+verify_convergence() {
+    if [[ ${#_MODIFIED_NAMES[@]} -eq 0 && ${#_PRUNED_NAMES[@]} -eq 0 ]]; then
+        return 0
+    fi
+
+    local failed=0
+    local verified=0
+    local pruned_verified=0
+
+    if [[ "$OUTPUT_FORMAT" != "json" ]]; then
+        echo ""
+        echo "Verifying convergence for ${#_MODIFIED_NAMES[@]} modified agent(s)..."
+        if [[ ${#_PRUNED_NAMES[@]} -gt 0 ]]; then
+            echo "Verifying ${#_PRUNED_NAMES[@]} pruned agent(s) are absent..."
+        fi
+    fi
+
+    # Refresh agent list once for all convergence checks
+    local agents_json_fresh
+    agents_json_fresh="$(agamemnon_list_agents)"
+
+    for i in "${!_MODIFIED_NAMES[@]}"; do
+        local agent_name="${_MODIFIED_NAMES[$i]}"
+        local desired="${_MODIFIED_DESIRED[$i]}"
+
+        local actual_json actual_status
+        actual_json="$(echo "$agents_json_fresh" | jq -r --arg n "$agent_name" '.[] | select(.name == $n)')"
+
+        if [[ -z "$actual_json" ]]; then
+            if [[ "$OUTPUT_FORMAT" != "json" ]]; then
+                echo "  [!] ${agent_name}: NOT FOUND in Agamemnon after apply (convergence failed)"
+            fi
+            report_add_convergence "$agent_name" "$desired" "not_found" 0 \
+                "not found in Agamemnon after apply"
+            failed=$((failed + 1))
+            continue
+        fi
+
+        actual_status="$(echo "$actual_json" | jq -r '.status // "unknown"')"
+
+        # Map desired state to expected runtime status
+        local converged=0
+        local reason=""
+        if [[ "$desired" == "active" ]]; then
+            # After a WAKE/CREATE, status should be active or online (not offline)
+            if [[ "$actual_status" == "active" || "$actual_status" == "online" || \
+                  "$actual_status" == "starting" ]]; then
+                converged=1
+                reason="status=${actual_status}"
+            else
+                reason="desired=active but actual_status=${actual_status}"
+            fi
+        elif [[ "$desired" == "hibernated" ]]; then
+            # After HIBERNATE, status should be offline or hibernated
+            if [[ "$actual_status" == "offline" || "$actual_status" == "hibernated" ]]; then
+                converged=1
+                reason="status=${actual_status}"
+            else
+                reason="desired=hibernated but actual_status=${actual_status}"
+            fi
+        else
+            # For UPDATE actions (field changes only), treat as converged if agent exists
+            converged=1
+            reason="update applied; status=${actual_status}"
+        fi
+
+        if [[ $converged -eq 1 ]]; then
+            if [[ "$OUTPUT_FORMAT" != "json" ]]; then
+                echo "  [ok] ${agent_name}: converged (status=${actual_status})"
+            fi
+            report_add_convergence "$agent_name" "$desired" "$actual_status" 1 "$reason"
+            verified=$((verified + 1))
+        else
+            if [[ "$OUTPUT_FORMAT" != "json" ]]; then
+                echo "  [!] ${agent_name}: NOT converged (desired=${desired}, actual_status=${actual_status})"
+            fi
+            report_add_convergence "$agent_name" "$desired" "$actual_status" 0 "$reason"
+            failed=$((failed + 1))
+        fi
+    done
+
+    # Verify pruned agents are gone from the API
+    if [[ ${#_PRUNED_NAMES[@]} -gt 0 ]]; then
+        for pruned_name in "${_PRUNED_NAMES[@]}"; do
+            local still_exists
+            still_exists="$(echo "$agents_json_fresh" | jq -r --arg n "$pruned_name" '.[] | select(.name == $n) | .name')"
+            if [[ -n "$still_exists" ]]; then
+                if [[ "$OUTPUT_FORMAT" != "json" ]]; then
+                    echo "  [!] ${pruned_name}: pruned but still present in API (convergence failed)"
+                fi
+                report_add_convergence "$pruned_name" "pruned" "present" 0 \
+                    "pruned but still present in Agamemnon API"
+                failed=$((failed + 1))
+            else
+                if [[ "$OUTPUT_FORMAT" != "json" ]]; then
+                    echo "  [ok] ${pruned_name}: confirmed absent (pruned)"
+                fi
+                pruned_verified=$((pruned_verified + 1))
+                report_add_convergence "$pruned_name" "pruned" "absent" 1 \
+                    "pruned and confirmed absent from Agamemnon API"
+            fi
+        done
+    fi
+
+    if [[ "$OUTPUT_FORMAT" != "json" ]]; then
+        if [[ ${#_PRUNED_NAMES[@]} -gt 0 ]]; then
+            echo "Convergence: ${verified} converged, ${pruned_verified} pruned, ${failed} failed."
+        else
+            echo "Convergence: ${verified} converged, ${failed} failed."
+        fi
+    fi
+
+    if [[ $failed -gt 0 ]]; then
+        return 1
+    fi
+    return 0
+}
+
+main() {
+    # Save original args before parse_args consumes them for dry-run filtering
+    local -a orig_args=("$@")
+
+    parse_args "$@"
+
+    # Validate AGAMEMNON_URL format early (#118)
+    validate_agamemnon_url
+
+    # Validate HOST argument against known agents/ subdirectories (#149)
+    if [[ -n "$HOST" && ! -d "${REPO_ROOT}/agents/${HOST}" ]]; then
+        echo "ERROR: Host '${HOST}' not found — no agents/${HOST}/ directory exists." >&2
+        echo "  Known hosts: $(find "${REPO_ROOT}/agents" -mindepth 1 -maxdepth 1 -type d \
+            ! -name '_templates' -printf '%f ' 2>/dev/null || echo '(none)')" >&2
+        exit 1
+    fi
+
+    # Export AIM_LOCK_TIMEOUT for use by child processes (e.g. api.sh)
+    export AIM_LOCK_TIMEOUT
+
+    if [[ $DRY_RUN -eq 1 ]]; then
+        # Strip --force, --dry-run, --lock-timeout, --snapshot-dir, --yes, --fail-fast,
+        # --retry, and --retry-file before forwarding to plan.sh (plan.sh doesn't understand these).
+        # --prune IS forwarded so plan.sh can show which unmanaged agents would
+        # be removed, preserving the prune intent in dry-run output. (#69, #71)
+        # --output and --webhook ARE also forwarded so plan.sh can emit JSON.
+        local -a clean_args=()
+        local skip_next=0
+        for arg in "${orig_args[@]}"; do
+            if [[ $skip_next -eq 1 ]]; then
+                skip_next=0
+                continue
+            fi
+            case "$arg" in
+                --force | --dry-run | --fail-fast | --retry | --yes | -y)
+                    continue
+                    ;;
+                --lock-timeout | --snapshot-dir | --retry-file)
+                    skip_next=1
+                    continue
+                    ;;
+                *)
+                    clean_args+=("$arg")
+                    ;;
+            esac
+        done
+
+        exec "${SCRIPT_DIR}/plan.sh" "${clean_args[@]}"
+    fi
+
+    check_deps
+    agamemnon_check_connection
+
+    # #54 — Acquire apply lock to prevent concurrent runs.
+    acquire_lock
+    trap 'release_lock; report_cleanup; cleanup_fleet_tmpdir' EXIT
+
+    # Check for agents/ and fleets/ directories
+    local has_agents=false
+    local has_fleets=false
+    [[ -d "${REPO_ROOT}/agents/" ]] && has_agents=true
+    [[ -d "${REPO_ROOT}/fleets/" ]] && has_fleets=true
+
+    if [[ "$has_agents" == "false" && "$has_fleets" == "false" ]]; then
+        log_error "Neither agents/ nor fleets/ directory found — nothing to reconcile"
+        exit 1
+    elif [[ "$has_agents" == "false" ]]; then
+        log_warn "agents/ directory not found — reconciling fleets only"
+    elif [[ "$has_fleets" == "false" ]]; then
+        log_warn "fleets/ directory not found — reconciling agents only"
+    fi
+
+    # Confirmation prompt when --prune is set (unless --yes or MYRMIDONS_YES=true)
+    if [[ $PRUNE -eq 1 && $YES -eq 0 && "${MYRMIDONS_YES:-}" != "true" ]]; then
+        echo "WARNING: --prune will hibernate and delete agents not in YAML."
+        if ! confirm_with_timeout "Continue? [y/N]"; then
+            echo "Aborted."
+            exit 0
+        fi
+    fi
+
+    # Initialise report accumulator
+    report_init "${HOST:-all}"
+
+    local agents_json
+    agents_json="$(agamemnon_list_agents)"
+
+    # Capture pre-apply snapshot (#228: includes context fields user/branch/host/timestamp)
+    local effective_snapshot_dir="${SNAPSHOT_DIR:-${REPO_ROOT}/.myrmidons/snapshots}"
+    # Guard: abort if snapshot dir is dangerous or outside repo tree (#391)
+    _guard_snapshot_dir "$effective_snapshot_dir" "${SNAPSHOT_DIR:+set}"
+    local snap_file
+    snap_file="$(snapshot_write "$agents_json" "$effective_snapshot_dir" "${HOST:-all}")"
+    snapshot_prune "$effective_snapshot_dir" "$SNAPSHOT_KEEP"
+    if [[ "$OUTPUT_FORMAT" != "json" ]]; then
+        echo "Snapshot saved: ${snap_file}"
+    fi
+
+    local yaml_files
+    if [[ $RETRY -eq 1 ]]; then
+        # Retry mode: read yaml_file paths directly from failed-agents.txt
+        if [[ ! -f "${FAILED_AGENTS_FILE}" ]] || [[ ! -s "${FAILED_AGENTS_FILE}" ]]; then
+            echo "No failed agents to retry (${FAILED_AGENTS_FILE} is empty or missing)."
+            exit 0
+        fi
+        mapfile -t yaml_files < "$FAILED_AGENTS_FILE"
+        echo "Retrying ${#yaml_files[@]} previously failed agent(s):"
+        for fn in "${yaml_files[@]}"; do echo "  - ${fn}"; done
+        echo ""
+    else
+        mapfile -t yaml_files < <(get_agent_files "$HOST" "$FLEET_NAME")
+    fi
+
+    # If --retry, filter yaml_files to only the agents listed in RETRY_FILE
+    if [[ $RETRY -eq 1 ]]; then
+        local effective_retry_file="${RETRY_FILE:-failed-agents.txt}"
+        if [[ -f "$effective_retry_file" ]]; then
+            local -a retry_files=()
+            while IFS= read -r agent_name; do
+                [[ -z "$agent_name" ]] && continue
+                for yaml_file in "${yaml_files[@]}"; do
+                    local fname_name
+                    fname_name="$(yq eval '.metadata.name' "$yaml_file")"
+                    if [[ "$fname_name" == "$agent_name" ]]; then
+                        retry_files+=("$yaml_file")
+                        break
+                    fi
+                done
+            done < "$effective_retry_file"
+            yaml_files=("${retry_files[@]}")
+        else
+            log_warn "--retry specified but retry file '${effective_retry_file}' not found; applying all agents"
+        fi
+    fi
+
+    if [[ ${#yaml_files[@]} -eq 0 ]]; then
+        if [[ "$OUTPUT_FORMAT" == "json" ]]; then
+            report_emit 0 0 0 0 0 0 0
+        else
+            echo "No agent YAML files found."
+        fi
+        exit 0
+    fi
+
+    # #48 — Count destructive ops and prompt for confirmation if needed.
+    count_destructive_ops "$agents_json" "${yaml_files[@]}"
+    local total_changes=${#yaml_files[@]}
+    confirm_destructive "$total_changes"
+
+    if [[ "$OUTPUT_FORMAT" != "json" ]]; then
+        echo "Applying desired state to ${AGAMEMNON_URL}"
+        echo "================================================"
+        echo ""
+    fi
+
+    # Truncate failed-agents file before this run (stores yaml_file paths for --retry)
+    mkdir -p "${MYRMIDONS_STATE_DIR}"
+    : > "$FAILED_AGENTS_FILE"
+
+    for yaml_file in "${yaml_files[@]}"; do
+        local errors_before=$ERRORS
+        apply_agent "$yaml_file" "$agents_json"
+
+        # If apply_agent recorded a new failure, store the yaml_file path for --retry
+        if [[ $ERRORS -gt $errors_before ]]; then
+            # Store the yaml_file path (not the agent name) so --retry can find it
+            echo "$yaml_file" >> "$FAILED_AGENTS_FILE"
+        fi
+
+        if [[ $FAIL_FAST -eq 1 && $ERRORS -gt 0 ]]; then
+            echo ""
+            echo "ERROR: --fail-fast enabled, stopping after first failure." >&2
+            break
+        fi
+
+        # Refresh actual state after each change
+        agents_json="$(agamemnon_list_agents)"
+    done
+
+    # Handle unmanaged agents.
+    # When --fleet is active, scope the check to only agents that belong to the
+    # fleet (i.e. agents whose names are in yaml_files), so agents managed by
+    # other fleets or outside this fleet are not flagged as unmanaged.
+    local scoped_agents_json
+    if [[ -n "$FLEET_NAME" ]]; then
+        local fleet_names_json
+        fleet_names_json="$(for f in "${yaml_files[@]}"; do yq eval '.metadata.name' "$f"; done | jq -Rsc 'split("\n") | map(select(length > 0))')"
+        scoped_agents_json="$(echo "$agents_json" | jq --argjson names "$fleet_names_json" '[.[] | select(.name as $n | $names | index($n) != null)]')"
+    else
+        scoped_agents_json="$agents_json"
+    fi
+    handle_unmanaged "$scoped_agents_json" "${yaml_files[@]}"
+
+    # #41 — Convergence verification: re-check all modified agents.
+    if ! verify_convergence; then
+        ERRORS=$((ERRORS + 1))
+    fi
+
+    # Write failed agents file when there were errors (and not a retry run)
+    if [[ $ERRORS -gt 0 && $RETRY -eq 0 ]]; then
+        _write_failed_agents_file
+    fi
+
+    # Emit output
+    if [[ "$OUTPUT_FORMAT" == "json" ]]; then
+        local report_json
+        report_json="$(report_emit "$CREATED" "$UPDATED" "$WOKEN" "$HIBERNATED" \
+                                   "$UNCHANGED" "$PRUNED" "$ERRORS")"
+        if [[ -n "$WEBHOOK_URL" ]]; then
+            local delivery_json
+            delivery_json="$(report_webhook "$report_json" "$WEBHOOK_URL")"
+            report_json="$(echo "$report_json" | jq --argjson d "$delivery_json" \
+                '. + {webhook_delivery: $d}')"
+        fi
+        report_save "$report_json"
+        echo "$report_json"
+    else
+        echo ""
+        echo "================================================"
+        echo "Summary: created=${CREATED} updated=${UPDATED} woken=${WOKEN} hibernated=${HIBERNATED} unchanged=${UNCHANGED} pruned=${PRUNED} errors=${ERRORS}"
+
+        # Always save a report file (silently) so report_save is useful even in text mode
+        local report_json
+        report_json="$(report_emit "$CREATED" "$UPDATED" "$WOKEN" "$HIBERNATED" \
+                                   "$UNCHANGED" "$PRUNED" "$ERRORS")"
+        if [[ -n "$WEBHOOK_URL" ]]; then
+            local delivery_json
+            delivery_json="$(report_webhook "$report_json" "$WEBHOOK_URL")"
+            report_json="$(echo "$report_json" | jq --argjson d "$delivery_json" \
+                '. + {webhook_delivery: $d}')"
+        fi
+        report_save "$report_json"
+    fi
+
+    if [[ $ERRORS -gt 0 ]]; then
+        print_error_summary
+
+        local total_processed=$(( CREATED + UPDATED + WOKEN + HIBERNATED + UNCHANGED + ERRORS ))
+        # Total failure: every processed agent either failed or none succeeded
+        if [[ $(( total_processed - ERRORS )) -eq 0 ]]; then
+            exit 2
+        fi
+        exit 1
+    fi
+
+    # Clear failed-agents file on full success (issue #269).
+    # This completes the self-managing lifecycle:
+    # - Populated during the apply loop with yaml_file paths of failed agents
+    # - Cleared here on full success (all agents passed in this run, $ERRORS == 0)
+    # This ensures the file always contains only agents currently failing, with no manual management needed.
+    if [[ -f "${FAILED_AGENTS_FILE}" ]]; then
+        : > "${FAILED_AGENTS_FILE}"
+    fi
+}
+
+# Write FAILED_AGENT_NAMES array to failed-agents.txt (one name per line).
+# FAILED_AGENT_NAMES holds metadata.name strings (e.g. "odyssey-mainline-analysis"), NOT
+# yaml_file paths. Do not confuse with FAILED_AGENT_STATUSES/FAILED_AGENT_MESSAGES (also
+# metadata.name strings, but used only for error-summary display in print_error_summary).
+# The FAILED_AGENTS_FILE written inline at line 583 uses yaml_file paths for --retry
+# resolution; this function writes to RETRY_FILE (default: failed-agents.txt) for a
+# different consumer. See #371.
+_write_failed_agents_file() {
+    local failed_file="${RETRY_FILE:-failed-agents.txt}"
+    if [[ ${#FAILED_AGENT_NAMES[@]} -gt 0 ]]; then
+        : > "$failed_file"
+        for agent_name in "${FAILED_AGENT_NAMES[@]}"; do
+            echo "$agent_name" >> "$failed_file"
+        done
+        log_warn "Wrote ${#FAILED_AGENT_NAMES[@]} failed agent(s) to ${failed_file}"
+    fi
+}
+
+apply_agent() {
+    local yaml_file="$1"
+    local agents_json="$2"
+
+    _LAST_CREATED_AGENT_JSON=""
+
+    # Parse YAML fields into local variables
+    local name label program workdir args desc tags owner role model deploy_type desired_state
+    name="$(yq eval '.metadata.name' "$yaml_file")"
+    local agent_host
+    agent_host="$(yq eval '.metadata.host // "hermes"' "$yaml_file")"
+    label="$(yq eval '.spec.label // ""' "$yaml_file")"
+    program="$(yq eval '.spec.program // "claude-code"' "$yaml_file")"
+    workdir="$(yq eval '.spec.workingDirectory // ""' "$yaml_file")"
+    args="$(yq eval '.spec.programArgs // ""' "$yaml_file")"
+    desc="$(yq eval '.spec.taskDescription // ""' "$yaml_file")"
+    tags="$(yq eval '.spec.tags // [] | join(",")' "$yaml_file")"
+    owner="$(yq eval '.spec.owner // ""' "$yaml_file")"
+    role="$(yq eval '.spec.role // "member"' "$yaml_file")"
+    model="$(yq eval '.spec.model // ""' "$yaml_file")"
+    deploy_type="$(yq eval '.spec.deployment.type // "local"' "$yaml_file")"
+    desired_state="$(yq eval '.spec.desiredState // "active"' "$yaml_file")"
+
+    # Look up actual agent
+    local actual_json
+    actual_json="$(echo "$agents_json" | jq -r --arg n "$name" '.[] | select(.name == $n)')"
+
+    if [[ -z "$actual_json" ]]; then
+        # CREATE
+        if [[ "$OUTPUT_FORMAT" != "json" ]]; then
+            echo "[+] Creating ${name}..."
+        fi
+        local create_body
+        create_body="$(build_create_json "$name" "$label" "$program" "$workdir" "$args" "$desc" "$tags" "$owner" "$role" "$model" "$deploy_type")"
+
+        local result
+        if result="$(agamemnon_create_agent "$create_body" 2>&1)"; then
+            local new_id
+            new_id="$(echo "$result" | jq -r '.id // empty')"
+            if [[ "$OUTPUT_FORMAT" != "json" ]]; then
+                echo "    Created: id=${new_id}"
+            fi
+            CREATED=$((CREATED + 1))
+            _LAST_CREATED_AGENT_JSON="$result"
+
+            local woke_status="created"
+            # Wake if desired
+            if [[ "$desired_state" == "active" && -n "$new_id" ]]; then
+                if [[ "$OUTPUT_FORMAT" != "json" ]]; then
+                    echo "    Starting ${name}..."
+                fi
+                agamemnon_wake_agent "$new_id" > /dev/null
+                if [[ "$OUTPUT_FORMAT" != "json" ]]; then
+                    echo "    Started."
+                fi
+                WOKEN=$((WOKEN + 1))
+                woke_status="active"
+            fi
+
+            # Track for convergence verification (#41)
+            _MODIFIED_NAMES+=("$name")
+            _MODIFIED_DESIRED+=("$desired_state")
+
+            report_add_agent "$name" "$agent_host" "CREATE" "$desired_state" "$woke_status" "[]" ""
+        else
+            # Try to extract HTTP status from error output
+            local http_status
+            http_status="$(echo "$result" | grep -oE 'HTTP [0-9]+' | grep -oE '[0-9]+' | head -1 || true)"
+            local err_msg
+            err_msg="$(echo "$result" | tail -1)"
+            if [[ "$OUTPUT_FORMAT" != "json" ]]; then
+                echo "    ERROR creating ${name}: ${err_msg}" >&2
+            fi
+            record_failure "$name" "$http_status" "$err_msg"
+            report_add_agent "$name" "$agent_host" "ERROR" "$desired_state" "unknown" "[]" "create failed: ${err_msg}"
+        fi
+        return
+    fi
+
+    # Agent exists — check what needs to change
+    local actual_id actual_status
+    actual_id="$(echo "$actual_json" | jq -r '.id')"
+    actual_status="$(echo "$actual_json" | jq -r '.status // "unknown"')"
+
+    local action
+    action="$(compute_drift "$name" "$desired_state" "$actual_json" \
+        "$label" "$program" "$workdir" "$args" "$desc" "$tags" "$model" "$owner" "$role" "$deploy_type")"
+
+    case "$action" in
+        UNCHANGED)
+            if [[ "$OUTPUT_FORMAT" != "json" ]]; then
+                echo "[=] Unchanged: ${name}"
+            fi
+            UNCHANGED=$((UNCHANGED + 1))
+            report_add_agent "$name" "$agent_host" "UNCHANGED" "$desired_state" "$actual_status" "[]" ""
+            ;;
+        WAKE)
+            if [[ "$OUTPUT_FORMAT" != "json" ]]; then
+                echo "[!] Starting ${name} (status=${actual_status}, desired=active)..."
+            fi
+            local wake_out
+            if wake_out="$(agamemnon_wake_agent "$actual_id" 2>&1)"; then
+                if [[ "$OUTPUT_FORMAT" != "json" ]]; then
+                    echo "    Started."
+                fi
+                WOKEN=$((WOKEN + 1))
+                # Track for convergence verification (#41)
+                _MODIFIED_NAMES+=("$name")
+                _MODIFIED_DESIRED+=("$desired_state")
+                report_add_agent "$name" "$agent_host" "WAKE" "$desired_state" "$actual_status" "[]" ""
+            else
+                local http_status err_msg
+                http_status="$(echo "$wake_out" | grep -oE 'HTTP [0-9]+' | grep -oE '[0-9]+' | head -1 || true)"
+                err_msg="$(echo "$wake_out" | tail -1)"
+                echo "    ERROR starting ${name}: ${err_msg}" >&2
+                record_failure "$name" "$http_status" "Failed to wake agent: ${err_msg}"
+                report_add_agent "$name" "$agent_host" "ERROR" "$desired_state" "$actual_status" "[]" "wake failed: ${err_msg}"
+            fi
+            ;;
+        HIBERNATE)
+            if [[ "$OUTPUT_FORMAT" != "json" ]]; then
+                echo "[z] Stopping ${name} (status=${actual_status}, desired=hibernated)..."
+            fi
+            local hib_out
+            if hib_out="$(agamemnon_hibernate_agent "$actual_id" 2>&1)"; then
+                if [[ "$OUTPUT_FORMAT" != "json" ]]; then
+                    echo "    Hibernated."
+                fi
+                HIBERNATED=$((HIBERNATED + 1))
+                # Track for convergence verification (#41)
+                _MODIFIED_NAMES+=("$name")
+                _MODIFIED_DESIRED+=("$desired_state")
+                report_add_agent "$name" "$agent_host" "HIBERNATE" "$desired_state" "$actual_status" "[]" ""
+            else
+                local http_status err_msg
+                http_status="$(echo "$hib_out" | grep -oE 'HTTP [0-9]+' | grep -oE '[0-9]+' | head -1 || true)"
+                err_msg="$(echo "$hib_out" | tail -1)"
+                echo "    ERROR stopping ${name}: ${err_msg}" >&2
+                record_failure "$name" "$http_status" "Failed to hibernate agent: ${err_msg}"
+                report_add_agent "$name" "$agent_host" "ERROR" "$desired_state" "$actual_status" "[]" "hibernate failed: ${err_msg}"
+            fi
+            ;;
+        UPDATE:*)
+            local changed_fields="${action#UPDATE:}"
+            if [[ "$OUTPUT_FORMAT" != "json" ]]; then
+                echo "[~] Updating ${name} (fields: ${changed_fields})..."
+            fi
+
+            local drift_json
+            drift_json="$(build_drift_json "$action" "$actual_json" \
+                "$label" "$program" "$workdir" "$args" "$desc" "$tags" "$owner" "$role")"
+
+            local tags_json
+            if [[ -z "$tags" ]]; then
+                tags_json="[]"
+            else
+                tags_json="$(echo "$tags" | jq -Rc 'split(",")')"
+            fi
+
+            local patch_body
+            # Note: $label is a reserved keyword in jq 1.6 (label-break syntax).
+            # Use $lbl as the variable name to avoid the parser conflict.
+            patch_body="$(jq -n \
+                --arg lbl "$label" \
+                --arg program "$program" \
+                --arg workingDirectory "$workdir" \
+                --arg programArgs "$args" \
+                --arg taskDescription "$desc" \
+                --argjson tags "$tags_json" \
+                --arg owner "$owner" \
+                --arg role "$role" \
+                '{label: $lbl, program: $program, workingDirectory: $workingDirectory,
+                  programArgs: $programArgs, taskDescription: $taskDescription,
+                  tags: $tags, owner: $owner, role: $role}')"
+
+            local update_out
+            if update_out="$(agamemnon_update_agent "$actual_id" "$patch_body" 2>&1)"; then
+                if [[ "$OUTPUT_FORMAT" != "json" ]]; then
+                    echo "    Updated."
+                fi
+                UPDATED=$((UPDATED + 1))
+                # Track for convergence verification (#41)
+                _MODIFIED_NAMES+=("$name")
+                _MODIFIED_DESIRED+=("$desired_state")
+                report_add_agent "$name" "$agent_host" "UPDATE" "$desired_state" "$actual_status" "$drift_json" ""
+
+                # Also start/stop if state needs to change
+                if [[ "$desired_state" == "active" && "$actual_status" == "offline" ]]; then
+                    agamemnon_wake_agent "$actual_id" > /dev/null
+                    WOKEN=$((WOKEN + 1))
+                elif [[ "$desired_state" == "hibernated" && \
+                        ("$actual_status" == "active" || "$actual_status" == "online") ]]; then
+                    agamemnon_hibernate_agent "$actual_id" > /dev/null
+                    HIBERNATED=$((HIBERNATED + 1))
+                fi
+            else
+                local http_status
+                http_status="$(echo "$update_out" | grep -oE 'HTTP [0-9]+' | grep -oE '[0-9]+' | head -1 || true)"
+                local err_msg
+                err_msg="$(echo "$update_out" | tail -1)"
+                if [[ "$OUTPUT_FORMAT" != "json" ]]; then
+                    echo "    ERROR updating ${name}: ${err_msg}" >&2
+                fi
+                record_failure "$name" "$http_status" "Failed to update fields [${changed_fields}]: ${err_msg}"
+                report_add_agent "$name" "$agent_host" "ERROR" "$desired_state" "$actual_status" "$drift_json" "update failed: ${err_msg}"
+            fi
+            ;;
+    esac
+}
+
+handle_unmanaged() {
+    local agents_json="$1"
+    shift
+    local yaml_files=("$@")
+
+    # Collect managed names
+    local managed_names=()
+    for yaml_file in "${yaml_files[@]}"; do
+        local n
+        n="$(yq eval '.metadata.name' "$yaml_file")"
+        managed_names+=("$n")
+    done
+
+    # Find unmanaged
+    while IFS= read -r actual_name; do
+        local is_managed=0
+        for mn in "${managed_names[@]}"; do
+            [[ "$mn" == "$actual_name" ]] && is_managed=1 && break
+        done
+
+        if [[ $is_managed -eq 0 ]]; then
+            if [[ $PRUNE -eq 1 ]]; then
+                local agent_id
+                agent_id="$(echo "$agents_json" | jq -r --arg n "$actual_name" \
+                    '.[] | select(.name == $n) | .id')"
+                if [[ "$OUTPUT_FORMAT" != "json" ]]; then
+                    echo "[-] Pruning unmanaged: ${actual_name}"
+                    echo "    Hibernating first..."
+                fi
+                # Hibernate is best-effort: deleting an already-offline agent
+                # is fine. Surface a warning so transient API errors are
+                # visible in the apply log even though prune continues.
+                if ! agamemnon_hibernate_agent "$agent_id" > /dev/null; then
+                    echo "    warn: pre-delete hibernate failed for ${actual_name} (continuing to delete)" >&2
+                fi
+                sleep "$HIBERNATE_SETTLE_SECONDS"
+                if [[ "$OUTPUT_FORMAT" != "json" ]]; then
+                    echo "    Deleting..."
+                fi
+                agamemnon_delete_agent "$agent_id" > /dev/null
+                if [[ "$OUTPUT_FORMAT" != "json" ]]; then
+                    echo "    Deleted (backup created)."
+                fi
+                PRUNED=$((PRUNED + 1))
+                # Track pruned names for convergence verification
+                _PRUNED_NAMES+=("$actual_name")
+                report_add_agent "$actual_name" "-" "PRUNE" "-" "pruned" "[]" ""
+            else
+                if [[ "$OUTPUT_FORMAT" != "json" ]]; then
+                    echo "[-] UNMANAGED: ${actual_name} (in Agamemnon but not in YAML — use --prune to remove)"
+                fi
+                report_add_unmanaged "$actual_name"
+            fi
+        fi
+    done < <(echo "$agents_json" | jq -r '.[].name')
+}
+
+main "$@"

--- a/tools/reconciler/scripts/diff.sh
+++ b/tools/reconciler/scripts/diff.sh
@@ -1,0 +1,305 @@
+#!/usr/bin/env bash
+# scripts/diff.sh — Field-level diff: YAML desired state vs Agamemnon actual state
+#
+# Shows a detailed, field-by-field comparison for each drifted agent.
+# Output is similar to `terraform plan`: old → new values side-by-side.
+# Agents with no drift produce no output (zero output = clean).
+#
+# Usage:
+#   ./scripts/diff.sh                      # Diff all agents on all hosts
+#   ./scripts/diff.sh hermes               # Diff agents for a specific host
+#   ./scripts/diff.sh --host hermes        # Same as above
+#   ./scripts/diff.sh --agent my-agent     # Diff a specific agent
+#   ./scripts/diff.sh hermes --agent foo   # Combine host + agent filters
+#
+# Exit codes:
+#   0 = no drift (all agents match)
+#   1 = drift detected (or error)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=scripts/lib/api.sh
+source "${SCRIPT_DIR}/lib/api.sh"
+# shellcheck source=scripts/lib/reconcile.sh
+source "${SCRIPT_DIR}/lib/reconcile.sh"
+
+HOST=""
+AGENT_FILTER=""
+
+# ---------------------------------------------------------------------------
+# Color support
+# ---------------------------------------------------------------------------
+
+_color_enabled() {
+    [[ -t 1 ]] && [[ -z "${NO_COLOR:-}" ]]
+}
+
+RED=""
+GREEN=""
+YELLOW=""
+BOLD=""
+RESET=""
+
+if _color_enabled; then
+    RED="\033[0;31m"
+    GREEN="\033[0;32m"
+    YELLOW="\033[1;33m"
+    BOLD="\033[1m"
+    RESET="\033[0m"
+fi
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --host)    HOST="$2"; shift 2 ;;
+            --agent)   AGENT_FILTER="$2"; shift 2 ;;
+            -h|--help) usage; exit 0 ;;
+            *)         HOST="$1"; shift ;;
+        esac
+    done
+}
+
+usage() {
+    echo "Usage: $0 [host] [--host <host>] [--agent <name>]"
+    echo ""
+    echo "Shows field-level differences between desired state (YAML) and"
+    echo "actual state (Agamemnon API) for each drifted agent."
+    echo ""
+    echo "Options:"
+    echo "  host             Filter by host (positional or --host)"
+    echo "  --host <host>    Filter by host"
+    echo "  --agent <name>   Show diff for a single agent only"
+    echo "  --help           Show this help"
+    echo ""
+    echo "Output:"
+    echo "  Zero output when no drift exists."
+    echo "  Field changes shown as:  field: \"old\" → \"new\""
+    echo ""
+    echo "Exit codes:"
+    echo "  0 = no drift"
+    echo "  1 = drift detected"
+    echo ""
+    echo "Examples:"
+    echo "  $0                     # All hosts"
+    echo "  $0 hermes              # Only hermes"
+    echo "  $0 --agent my-agent    # One agent across all hosts"
+    echo "  NO_COLOR=1 $0          # Disable color output"
+}
+
+# ---------------------------------------------------------------------------
+# Tag diff helpers
+# ---------------------------------------------------------------------------
+
+# Print added/removed items in a tag comparison.
+# Usage: diff_tags <desired_csv> <actual_csv>
+diff_tags() {
+    local desired_csv="$1"
+    local actual_csv="$2"
+
+    # Build sorted arrays
+    local desired_tags=()
+    local actual_tags=()
+
+    if [[ -n "$desired_csv" ]]; then
+        mapfile -t desired_tags < <(echo "$desired_csv" | tr ',' '\n' | sort)
+    fi
+    if [[ -n "$actual_csv" ]]; then
+        mapfile -t actual_tags < <(echo "$actual_csv" | tr ',' '\n' | sort)
+    fi
+
+    # Added (in desired, not in actual)
+    for tag in "${desired_tags[@]+"${desired_tags[@]}"}"; do
+        local found=0
+        for at in "${actual_tags[@]+"${actual_tags[@]}"}"; do
+            [[ "$tag" == "$at" ]] && found=1 && break
+        done
+        if [[ $found -eq 0 ]]; then
+            printf "        ${GREEN}+ %s${RESET}\n" "$tag"
+        fi
+    done
+
+    # Removed (in actual, not in desired)
+    for tag in "${actual_tags[@]+"${actual_tags[@]}"}"; do
+        local found=0
+        for dt in "${desired_tags[@]+"${desired_tags[@]}"}"; do
+            [[ "$tag" == "$dt" ]] && found=1 && break
+        done
+        if [[ $found -eq 0 ]]; then
+            printf "        ${RED}- %s${RESET}\n" "$tag"
+        fi
+    done
+}
+
+# ---------------------------------------------------------------------------
+# Per-agent diff
+# ---------------------------------------------------------------------------
+
+# Print field-level diff for one agent. Returns 1 if drift was found.
+diff_agent() {
+    local yaml_file="$1"
+    local agents_json="$2"
+
+    # Parse YAML fields
+    declare -A fields
+    while IFS='=' read -r key value; do
+        fields["$key"]="${value}"
+    done < <(parse_agent_yaml "$yaml_file")
+
+    local name="${fields[name]}"
+    local desired_state="${fields[desiredState]:-active}"
+    local desired_label="${fields[label]:-}"
+    local desired_program="${fields[program]:-}"
+    local desired_workdir
+    desired_workdir="$(normalize_path "${fields[workingDirectory]:-}")"
+    local desired_args="${fields[programArgs]:-}"
+    local desired_desc="${fields[taskDescription]:-}"
+    local desired_tags_csv="${fields[tags]:-}"
+
+    # Apply --agent filter
+    if [[ -n "$AGENT_FILTER" && "$name" != "$AGENT_FILTER" ]]; then
+        return 0
+    fi
+
+    # Look up actual state
+    local actual_json
+    actual_json="$(echo "$agents_json" | jq -r --arg name "$name" \
+        '.[] | select(.name == $name)')"
+
+    if [[ -z "$actual_json" ]]; then
+        printf "${BOLD}${GREEN}[+] %s${RESET} — not in Agamemnon (would be created)\n" "$name"
+        printf "    %-20s ${GREEN}\"%s\"${RESET}\n" "label:"            "$desired_label"
+        printf "    %-20s ${GREEN}\"%s\"${RESET}\n" "program:"          "$desired_program"
+        printf "    %-20s ${GREEN}\"%s\"${RESET}\n" "workingDirectory:" "$desired_workdir"
+        if [[ -n "$desired_args" ]]; then
+            printf "    %-20s ${GREEN}\"%s\"${RESET}\n" "programArgs:"  "$desired_args"
+        fi
+        if [[ -n "$desired_desc" ]]; then
+            printf "    %-20s ${GREEN}\"%s\"${RESET}\n" "taskDescription:" "$desired_desc"
+        fi
+        if [[ -n "$desired_tags_csv" ]]; then
+            printf "    %-20s ${GREEN}\"%s\"${RESET}\n" "tags:"         "$desired_tags_csv"
+        fi
+        printf "    %-20s ${GREEN}\"%s\"${RESET}\n" "desiredState:"     "$desired_state"
+        echo ""
+        return 1
+    fi
+
+    local actual_status
+    actual_status="$(echo "$actual_json" | jq -r '.status // "unknown"')"
+
+    # Check lifecycle drift first
+    if [[ "$desired_state" == "active" && "$actual_status" == "offline" ]]; then
+        printf "${BOLD}${YELLOW}[!] %s${RESET} — needs wake (desired=active, actual=offline)\n" "$name"
+        return 1
+    fi
+    if [[ "$desired_state" == "hibernated" ]] && \
+       [[ "$actual_status" == "active" || "$actual_status" == "online" ]]; then
+        printf "${BOLD}${YELLOW}[z] %s${RESET} — needs hibernate (desired=hibernated, actual=%s)\n" \
+            "$name" "$actual_status"
+        return 1
+    fi
+
+    # Extract actual field values
+    local actual_label actual_program actual_workdir actual_args actual_desc actual_tags
+    actual_label="$(echo "$actual_json" | jq -r '.label // ""')"
+    actual_program="$(echo "$actual_json" | jq -r '.program // ""')"
+    actual_workdir="$(normalize_path "$(echo "$actual_json" | jq -r '.workingDirectory // ""')")"
+    actual_args="$(echo "$actual_json" | jq -r '.programArgs // ""')"
+    actual_desc="$(echo "$actual_json" | jq -r '.taskDescription // ""')"
+    actual_tags="$(echo "$actual_json" | jq -r '.tags // [] | sort | join(",")')"
+
+    # Sort desired tags for stable comparison
+    local desired_tags_sorted=""
+    if [[ -n "$desired_tags_csv" ]]; then
+        desired_tags_sorted="$(echo "$desired_tags_csv" | tr ',' '\n' | sort | tr '\n' ',' | sed 's/,$//')"
+    fi
+
+    # Collect drifted fields
+    local has_drift=0
+    local drift_lines=()
+
+    _check_field_drift() {
+        local field="$1" desired="$2" actual="$3"
+        if [[ "$desired" != "$actual" ]]; then
+            drift_lines+=("$(printf "    %-20s ${RED}\"%s\"${RESET} → ${GREEN}\"%s\"${RESET}" \
+                "${field}:" "$actual" "$desired")")
+            has_drift=1
+        fi
+    }
+
+    _check_field_drift "label"            "$desired_label"         "$actual_label"
+    _check_field_drift "program"          "$desired_program"       "$actual_program"
+    _check_field_drift "workingDirectory" "$desired_workdir"       "$actual_workdir"
+    _check_field_drift "programArgs"      "$desired_args"          "$actual_args"
+    _check_field_drift "taskDescription"  "$desired_desc"          "$actual_desc"
+
+    # Tags are handled separately
+    local tags_differ=0
+    if [[ "$desired_tags_sorted" != "$actual_tags" ]]; then
+        tags_differ=1
+        has_drift=1
+    fi
+
+    if [[ $has_drift -eq 0 ]]; then
+        return 0
+    fi
+
+    # Print agent header
+    printf "${BOLD}[~] %s${RESET}\n" "$name"
+
+    # Print scalar field diffs
+    for line in "${drift_lines[@]+"${drift_lines[@]}"}"; do
+        echo -e "$line"
+    done
+
+    # Print tag diff if needed
+    if [[ $tags_differ -eq 1 ]]; then
+        printf "    %-20s\n" "tags:"
+        diff_tags "$desired_tags_sorted" "$actual_tags"
+    fi
+
+    echo ""
+    return 1
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+main() {
+    parse_args "$@"
+    check_deps
+    agamemnon_check_connection
+
+    local agents_json
+    agents_json="$(agamemnon_list_agents)"
+
+    local yaml_files
+    mapfile -t yaml_files < <(get_agent_files "$HOST")
+
+    if [[ ${#yaml_files[@]} -eq 0 ]]; then
+        echo "No agent YAML files found."
+        exit 0
+    fi
+
+    local has_drift=0
+
+    for yaml_file in "${yaml_files[@]}"; do
+        diff_agent "$yaml_file" "$agents_json" || has_drift=1
+    done
+
+    if [[ $has_drift -eq 0 ]]; then
+        echo "No drift detected. Desired state matches actual state."
+        exit 0
+    else
+        exit 1
+    fi
+}
+
+main "$@"

--- a/tools/reconciler/scripts/doctor.sh
+++ b/tools/reconciler/scripts/doctor.sh
@@ -1,0 +1,410 @@
+#!/usr/bin/env bash
+# scripts/doctor.sh — Environment health check for Myrmidons
+#
+# Validates the local setup: required tools, Agamemnon connectivity,
+# YAML schema validity, git hooks, and pixi environment.
+#
+# Usage:
+#   ./scripts/doctor.sh
+#   just doctor
+#
+# Exit codes:
+#   0 = all checks passed
+#   1 = one or more checks failed
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# shellcheck source=scripts/lib/config.sh
+source "${SCRIPT_DIR}/lib/config.sh"
+load_config
+
+# shellcheck source=scripts/lib/api.sh
+source "${SCRIPT_DIR}/lib/api.sh"
+
+# MYRM_AIM_HOST is populated by load_config; fall back to env/default for safety.
+AGAMEMNON_URL="${AGAMEMNON_URL:-${MYRM_AIM_HOST:-http://localhost:8080}}"
+
+# Flags
+SKIP_CONNECTIVITY=false
+SKIP_HOOKS=false
+
+# Parse command-line flags
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --skip-connectivity) SKIP_CONNECTIVITY=true; shift ;;
+        --skip-hooks) SKIP_HOOKS=true; shift ;;
+        *) shift ;;
+    esac
+done
+
+# Counters
+PASS=0
+FAIL=0
+
+# =============================================================================
+# Output helpers
+# =============================================================================
+
+# Only use ANSI colors when stdout is a TTY (not piped)
+if [[ -t 1 ]]; then
+    green()  { printf '\033[0;32m%s\033[0m' "$*"; }
+    red()    { printf '\033[0;31m%s\033[0m' "$*"; }
+    yellow() { printf '\033[1;33m%s\033[0m' "$*"; }
+else
+    green()  { printf '%s' "$*"; }  # allow-duplicate-function: if/else TTY vs plain-text branch
+    red()    { printf '%s' "$*"; }  # allow-duplicate-function: if/else TTY vs plain-text branch
+    yellow() { printf '%s' "$*"; }  # allow-duplicate-function: if/else TTY vs plain-text branch
+fi
+
+pass() {
+    local label="$1"
+    local detail="${2:-}"
+    printf '  %s %s' "$(green "[PASS]")" "$label"
+    if [[ -n "$detail" ]]; then
+        printf ' (%s)' "$detail"
+    fi
+    printf '\n'
+    PASS=$((PASS + 1))
+}
+
+fail() {
+    local label="$1"
+    local hint="${2:-}"
+    printf '  %s %s\n' "$(red "[FAIL]")" "$label"
+    if [[ -n "$hint" ]]; then
+        printf '         %s\n' "$(yellow "→ ${hint}")"
+    fi
+    FAIL=$((FAIL + 1))
+}
+
+warn() {
+    local label="$1"
+    local hint="${2:-}"
+    printf '  %s %s\n' "$(yellow "[WARN]")" "$label"
+    if [[ -n "$hint" ]]; then
+        printf '         %s\n' "$(yellow "→ ${hint}")"
+    fi
+}
+
+section() {
+    printf '\n%s\n' "$*"
+}
+
+# =============================================================================
+# Check 1: Required tools
+# =============================================================================
+
+check_tools() {
+    section "Check 1: Required tools"
+
+    local tools=(yq jq curl)
+    local install_hints=(
+        "https://github.com/mikefarah/yq"
+        "apt install jq  /  brew install jq"
+        "apt install curl  /  brew install curl"
+    )
+
+    for i in "${!tools[@]}"; do
+        local cmd="${tools[$i]}"
+        local hint="${install_hints[$i]}"
+        if command -v "$cmd" &>/dev/null; then
+            local version
+            version="$("$cmd" --version 2>&1 | head -1)" || version="(version unknown)"
+            pass "$cmd" "$version"
+        else
+            fail "$cmd not found" "Install: ${hint}"
+        fi
+    done
+}
+
+# =============================================================================
+# Check 2: Agamemnon connectivity
+# =============================================================================
+
+check_connectivity() {
+    section "Check 2: Agamemnon connectivity"
+
+    printf '  URL: %s\n' "$AGAMEMNON_URL"
+
+    # Validate URL format (#118)
+    if [[ -z "$AGAMEMNON_URL" ]]; then
+        fail "AGAMEMNON_URL is not set" \
+            "Export AGAMEMNON_URL before running (e.g. export AGAMEMNON_URL=http://localhost:8080)"
+        return
+    fi
+    case "$AGAMEMNON_URL" in
+        http://*|https://*) ;;
+        *)
+            fail "AGAMEMNON_URL has an unrecognised scheme: ${AGAMEMNON_URL}" \
+                "Expected a URL beginning with http:// or https://"
+            return
+            ;;
+    esac
+
+    if [[ "$SKIP_CONNECTIVITY" == "true" ]]; then
+        warn "Agamemnon connectivity (skipped via --skip-connectivity)"
+        return 0
+    fi
+
+    # Health endpoint — guard xtrace so AGAMEMNON_API_KEY does not leak if set
+    _agamemnon_auth_headers
+    local http_code
+    local _had_xtrace=0
+    if [[ "$-" == *x* ]]; then _had_xtrace=1; fi
+    { set +x; } 2>/dev/null
+    http_code="$(curl -s --max-time 5 -o /dev/null -w "%{http_code}" \
+        "${_AGAMEMNON_TLS_FLAGS[@]+"${_AGAMEMNON_TLS_FLAGS[@]}"}" \
+        "${_AUTH_HEADERS[@]+"${_AUTH_HEADERS[@]}"}" \
+        "${AGAMEMNON_URL}/v1/health" 2>/dev/null)" || http_code="000"
+    if [[ $_had_xtrace -eq 1 ]]; then set -x; fi
+
+    if [[ "$http_code" == "200" ]]; then
+        pass "Agamemnon reachable at ${AGAMEMNON_URL}" "HTTP ${http_code}"
+    elif [[ "$http_code" == "000" ]]; then
+        fail "Agamemnon unreachable at ${AGAMEMNON_URL}" \
+            "Is ProjectAgamemnon running? Check AGAMEMNON_URL env var."
+        return
+    else
+        fail "Agamemnon health check failed" \
+            "HTTP ${http_code} — check ProjectAgamemnon logs"
+        return
+    fi
+
+    # List agents endpoint (API functional check) — same xtrace guard
+    local agents_code
+    _had_xtrace=0
+    if [[ "$-" == *x* ]]; then _had_xtrace=1; fi
+    { set +x; } 2>/dev/null
+    agents_code="$(curl -s --max-time 5 -o /dev/null -w "%{http_code}" \
+        "${_AGAMEMNON_TLS_FLAGS[@]+"${_AGAMEMNON_TLS_FLAGS[@]}"}" \
+        "${_AUTH_HEADERS[@]+"${_AUTH_HEADERS[@]}"}" \
+        "${AGAMEMNON_URL}/v1/agents" 2>/dev/null)" || agents_code="000"
+    if [[ $_had_xtrace -eq 1 ]]; then set -x; fi
+
+    if [[ "${agents_code:0:1}" == "2" ]]; then
+        pass "Agamemnon API responding" "GET /v1/agents → HTTP ${agents_code}"
+    else
+        fail "Agamemnon API not responding correctly" \
+            "GET /v1/agents returned HTTP ${agents_code}"
+    fi
+}
+
+# =============================================================================
+# Check 3: YAML validation
+# =============================================================================
+
+check_yaml() {
+    section "Check 3: YAML validation"
+
+    if ! command -v yq &>/dev/null; then
+        warn "Skipping YAML check (yq not installed)"
+        return
+    fi
+
+    local errors=0
+    local checked=0
+    local yaml_files=()
+
+    while IFS= read -r -d '' file; do
+        [[ "$file" == *"/_templates/"* ]] && continue
+        yaml_files+=("$file")
+    done < <(find "${REPO_ROOT}/agents" "${REPO_ROOT}/fleets" \
+        -name "*.yaml" -print0 2>/dev/null)
+
+    if [[ ${#yaml_files[@]} -eq 0 ]]; then
+        warn "No agent/fleet YAML files found"
+        return
+    fi
+
+    for file in "${yaml_files[@]}"; do
+        checked=$((checked + 1))
+        local rel="${file#"${REPO_ROOT}/"}"
+
+        # Syntax check
+        if ! yq eval '.' "$file" > /dev/null 2>&1; then
+            fail "${rel}: invalid YAML syntax"
+            errors=$((errors + 1))
+            continue
+        fi
+
+        local api_version kind
+        api_version="$(yq eval '.apiVersion // ""' "$file")"
+        kind="$(yq eval '.kind // ""' "$file")"
+
+        if [[ "$api_version" != "myrmidons/v1" ]]; then
+            fail "${rel}: wrong apiVersion ('${api_version}')" \
+                "Expected myrmidons/v1"
+            errors=$((errors + 1))
+            continue
+        fi
+
+        if [[ "$kind" != "Agent" && "$kind" != "Fleet" ]]; then
+            fail "${rel}: invalid kind ('${kind}')" \
+                "Expected Agent or Fleet"
+            errors=$((errors + 1))
+            continue
+        fi
+
+        if [[ "$kind" == "Fleet" ]]; then
+            local fleet_name
+            fleet_name="$(yq eval '.metadata.name // ""' "$file")"
+            if [[ -z "$fleet_name" ]]; then
+                fail "${rel}: metadata.name required in Fleet"
+                errors=$((errors + 1))
+            else
+                pass "${rel}" "Fleet: ${fleet_name}"
+            fi
+            continue
+        fi
+
+        # Agent field validation
+        local name host program workdir desired_state deploy_type
+        name="$(yq eval '.metadata.name // ""' "$file")"
+        host="$(yq eval '.metadata.host // ""' "$file")"
+        program="$(yq eval '.spec.program // ""' "$file")"
+        workdir="$(yq eval '.spec.workingDirectory // ""' "$file")"
+        desired_state="$(yq eval '.spec.desiredState // ""' "$file")"
+        deploy_type="$(yq eval '.spec.deployment.type // "local"' "$file")"
+
+        local field_errors=()
+        [[ -z "$name" ]] && field_errors+=("metadata.name is required")
+        [[ -z "$host" ]] && field_errors+=("metadata.host is required")
+        [[ -z "$program" ]] && field_errors+=("spec.program is required")
+        [[ -z "$workdir" ]] && field_errors+=("spec.workingDirectory is required")
+        if [[ -n "$desired_state" && "$desired_state" != "active" && "$desired_state" != "hibernated" ]]; then
+            field_errors+=("spec.desiredState must be 'active' or 'hibernated'")
+        fi
+        if [[ "$deploy_type" != "local" && "$deploy_type" != "docker" ]]; then
+            field_errors+=("spec.deployment.type must be 'local' or 'docker'")
+        fi
+
+        if [[ ${#field_errors[@]} -gt 0 ]]; then
+            fail "${rel}: field validation failed"
+            for err in "${field_errors[@]}"; do
+                printf '           - %s\n' "$err"
+            done
+            errors=$((errors + 1))
+        else
+            pass "${rel}" "Agent: ${name}"
+        fi
+    done
+
+    if [[ $errors -eq 0 ]]; then
+        printf '  %s\n' "$(green "All ${checked} file(s) valid.")"
+    fi
+}
+
+# =============================================================================
+# Check 4: Git hooks
+# =============================================================================
+
+check_hooks() {
+    section "Check 4: Git hooks"
+
+    if [[ "$SKIP_HOOKS" == "true" ]]; then
+        warn "pre-commit hook check skipped (--skip-hooks)"
+        return
+    fi
+
+    local hook_src="${REPO_ROOT}/hooks/pre-commit"
+    local hook_dst="${REPO_ROOT}/.git/hooks/pre-commit"
+
+    if [[ ! -f "$hook_src" ]]; then
+        warn "hooks/pre-commit source not found in repo"
+        return
+    fi
+
+    if [[ ! -f "$hook_dst" ]]; then
+        fail "pre-commit hook not installed" \
+            "Run: just install-hooks"
+    elif [[ ! -x "$hook_dst" ]]; then
+        fail "pre-commit hook not executable" \
+            "Run: chmod +x .git/hooks/pre-commit"
+    else
+        pass "pre-commit hook installed and executable"
+    fi
+}
+
+# =============================================================================
+# Check 5: pixi environment
+# =============================================================================
+
+check_pixi() {
+    section "Check 5: pixi environment"
+
+    if ! command -v pixi &>/dev/null; then
+        warn "pixi not found — skipping environment check" \
+            "Install: https://prefix.dev/docs/pixi/overview"
+        return
+    fi
+
+    local version
+    version="$(pixi --version 2>&1 | head -1)" || version="(unknown)"
+    pass "pixi installed" "$version"
+
+    local pixi_toml="${REPO_ROOT}/pixi.toml"
+    if [[ ! -f "$pixi_toml" ]]; then
+        warn "pixi.toml not found — skipping environment validation"
+        return
+    fi
+
+    # Check if the pixi environment is initialised (has a lockfile)
+    local lock="${REPO_ROOT}/pixi.lock"
+    if [[ -f "$lock" ]]; then
+        pass "pixi.lock present"
+    else
+        warn "pixi.lock not found" \
+            "Run: pixi install"
+    fi
+
+    # Verify that core deps resolve inside the pixi shell
+    if pixi run --manifest-path "$pixi_toml" yq --version &>/dev/null 2>&1; then
+        pass "pixi environment active (yq accessible)"
+    else
+        warn "pixi environment not active or deps missing" \
+            "Run: pixi install"
+    fi
+}
+
+# =============================================================================
+# Summary
+# =============================================================================
+
+print_summary() {
+    local total=$((PASS + FAIL))
+    printf '\n'
+    printf '━%.0s' {1..50}
+    printf '\n'
+    printf 'Summary: %s passed, %s failed (of %s checks)\n' \
+        "$(green "$PASS")" "$(if [[ $FAIL -gt 0 ]]; then red "$FAIL"; else echo "$FAIL"; fi)" "$total"
+
+    if [[ $FAIL -gt 0 ]]; then
+        printf '\n%s\n' "$(red "Doctor found issues. Fix the failures above before running scripts.")"
+        return 1
+    else
+        printf '\n%s\n' "$(green "All checks passed. Environment looks healthy.")"
+        return 0
+    fi
+}
+
+# =============================================================================
+# Main
+# =============================================================================
+
+main() {
+    printf 'Myrmidons Doctor — environment health check\n'
+    printf 'AGAMEMNON_URL=%s\n' "$AGAMEMNON_URL"
+
+    check_tools
+    check_connectivity
+    check_yaml
+    check_hooks
+    check_pixi
+
+    print_summary
+}
+
+main "$@"

--- a/tools/reconciler/scripts/export.sh
+++ b/tools/reconciler/scripts/export.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# scripts/export.sh — Bootstrap: export current Agamemnon agents to YAML
+#
+# Reads the current agent registry from Agamemnon and writes one YAML
+# file per agent into agents/<host>/.
+#
+# Usage:
+#   ./scripts/export.sh hermes
+#   ./scripts/export.sh                # defaults to "hermes"
+#
+# Environment:
+#   MYRMIDONS_DEFAULT_OWNER  Fallback owner written to exported agent YAMLs when
+#                            the Agamemnon API returns no owner. Defaults to $(whoami).
+#
+# This is the bootstrap script. Run it once to seed Myrmidons
+# from the current Agamemnon state.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# shellcheck source=scripts/lib/config.sh
+source "${SCRIPT_DIR}/lib/config.sh"
+# shellcheck source=scripts/lib/log.sh
+source "${SCRIPT_DIR}/lib/log.sh"
+# shellcheck source=scripts/lib/api.sh
+source "${SCRIPT_DIR}/lib/api.sh"
+
+load_config
+
+HOST="${1:-hermes}"
+OUTPUT_DIR="${REPO_ROOT}/agents/${HOST}"
+
+main() {
+    # Validate AGAMEMNON_URL format early (#118)
+    validate_agamemnon_url
+
+    check_jq
+    agamemnon_check_connection
+
+    # Resolve the effective owner once into a function-local variable with a
+    # distinct name. We deliberately do NOT `export` it: bash subshells
+    # (including the pipe-fed `while` loop below) already inherit non-exported
+    # shell variables, so `export_agent` sees the value without polluting the
+    # parent shell's environment when this script is `source`d.
+    #
+    # NB: we cannot use `local MYRMIDONS_DEFAULT_OWNER=...` here because bash
+    # keeps function locals visible to the EXIT trap when `exit` is called
+    # from inside the function — which would leak a name-collision back into
+    # the sourcing shell's trap context (see test_export_no_env_leak.bats).
+    # See issue #526 (follow-up from #404).
+    local _effective_owner="${MYRMIDONS_DEFAULT_OWNER:-$(whoami)}"
+    log_debug "Default owner for exported agents: ${_effective_owner}"
+
+    log_info "Exporting agents from Agamemnon (${AGAMEMNON_URL}) for host: ${HOST}"
+    log_info ""
+
+    mkdir -p "${OUTPUT_DIR}"
+
+    local agents_json
+    agents_json="$(agamemnon_list_agents)"
+
+    local count
+    count="$(echo "$agents_json" | jq 'length')"
+
+    if [[ "$count" -eq 0 ]]; then
+        log_info "No agents found in Agamemnon."
+        exit 0
+    fi
+
+    echo "$agents_json" | jq -c '.[]' | while IFS= read -r agent; do
+        export_agent "$agent"
+    done
+
+    log_info ""
+    log_info "Exported ${count} agents to ${OUTPUT_DIR}/"
+}
+
+check_jq() {
+    local missing=()
+    if ! command -v jq &>/dev/null; then
+        missing+=("jq")
+    fi
+    if ! command -v yq &>/dev/null; then
+        missing+=("yq")
+    fi
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        log_error "Missing required tools: ${missing[*]}"
+        log_error "  Install jq: apt install jq / brew install jq"
+        log_error "  Install yq: https://github.com/mikefarah/yq"
+        exit 1
+    fi
+}
+
+# Derive the canonical filename stem from a label (lowercase, spaces→hyphens)
+# Convention: filename = lowercase(spec.label) + ".yaml"
+label_to_stem() {
+    local lbl="$1"
+    echo "${lbl}" | tr '[:upper:]' '[:lower:]' | tr ' ' '-'
+}
+
+# Map program name → default AchaeanFleet image name
+program_to_image() {
+    local prog="$1"
+    case "$prog" in
+        claude-code|claude) echo "achaean-claude:latest" ;;
+        codex)              echo "achaean-codex:latest" ;;
+        aider)              echo "achaean-aider:latest" ;;
+        goose)              echo "achaean-goose:latest" ;;
+        cline)              echo "achaean-cline:latest" ;;
+        opencode)           echo "achaean-opencode:latest" ;;
+        codebuff)           echo "achaean-codebuff:latest" ;;
+        ampcode)            echo "achaean-ampcode:latest" ;;
+        none|worker|"")     echo "achaean-worker:latest" ;;
+        *)                  echo "achaean-worker:latest" ;;
+    esac
+}
+
+export_agent() {
+    local agent_json="$1"
+
+    local name label program model workdir args desc owner role status deployment_type
+    name="$(echo "$agent_json" | jq -r '.name')"
+    label="$(echo "$agent_json" | jq -r '.label // .name')"
+    program="$(echo "$agent_json" | jq -r '.program // "claude-code"')"
+    model="$(echo "$agent_json" | jq -r '.model // "null"')"
+    workdir="$(echo "$agent_json" | jq -r '.workingDirectory // ""')"
+    args="$(echo "$agent_json" | jq -r '.programArgs // ""')"
+    desc="$(echo "$agent_json" | jq -r '.taskDescription // ""')"
+    owner="$(echo "$agent_json" | jq -r --arg default_owner "${_effective_owner:-${MYRMIDONS_DEFAULT_OWNER:-$(whoami)}}" '.owner // $default_owner')"
+    role="$(echo "$agent_json" | jq -r '.role // "member"')"
+    status="$(echo "$agent_json" | jq -r '.status // "offline"')"
+    deployment_type="$(echo "$agent_json" | jq -r '.deployment.type // "local"')"
+
+    # Map current status to desiredState
+    local desired_state="hibernated"
+    if [[ "$status" == "active" || "$status" == "online" ]]; then
+        desired_state="active"
+    fi
+
+    # Build tags YAML list
+    local tags_yaml
+    tags_yaml="$(echo "$agent_json" | jq -r '.tags // [] | if length == 0 then "  tags: []" else "  tags:\n" + (map("    - " + .) | join("\n")) end')"
+
+    # Derive filename from label per convention: filename = lowercase(spec.label) + ".yaml"
+    local label_lower
+    label_lower="$(label_to_stem "$label")"
+    local outfile="${OUTPUT_DIR}/${label_lower}.yaml"
+
+    # Warn if a stale file exists under the old name-derived path that would not be overwritten
+    local name_lower
+    name_lower="$(label_to_stem "$name")"
+    local name_outfile="${OUTPUT_DIR}/${name_lower}.yaml"
+    if [[ "$name_lower" != "$label_lower" && -e "$name_outfile" ]]; then
+        log_warn "  WARN: stale file '${name_outfile}' may exist from a prior name-based export; label-derived path is '${outfile}'"
+    fi
+
+    # Handle model: if "null" string, write null (no quotes)
+    local model_yaml
+    if [[ "$model" == "null" || -z "$model" ]]; then
+        model_yaml="null"
+    else
+        model_yaml="\"${model}\""
+    fi
+
+    # Map program → correct docker image
+    local docker_image
+    docker_image="$(program_to_image "$program")"
+
+    # Use jq to safely quote string fields that may contain special characters.
+    # Scalar YAML strings only need quoting when they contain: :, #, {, }, [, ], , &, * ! | > ' " % @ `
+    # Using double-quoted YAML strings throughout is safe and simple.
+    local name_yaml label_yaml program_yaml workdir_yaml owner_yaml role_yaml
+    name_yaml="$(echo "$name" | jq -Rr '.')"
+    label_yaml="$(echo "$label" | jq -Rr '.')"
+    program_yaml="$(echo "$program" | jq -Rr '.')"
+    workdir_yaml="$(echo "$workdir" | jq -Rr '.')"
+    owner_yaml="$(echo "$owner" | jq -Rr '.')"
+    role_yaml="$(echo "$role" | jq -Rr '.')"
+
+    # args and desc always get explicit double-quotes in the YAML
+    local args_escaped desc_escaped
+    args_escaped="$(echo "$args" | jq -Rr '.')"
+    desc_escaped="$(echo "$desc" | jq -Rr '.')"
+
+    cat > "$outfile" <<YAML
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: ${name_yaml}
+  host: ${HOST}
+spec:
+  label: ${label_yaml}
+  program: ${program_yaml}
+  model: ${model_yaml}
+  workingDirectory: ${workdir_yaml}
+  programArgs: "${args_escaped}"
+  taskDescription: "${desc_escaped}"
+${tags_yaml}
+  owner: ${owner_yaml}
+  role: ${role_yaml}
+  deployment:
+    type: ${deployment_type}
+    docker:
+      image: ${docker_image}
+      cpus: 2
+      memory: 4g
+  desiredState: ${desired_state}
+YAML
+
+    log_info "  ${outfile}"
+}
+
+main "$@"

--- a/tools/reconciler/scripts/lib/api.sh
+++ b/tools/reconciler/scripts/lib/api.sh
@@ -1,0 +1,413 @@
+#!/usr/bin/env bash
+# scripts/lib/api.sh — ProjectAgamemnon API client
+#
+# Thin wrapper around curl calls to the ProjectAgamemnon REST API.
+# All functions print raw JSON to stdout. Callers parse with jq.
+#
+# Usage:
+#   source scripts/lib/api.sh
+#   agamemnon_list_agents | jq '.[].name'
+#
+# TLS environment variables:
+#   AGAMEMNON_CA_CERT     Path to custom CA certificate bundle (PEM)
+#   AGAMEMNON_CLIENT_CERT Path to client certificate for mutual TLS (PEM)
+#   AGAMEMNON_CLIENT_KEY  Path to client private key for mutual TLS (PEM)
+#   AGAMEMNON_TLS_VERIFY  Set to "false" or "0" to disable TLS verification
+#                         (insecure — only for development; emits a loud warning)
+
+set -euo pipefail
+
+# Default AGAMEMNON_URL only when truly unset. Issue #513: an explicitly empty
+# exported value must reach _agamemnon_validate_url unchanged so it can be
+# rejected by the empty-string guard, rather than being silently coerced to
+# the localhost default by `:-`.
+if [[ -z "${AGAMEMNON_URL+set}" ]]; then
+    AGAMEMNON_URL="http://localhost:8080"
+fi
+_aim_had_xtrace=0
+if [[ "$-" == *x* ]]; then _aim_had_xtrace=1; fi
+{ set +x; } 2>/dev/null
+AGAMEMNON_API_KEY="${AGAMEMNON_API_KEY:-}"
+if [[ $_aim_had_xtrace -eq 1 ]]; then set -x; fi
+unset _aim_had_xtrace
+
+# Validate that AGAMEMNON_URL is a safe http/https URL.
+#
+# Rejects:
+#   - Non-http/https schemes (ftp://, file://, javascript:, etc.)
+#   - URLs with embedded credentials (user:password@)
+#   - URLs with fragment (#) or query (?) components
+#   - Non-numeric port numbers
+#   - IPv6 bracket notation in the hostname field
+#   - Empty or clearly non-URL strings
+#   - Strings with embedded newlines (header injection)
+#
+# Usage:
+#   _agamemnon_validate_url "$AGAMEMNON_URL" || exit 1
+_agamemnon_validate_url() {
+    local url="$1"
+
+    # Reject empty
+    if [[ -z "$url" ]]; then
+        echo "ERROR: AGAMEMNON_URL is empty." >&2
+        return 1
+    fi
+
+    # Reject embedded newlines (header injection)
+    if [[ "$url" == *$'\n'* ]]; then
+        echo "ERROR: AGAMEMNON_URL contains a newline character." >&2
+        return 1
+    fi
+
+    # Must start with http:// or https://
+    if [[ "$url" != http://* && "$url" != https://* ]]; then
+        echo "ERROR: AGAMEMNON_URL must use http or https scheme: ${url}" >&2
+        return 1
+    fi
+
+    # Strip scheme
+    local rest="${url#http://}"
+    rest="${rest#https://}"
+
+    # Reject embedded credentials (user:pass@)
+    if [[ "$rest" == *@* ]]; then
+        echo "ERROR: AGAMEMNON_URL must not contain credentials: ${url}" >&2
+        return 1
+    fi
+
+    # Reject fragment (#) — fragments are client-side and indicate a bad URL
+    if [[ "$url" == *'#'* ]]; then
+        echo "ERROR: AGAMEMNON_URL must not contain a fragment (#): ${url}" >&2
+        return 1
+    fi
+
+    # Reject query string (?) — the API path is fixed; a query in the base URL is suspicious
+    if [[ "$url" == *'?'* ]]; then
+        echo "ERROR: AGAMEMNON_URL must not contain a query string (?): ${url}" >&2
+        return 1
+    fi
+
+    # Reject IPv6 bracket notation in the host field (not supported)
+    if [[ "$rest" == '['* ]]; then
+        echo "ERROR: AGAMEMNON_URL IPv6 bracket notation is not supported: ${url}" >&2
+        return 1
+    fi
+
+    # Extract host[:port][/path] — split off optional path
+    local hostport="${rest%%/*}"
+
+    # If there is a port, validate it is numeric
+    if [[ "$hostport" == *:* ]]; then
+        local port="${hostport##*:}"
+        if [[ -z "$port" || "$port" =~ [^0-9] ]]; then
+            echo "ERROR: AGAMEMNON_URL port must be numeric: ${url}" >&2
+            return 1
+        fi
+    fi
+
+    # Host must be non-empty
+    local host="${hostport%%:*}"
+    if [[ -z "$host" ]]; then
+        echo "ERROR: AGAMEMNON_URL host is empty: ${url}" >&2
+        return 1
+    fi
+
+    return 0
+}
+
+
+# Build the TLS flags array for curl based on environment variables.
+# Populates the global _AGAMEMNON_TLS_FLAGS array; call once at source time.
+_agamemnon_build_tls_flags() {
+    _AGAMEMNON_TLS_FLAGS=()
+
+    # Disable TLS verification escape hatch — warn loudly.
+    local tls_verify="${AGAMEMNON_TLS_VERIFY:-true}"
+    if [[ "$tls_verify" == "false" || "$tls_verify" == "0" ]]; then
+        echo "WARNING: TLS verification is DISABLED (AGAMEMNON_TLS_VERIFY=${tls_verify})." >&2
+        echo "  This is insecure and must not be used in production." >&2
+        _AGAMEMNON_TLS_FLAGS+=(--insecure)
+    fi
+
+    # Custom CA certificate bundle.
+    # Issue #167: validate path at source time.
+    if [[ -n "${AGAMEMNON_CA_CERT:-}" ]]; then
+        if [[ ! -r "${AGAMEMNON_CA_CERT}" ]]; then
+            echo "WARN: AGAMEMNON_CA_CERT is set but path is not readable: ${AGAMEMNON_CA_CERT}" >&2
+        fi
+        _AGAMEMNON_TLS_FLAGS+=(--cacert "${AGAMEMNON_CA_CERT}")
+    fi
+
+    # Issue #168: warn when only one of CLIENT_CERT / CLIENT_KEY is specified.
+    local have_cert=0 have_key=0
+    [[ -n "${AGAMEMNON_CLIENT_CERT:-}" ]] && have_cert=1
+    [[ -n "${AGAMEMNON_CLIENT_KEY:-}"  ]] && have_key=1
+    if [[ $have_cert -ne $have_key ]]; then
+        echo "WARN: mTLS misconfiguration — AGAMEMNON_CLIENT_CERT and AGAMEMNON_CLIENT_KEY must both be set or both be unset." >&2
+        if [[ $have_cert -eq 0 ]]; then
+            echo "  AGAMEMNON_CLIENT_CERT is unset; AGAMEMNON_CLIENT_KEY is set." >&2
+        else
+            echo "  AGAMEMNON_CLIENT_CERT is set; AGAMEMNON_CLIENT_KEY is unset." >&2
+        fi
+    fi
+
+    # Mutual TLS: client certificate + key.
+    # Issue #167: validate paths at source time.
+    if [[ -n "${AGAMEMNON_CLIENT_CERT:-}" ]]; then
+        if [[ ! -r "${AGAMEMNON_CLIENT_CERT}" ]]; then
+            echo "WARN: AGAMEMNON_CLIENT_CERT is set but path is not readable: ${AGAMEMNON_CLIENT_CERT}" >&2
+        fi
+        _AGAMEMNON_TLS_FLAGS+=(--cert "${AGAMEMNON_CLIENT_CERT}")
+    fi
+    if [[ -n "${AGAMEMNON_CLIENT_KEY:-}" ]]; then
+        if [[ ! -r "${AGAMEMNON_CLIENT_KEY}" ]]; then
+            echo "WARN: AGAMEMNON_CLIENT_KEY is set but path is not readable: ${AGAMEMNON_CLIENT_KEY}" >&2
+        fi
+        _AGAMEMNON_TLS_FLAGS+=(--key "${AGAMEMNON_CLIENT_KEY}")
+    fi
+}
+
+# Initialise TLS flags when this library is sourced.
+_agamemnon_build_tls_flags
+
+# Build auth headers array for curl. Populates _AUTH_HEADERS global array.
+# Prefers Authorization: Bearer when AGAMEMNON_API_KEY is set.
+# Falls back to no auth (backward compatible).
+# set +x guard prevents the token value from appearing in bash -x / xtrace output.
+_agamemnon_auth_headers() {
+    _AUTH_HEADERS=()
+    local _had_xtrace=0
+    if [[ "$-" == *x* ]]; then _had_xtrace=1; fi
+    { set +x; } 2>/dev/null
+    if [[ -n "${AGAMEMNON_API_KEY}" ]]; then
+        _AUTH_HEADERS+=(-H "Authorization: Bearer ${AGAMEMNON_API_KEY}")
+        _AUTH_HEADERS+=(-H "X-API-Key: ${AGAMEMNON_API_KEY}")
+    fi
+    if [[ $_had_xtrace -eq 1 ]]; then set -x; fi
+}
+
+# Validate that AGAMEMNON_URL is set and has a recognised scheme (http/https).
+# Call this early in any entry-point script before issuing API calls.
+validate_agamemnon_url() {
+    local url="${AGAMEMNON_URL:-}"
+    if [[ -z "$url" ]]; then
+        echo "ERROR: AGAMEMNON_URL is not set." >&2
+        echo "  Export AGAMEMNON_URL before running this script." >&2
+        echo "  Example: export AGAMEMNON_URL=http://localhost:8080" >&2
+        return 1
+    fi
+    case "$url" in
+        http://*|https://*)
+            ;;
+        *)
+            echo "ERROR: AGAMEMNON_URL has an unrecognised scheme: ${url}" >&2
+            echo "  Expected a URL beginning with http:// or https://" >&2
+            return 1
+            ;;
+    esac
+}
+
+# Check that Agamemnon is reachable before making calls.
+# Also validates that AGAMEMNON_URL is a safe http/https URL (issue #120).
+# Issue #116: a RETURN trap ensures any curl temp state (e.g. response output
+# files written to disk on unexpected exit) is cleaned up on every exit path.
+agamemnon_check_connection() {
+    # Validate the URL before making any network calls.
+    if ! _agamemnon_validate_url "${AGAMEMNON_URL}"; then
+        echo "ERROR: Refusing to connect — AGAMEMNON_URL failed security validation." >&2
+        return 1
+    fi
+    local _check_tmpfile
+    _check_tmpfile="$(mktemp)"
+    # Trap fires on RETURN (normal exit, error, or early return) to remove any
+    # temp file left behind if curl exits unexpectedly mid-transfer.
+    # shellcheck disable=SC2064
+    trap "rm -f '${_check_tmpfile}'" RETURN
+
+    _agamemnon_auth_headers
+    local _had_xtrace=0
+    if [[ "$-" == *x* ]]; then _had_xtrace=1; fi
+    { set +x; } 2>/dev/null
+    local _conn_rc=0
+    curl -sf --max-time 5 -o "${_check_tmpfile}" \
+            "${_AGAMEMNON_TLS_FLAGS[@]+"${_AGAMEMNON_TLS_FLAGS[@]}"}" \
+            "${_AUTH_HEADERS[@]+"${_AUTH_HEADERS[@]}"}" \
+            "${AGAMEMNON_URL}/v1/health" 2>&1 || _conn_rc=$?
+    if [[ $_had_xtrace -eq 1 ]]; then set -x; fi
+    if [[ $_conn_rc -ne 0 ]]; then
+        echo "ERROR: Cannot reach Agamemnon at ${AGAMEMNON_URL}" >&2
+        echo "  Is Agamemnon running? Check your ProjectAgamemnon deployment." >&2
+        return 1
+    fi
+}
+
+# Internal helper: curl with retry on transient errors (connection refused, timeout, 5xx).
+# Injects auth headers automatically when AGAMEMNON_API_KEY is set.
+# Usage: _agamemnon_curl_retry [-X METHOD] URL [-H header] [-d body]
+_agamemnon_curl_retry() {
+    local max_attempts=3
+    local delay=1
+    local attempt=1
+    local http_code response tmpfile curl_exit
+
+    _agamemnon_auth_headers
+
+    while [[ $attempt -le $max_attempts ]]; do
+        tmpfile="$(mktemp)"
+        local _had_xtrace=0
+        if [[ "$-" == *x* ]]; then _had_xtrace=1; fi
+        { set +x; } 2>/dev/null
+        http_code="$(curl -s --max-time "${AGAMEMNON_TIMEOUT:-10}" -w "%{http_code}" -o "$tmpfile" \
+            "${_AGAMEMNON_TLS_FLAGS[@]+"${_AGAMEMNON_TLS_FLAGS[@]}"}" "${_AUTH_HEADERS[@]+"${_AUTH_HEADERS[@]}"}" "$@" 2>/dev/null)"
+        curl_exit=$?
+        if [[ $_had_xtrace -eq 1 ]]; then set -x; fi
+        response="$(cat "$tmpfile")"
+        rm -f "$tmpfile"
+
+        # Success
+        if [[ $curl_exit -eq 0 && "${http_code:0:1}" == "2" ]]; then
+            echo "$response"
+            return 0
+        fi
+
+        # Classify failure: transient = retry; permanent = fail immediately
+        local is_transient=0
+        if [[ $curl_exit -eq 7 || $curl_exit -eq 28 ]]; then
+            is_transient=1
+        elif [[ $curl_exit -ne 0 ]]; then
+            is_transient=0
+        elif [[ "${http_code:0:1}" == "5" ]]; then
+            is_transient=1
+        fi
+
+        if [[ $is_transient -eq 0 ]]; then
+            if [[ $curl_exit -ne 0 ]]; then
+                echo "ERROR: curl failed (exit ${curl_exit}) for: $*" >&2
+            else
+                if [[ "$http_code" == "401" || "$http_code" == "403" ]]; then
+                    echo "ERROR: Authentication failed (HTTP ${http_code}) — check AGAMEMNON_API_KEY" >&2
+                else
+                    echo "ERROR: HTTP ${http_code} from Agamemnon" >&2
+                    echo "  URL: $*" >&2
+                    if [[ -n "$response" ]]; then
+                        echo "  Body: ${response}" >&2
+                    fi
+                fi
+            fi
+            return 1
+        fi
+
+        if [[ $attempt -lt $max_attempts ]]; then
+            echo "WARN: Retry ${attempt}/${max_attempts} in ${delay}s (curl_exit=${curl_exit} http=${http_code}): $*" >&2
+            sleep "$delay"
+            delay=$((delay * 2))
+        fi
+
+        attempt=$((attempt + 1))
+    done
+
+    if [[ $curl_exit -ne 0 ]]; then
+        echo "ERROR: curl failed after ${max_attempts} attempts (exit ${curl_exit}) for: $*" >&2
+    else
+        echo "ERROR: HTTP ${http_code} from Agamemnon after ${max_attempts} attempts" >&2
+        echo "  URL: $*" >&2
+        if [[ -n "$response" ]]; then
+            echo "  Body: ${response}" >&2
+        fi
+    fi
+    return 1
+}
+
+# Internal helper: single curl call with auth headers.
+# All API functions delegate here. Uses retry logic from _agamemnon_curl_retry.
+# Usage: _agamemnon_curl [-X METHOD] URL [-H header] [-d body]
+_agamemnon_curl() {
+    _agamemnon_curl_retry "$@"
+}
+
+# List all agents registered on this host.
+agamemnon_list_agents() {
+    _agamemnon_curl "${AGAMEMNON_URL}/v1/agents"
+}
+
+# Get a single agent by ID.
+agamemnon_get_agent() {
+    local agent_id="$1"
+    _agamemnon_curl "${AGAMEMNON_URL}/v1/agents/${agent_id}"
+}
+
+# Get a single agent by name (rich resolution).
+agamemnon_by_name() {
+    local name="$1"
+    _agamemnon_curl "${AGAMEMNON_URL}/v1/agents/by-name/${name}"
+}
+
+# Create a new agent. $1 = JSON body.
+# Required fields: name, program, workingDirectory
+agamemnon_create_agent() {
+    local body="$1"
+    _agamemnon_curl -X POST \
+        "${AGAMEMNON_URL}/v1/agents" \
+        -H 'Content-Type: application/json' \
+        -d "${body}"
+}
+
+# Partially update an agent. $1 = agent ID, $2 = JSON patch body.
+agamemnon_update_agent() {
+    local agent_id="$1"
+    local body="$2"
+    _agamemnon_curl -X PATCH \
+        "${AGAMEMNON_URL}/v1/agents/${agent_id}" \
+        -H 'Content-Type: application/json' \
+        -d "${body}"
+}
+
+# Delete an agent (hard delete creates a backup).
+# Always stop first for graceful shutdown.
+agamemnon_delete_agent() {
+    local agent_id="$1"
+    _agamemnon_curl -X DELETE "${AGAMEMNON_URL}/v1/agents/${agent_id}?hard=true"
+}
+
+# Start an agent (starts tmux session + AI program).
+agamemnon_wake_agent() {
+    local agent_id="$1"
+    _agamemnon_curl -X POST \
+        "${AGAMEMNON_URL}/v1/agents/${agent_id}/start" \
+        -H 'Content-Type: application/json' \
+        -d '{}'
+}
+
+# Stop an agent (graceful stop: Ctrl-C, exit, kill tmux).
+agamemnon_hibernate_agent() {
+    local agent_id="$1"
+    _agamemnon_curl -X POST \
+        "${AGAMEMNON_URL}/v1/agents/${agent_id}/stop" \
+        -H 'Content-Type: application/json' \
+        -d '{}'
+}
+
+# Create a Docker-deployed agent.
+agamemnon_docker_create() {
+    local body="$1"
+    _agamemnon_curl -X POST \
+        "${AGAMEMNON_URL}/v1/agents/docker" \
+        -H 'Content-Type: application/json' \
+        -d "${body}"
+}
+
+# Helper: get agent ID by name. Returns empty string if not found.
+agamemnon_id_by_name() {
+    local name="$1"
+    agamemnon_list_agents | jq -r --arg name "$name" \
+        '.[] | select(.name == $name) | .id // empty'
+}
+
+# Helper: get agent status by name. Returns "unknown" if not found.
+agamemnon_status_by_name() {
+    local name="$1"
+    local status
+    status="$(agamemnon_list_agents | jq -r --arg name "$name" \
+        'first(.[] | select(.name == $name) | .status) // "unknown"')"
+    echo "${status:-unknown}"
+}

--- a/tools/reconciler/scripts/lib/config.sh
+++ b/tools/reconciler/scripts/lib/config.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+# scripts/lib/config.sh — Project-level configuration loader
+#
+# Loads configuration from (in order of precedence, lowest to highest):
+#   1. Built-in defaults
+#   2. .myrmidons.yaml  (project config, committed to git)
+#   3. .myrmidons.local.yaml  (local overrides, gitignored)
+#   4. Environment variables
+#
+# After sourcing this file, use MYRM_* variables for effective config.
+#
+# Usage:
+#   source scripts/lib/config.sh
+#   load_config              # populate MYRM_* from all sources
+#   show_config              # print effective config table
+
+set -euo pipefail
+
+# =============================================================================
+# Defaults
+# =============================================================================
+
+_MYRM_DEFAULT_HOST="hermes"
+_MYRM_DEFAULT_AIM_HOST="http://localhost:8080"
+_MYRM_DEFAULT_LOG_LEVEL="info"
+_MYRM_DEFAULT_PRUNE_POLICY="manual"
+_MYRM_DEFAULT_SNAPSHOT_RETENTION="7"
+
+# =============================================================================
+# Internal helpers
+# =============================================================================
+
+# Read a scalar field from a YAML file using yq.
+# Returns the default value if the field is absent or null.
+# Usage: _cfg_read_yaml FILE FIELD DEFAULT
+_cfg_read_yaml() {
+    local file="$1"
+    local field="$2"
+    local default="$3"
+
+    if [[ ! -f "$file" ]]; then
+        echo "$default"
+        return
+    fi
+
+    local value
+    value="$(yq eval ".${field} // \"\"" "$file" 2>/dev/null || echo "")"
+    if [[ -z "$value" || "$value" == "null" ]]; then
+        echo "$default"
+    else
+        echo "$value"
+    fi
+}
+
+# Find the repository root (directory containing justfile or .myrmidons.yaml).
+# Falls back to the current working directory.
+_cfg_repo_root() {
+    local dir
+    dir="$(pwd)"
+    while [[ "$dir" != "/" ]]; do
+        if [[ -f "$dir/justfile" || -f "$dir/.myrmidons.yaml" ]]; then
+            echo "$dir"
+            return
+        fi
+        dir="$(dirname "$dir")"
+    done
+    echo "$(pwd)"
+}
+
+# =============================================================================
+# Public API
+# =============================================================================
+
+# load_config — populate MYRM_* variables from all configuration sources.
+#
+# Precedence (highest wins):
+#   env vars > .myrmidons.local.yaml > .myrmidons.yaml > built-in defaults
+#
+# Exported variables:
+#   MYRM_DEFAULT_HOST       — default agent host (used by scripts as HOST default)
+#   MYRM_AIM_HOST           — ProjectAgamemnon base URL (alias: AGAMEMNON_URL)
+#   MYRM_LOG_LEVEL          — verbosity: debug | info | warn | error
+#   MYRM_PRUNE_POLICY       — when to prune: manual | auto
+#   MYRM_SNAPSHOT_RETENTION — days to keep snapshots (integer)
+load_config() {
+    local root
+    root="$(_cfg_repo_root)"
+
+    local project_cfg="${root}/.myrmidons.yaml"
+    local local_cfg="${root}/.myrmidons.local.yaml"
+
+    # --- Step 1: built-in defaults ---
+    local d_host="$_MYRM_DEFAULT_HOST"
+    local d_aim_host="$_MYRM_DEFAULT_AIM_HOST"
+    local d_log_level="$_MYRM_DEFAULT_LOG_LEVEL"
+    local d_prune_policy="$_MYRM_DEFAULT_PRUNE_POLICY"
+    local d_snapshot_retention="$_MYRM_DEFAULT_SNAPSHOT_RETENTION"
+
+    # --- Step 2: project config file (.myrmidons.yaml) ---
+    d_host="$(_cfg_read_yaml "$project_cfg" "defaultHost" "$d_host")"
+    d_aim_host="$(_cfg_read_yaml "$project_cfg" "aimHost" "$d_aim_host")"
+    d_log_level="$(_cfg_read_yaml "$project_cfg" "logLevel" "$d_log_level")"
+    d_prune_policy="$(_cfg_read_yaml "$project_cfg" "prunePolicy" "$d_prune_policy")"
+    d_snapshot_retention="$(_cfg_read_yaml "$project_cfg" "snapshotRetention" "$d_snapshot_retention")"
+
+    # --- Step 3: local override file (.myrmidons.local.yaml) ---
+    d_host="$(_cfg_read_yaml "$local_cfg" "defaultHost" "$d_host")"
+    d_aim_host="$(_cfg_read_yaml "$local_cfg" "aimHost" "$d_aim_host")"
+    d_log_level="$(_cfg_read_yaml "$local_cfg" "logLevel" "$d_log_level")"
+    d_prune_policy="$(_cfg_read_yaml "$local_cfg" "prunePolicy" "$d_prune_policy")"
+    d_snapshot_retention="$(_cfg_read_yaml "$local_cfg" "snapshotRetention" "$d_snapshot_retention")"
+
+    # --- Step 4: environment variables (highest precedence) ---
+    MYRM_DEFAULT_HOST="${HOST:-${d_host}}"
+    MYRM_AIM_HOST="${AGAMEMNON_URL:-${d_aim_host}}"
+    MYRM_LOG_LEVEL="${MYRM_LOG_LEVEL:-${d_log_level}}"
+    MYRM_PRUNE_POLICY="${MYRM_PRUNE_POLICY:-${d_prune_policy}}"
+    MYRM_SNAPSHOT_RETENTION="${MYRM_SNAPSHOT_RETENTION:-${d_snapshot_retention}}"
+
+    export MYRM_DEFAULT_HOST MYRM_AIM_HOST MYRM_LOG_LEVEL \
+           MYRM_PRUNE_POLICY MYRM_SNAPSHOT_RETENTION
+}
+
+# show_config — print the effective configuration and its source for each field.
+show_config() {
+    local root
+    root="$(_cfg_repo_root)"
+
+    local project_cfg="${root}/.myrmidons.yaml"
+    local local_cfg="${root}/.myrmidons.local.yaml"
+
+    # Capture which env vars were set BEFORE load_config exports the MYRM_* names.
+    local env_host="${HOST:-}"
+    local env_aim_host="${AGAMEMNON_URL:-}"
+    local env_log_level="${MYRM_LOG_LEVEL:-}"
+    local env_prune_policy="${MYRM_PRUNE_POLICY:-}"
+    local env_snapshot_retention="${MYRM_SNAPSHOT_RETENTION:-}"
+
+    load_config
+
+    echo "Effective Myrmidons configuration"
+    echo "=================================="
+    echo ""
+    echo "Sources (lowest → highest precedence):"
+    echo "  [defaults]  built-in defaults"
+    if [[ -f "$project_cfg" ]]; then
+        echo "  [project]   ${project_cfg}"
+    else
+        echo "  [project]   ${project_cfg} (not found — using defaults)"
+    fi
+    if [[ -f "$local_cfg" ]]; then
+        echo "  [local]     ${local_cfg}"
+    else
+        echo "  [local]     ${local_cfg} (not found)"
+    fi
+    echo "  [env]       environment variables"
+    echo ""
+    printf "%-24s  %-40s  %s\n" "FIELD" "VALUE" "SOURCE"
+    printf "%-24s  %-40s  %s\n" "------------------------" "----------------------------------------" "------"
+
+    _cfg_show_field "defaultHost"       "$MYRM_DEFAULT_HOST"       "$project_cfg" "$local_cfg" "$env_host"
+    _cfg_show_field "aimHost"           "$MYRM_AIM_HOST"           "$project_cfg" "$local_cfg" "$env_aim_host"
+    _cfg_show_field "logLevel"          "$MYRM_LOG_LEVEL"          "$project_cfg" "$local_cfg" "$env_log_level"
+    _cfg_show_field "prunePolicy"       "$MYRM_PRUNE_POLICY"       "$project_cfg" "$local_cfg" "$env_prune_policy"
+    _cfg_show_field "snapshotRetention" "$MYRM_SNAPSHOT_RETENTION" "$project_cfg" "$local_cfg" "$env_snapshot_retention"
+}
+
+# _cfg_show_field — helper for show_config to resolve and print a single field's source.
+# $1=field  $2=effective-value  $3=project-cfg  $4=local-cfg  $5=pre-captured-env-value
+_cfg_show_field() {
+    local field="$1"
+    local effective="$2"
+    local project_cfg="$3"
+    local local_cfg="$4"
+    local env_value="$5"
+
+    local source="defaults"
+
+    local from_project
+    from_project="$(_cfg_read_yaml "$project_cfg" "$field" "")"
+    if [[ -n "$from_project" && "$from_project" != "null" ]]; then
+        source="project"
+    fi
+
+    local from_local
+    from_local="$(_cfg_read_yaml "$local_cfg" "$field" "")"
+    if [[ -n "$from_local" && "$from_local" != "null" ]]; then
+        source="local"
+    fi
+
+    if [[ -n "$env_value" ]]; then
+        source="env"
+    fi
+
+    printf "%-24s  %-40s  %s\n" "$field" "$effective" "$source"
+}

--- a/tools/reconciler/scripts/lib/git-safety.sh
+++ b/tools/reconciler/scripts/lib/git-safety.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# scripts/lib/git-safety.sh — pre-commit safety guards
+#
+# Provides helpers to detect no-op git commit scenarios (empty staging area)
+# and report the current HEAD SHA clearly, preventing false-positive "commit
+# succeeded" reports when nothing was actually staged.
+#
+# Background: the 29-auto-impl branch exhibited a case where `git commit`
+# printed an already-existing SHA because nothing was staged (see issue #142).
+# These helpers make that scenario detectable and diagnosable before commit.
+#
+# Usage:
+#   source "${SCRIPT_DIR}/lib/git-safety.sh"
+#   assert_staged_nonempty || exit 1
+#   git commit -m "..."
+#   report_commit_sha
+
+set -euo pipefail
+
+# assert_staged_nonempty — exit non-zero with a clear diagnostic if the
+# staging area is empty, so callers can abort before running `git commit`
+# (which would silently succeed and report the existing HEAD SHA).
+#
+# Returns: 0 if something is staged; 1 (with diagnostic) if nothing is staged.
+assert_staged_nonempty() {
+    if git diff --staged --quiet 2>/dev/null; then
+        echo "ERROR: Nothing is staged for commit." >&2
+        echo "  git commit would produce a no-op and report the existing HEAD SHA." >&2
+        echo "  Current HEAD: $(git log --oneline -1 2>/dev/null || echo '(no commits yet)')" >&2
+        echo "  Staged files: (none)" >&2
+        echo "  Run 'git status' to see what is modified but unstaged." >&2
+        return 1
+    fi
+    return 0
+}
+
+# report_commit_sha — print the SHA of the most recent commit with a clear
+# label, so callers can distinguish a new commit from an already-existing one.
+#
+# Usage: call this AFTER `git commit` to log the resulting SHA.
+report_commit_sha() {
+    local sha
+    sha="$(git rev-parse HEAD 2>/dev/null || echo 'unknown')"
+    local oneline
+    oneline="$(git log --oneline -1 2>/dev/null || echo 'unknown')"
+    echo "Committed: ${sha} — ${oneline}"
+}
+
+# is_head_already_pushed — return 0 if the current HEAD has already been
+# pushed to the given remote branch, 1 otherwise.
+#
+# Usage: is_head_already_pushed origin my-branch
+is_head_already_pushed() {
+    local remote="${1:-origin}"
+    local branch="${2:-$(git rev-parse --abbrev-ref HEAD 2>/dev/null)}"
+    local local_sha remote_sha
+    local_sha="$(git rev-parse HEAD 2>/dev/null || echo '')"
+    remote_sha="$(git ls-remote "${remote}" "refs/heads/${branch}" 2>/dev/null | awk '{print $1}')"
+    if [[ -n "${remote_sha}" && "${local_sha}" == "${remote_sha}" ]]; then
+        return 0
+    fi
+    return 1
+}

--- a/tools/reconciler/scripts/lib/log.sh
+++ b/tools/reconciler/scripts/lib/log.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# scripts/lib/log.sh — Structured logging library for Myrmidons scripts
+#
+# Provides log_debug, log_info, log_warn, log_error functions with:
+#   - Log level filtering (LOG_LEVEL env var)
+#   - Text or JSON output (LOG_FORMAT env var)
+#   - Timestamps, level, script name, and message in each line
+#   - Color output for TTY (auto-detected)
+#   - ERROR goes to stderr; DEBUG/INFO/WARN go to stdout
+#
+# Usage:
+#   source scripts/lib/log.sh
+#   log_info "Starting reconciliation"
+#   log_debug "Parsed agent: name=${name}"
+#   log_warn "Agent not found: ${name}"
+#   log_error "Failed to connect to Agamemnon"
+#
+# Environment variables:
+#   LOG_LEVEL   - Minimum level to emit: DEBUG, INFO, WARN, ERROR (default: INFO)
+#   LOG_FORMAT  - Output format: text, json (default: text)
+
+# Numeric level mapping
+_LOG_LEVEL_DEBUG=0
+_LOG_LEVEL_INFO=1
+_LOG_LEVEL_WARN=2
+_LOG_LEVEL_ERROR=3
+
+# Resolve configured minimum level to its numeric value
+_log_min_level() {
+    case "${LOG_LEVEL:-INFO}" in
+        DEBUG) echo $_LOG_LEVEL_DEBUG ;;
+        INFO)  echo $_LOG_LEVEL_INFO  ;;
+        WARN)  echo $_LOG_LEVEL_WARN  ;;
+        ERROR) echo $_LOG_LEVEL_ERROR ;;
+        *)     echo $_LOG_LEVEL_INFO  ;;
+    esac
+}
+
+# Auto-detect color support: enabled when stdout is a TTY and LOG_FORMAT != json
+_log_use_color() {
+    if [[ "${LOG_FORMAT:-text}" == "json" ]]; then
+        echo 0; return
+    fi
+    if [[ -t 1 ]]; then
+        echo 1
+    else
+        echo 0
+    fi
+}
+
+# ANSI color codes
+_LOG_COLOR_DEBUG='\033[0;36m'   # cyan
+_LOG_COLOR_INFO='\033[0;32m'    # green
+_LOG_COLOR_WARN='\033[0;33m'    # yellow
+_LOG_COLOR_ERROR='\033[0;31m'   # red
+_LOG_COLOR_RESET='\033[0m'
+
+# Derive the calling script's basename for inclusion in log lines.
+# Falls back to the sourcing script name or "myrmidons".
+_log_script_name() {
+    local name
+    # BASH_SOURCE[2]: 0=log.sh, 1=caller of log_*, 2=top-level script
+    name="$(basename "${BASH_SOURCE[2]:-${BASH_SOURCE[1]:-myrmidons}}" .sh)"
+    echo "$name"
+}
+
+# Core emit function — not called directly by user code.
+# Usage: _log_emit LEVEL numeric_level message
+_log_emit() {
+    local level="$1"          # DEBUG|INFO|WARN|ERROR
+    local level_num="$2"      # numeric value
+    local message="$3"
+
+    local min_level
+    min_level="$(_log_min_level)"
+    if [[ "$level_num" -lt "$min_level" ]]; then
+        return 0
+    fi
+
+    local ts
+    ts="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+
+    local script
+    script="$(_log_script_name)"
+
+    local format="${LOG_FORMAT:-text}"
+
+    if [[ "$format" == "json" ]]; then
+        # Emit a single JSON object on one line; escape message for JSON safety
+        local msg_escaped
+        msg_escaped="$(printf '%s' "$message" | jq -Rr '.')"
+        local line="{\"timestamp\":\"${ts}\",\"level\":\"${level}\",\"script\":\"${script}\",\"message\":${msg_escaped}}"
+        if [[ "$level" == "ERROR" ]]; then
+            echo "$line" >&2
+        else
+            echo "$line"
+        fi
+    else
+        # Text format
+        local use_color
+        use_color="$(_log_use_color)"
+        local color=""
+        local reset=""
+
+        if [[ "$use_color" -eq 1 ]]; then
+            reset="$_LOG_COLOR_RESET"
+            case "$level" in
+                DEBUG) color="$_LOG_COLOR_DEBUG" ;;
+                INFO)  color="$_LOG_COLOR_INFO"  ;;
+                WARN)  color="$_LOG_COLOR_WARN"  ;;
+                ERROR) color="$_LOG_COLOR_ERROR" ;;
+            esac
+        fi
+
+        local line="${ts} ${color}${level}${reset} [${script}] ${message}"
+
+        if [[ "$level" == "ERROR" ]]; then
+            printf '%b\n' "$line" >&2
+        else
+            printf '%b\n' "$line"
+        fi
+    fi
+}
+
+log_debug() { _log_emit "DEBUG" "$_LOG_LEVEL_DEBUG" "$*"; }
+log_info()  { _log_emit "INFO"  "$_LOG_LEVEL_INFO"  "$*"; }
+log_warn()  { _log_emit "WARN"  "$_LOG_LEVEL_WARN"  "$*"; }
+log_error() { _log_emit "ERROR" "$_LOG_LEVEL_ERROR" "$*"; }

--- a/tools/reconciler/scripts/lib/prompt.sh
+++ b/tools/reconciler/scripts/lib/prompt.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# scripts/lib/prompt.sh — Interactive confirmation helper for Myrmidons scripts
+#
+# Provides confirm_with_timeout() so all yes/no prompts share the same
+# TTY-detection, timeout, and non-TTY fallback logic. This prevents bare
+# `read -r` calls (no timeout) from hanging in CI or pipeline contexts.
+#
+# Usage:
+#   source scripts/lib/prompt.sh
+#   if confirm_with_timeout "Apply changes? [y/N]"; then
+#       do_the_thing
+#   fi
+#
+# Non-TTY behavior (CI / piped stdin):
+#   Reads one line with a 1-second timeout. If nothing arrives, falls back to
+#   the DEFAULT argument. The caller controls the default; scripts that must
+#   be safe-by-default should pass "n" (the built-in default).
+
+# confirm_with_timeout PROMPT [TIMEOUT [DEFAULT]]
+#
+# Writes PROMPT to stderr, waits up to TIMEOUT seconds for a y/n reply.
+# Returns 0 for yes (y/Y/yes/YES), 1 for anything else.
+#
+#   PROMPT   — text shown to the user (default: "Continue? [y/N]")
+#   TIMEOUT  — seconds to wait on a TTY (default: 30)
+#   DEFAULT  — reply assumed on timeout or non-TTY with no piped input (default: "n")
+confirm_with_timeout() {
+    local prompt="${1:-Continue? [y/N]}"
+    local timeout="${2:-30}"
+    local default="${3:-n}"
+    local reply
+
+    if [[ -t 0 ]]; then
+        printf '%s ' "$prompt" >&2
+        if ! read -r -t "$timeout" reply; then
+            printf '\n(Timed out after %ss — defaulting to %s)\n' "$timeout" "$default" >&2
+            reply="$default"
+        fi
+    else
+        # Non-TTY (CI, pipe): read one line if available within 1s, else use default
+        if ! IFS= read -r -t 1 reply 2>/dev/null; then
+            reply="$default"
+        fi
+    fi
+
+    [[ "${reply,,}" == y* ]]
+}

--- a/tools/reconciler/scripts/lib/reconcile.sh
+++ b/tools/reconciler/scripts/lib/reconcile.sh
@@ -1,0 +1,487 @@
+#!/usr/bin/env bash
+# scripts/lib/reconcile.sh — diff and reconciliation logic
+#
+# Provides functions used by apply.sh and plan.sh.
+# Parses YAML agent definitions, compares with actual Agamemnon state,
+# and produces a list of actions to take.
+#
+# Requires: yq (YAML parser), jq, source of api.sh
+
+set -euo pipefail
+
+# Check required tools
+check_deps() {
+    local missing=()
+    for cmd in yq jq curl; do
+        if ! command -v "$cmd" &>/dev/null; then
+            missing+=("$cmd")
+        fi
+    done
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        log_error "Missing required tools: ${missing[*]}"
+        log_error "  Install yq: https://github.com/mikefarah/yq"
+        log_error "  Install jq: apt install jq / brew install jq"
+        return 1
+    fi
+}
+
+# Parse a single agent YAML file. Outputs key=value lines for each field.
+# Usage: parse_agent_yaml /path/to/agent.yaml
+parse_agent_yaml() {
+    local file="$1"
+
+    yq eval '{
+        "name": .metadata.name,
+        "host": .metadata.host,
+        "label": .spec.label,
+        "program": .spec.program,
+        "model": (.spec.model // ""),
+        "workingDirectory": .spec.workingDirectory,
+        "programArgs": (.spec.programArgs // ""),
+        "taskDescription": (.spec.taskDescription // ""),
+        "tags": (.spec.tags // [] | join(",")),
+        "owner": (.spec.owner // ""),
+        "role": (.spec.role // "member"),
+        "deploymentType": (.spec.deployment.type // "local"),
+        "dockerImage": (.spec.deployment.docker.image // ""),
+        "dockerCpus": (.spec.deployment.docker.cpus // ""),
+        "dockerMemory": (.spec.deployment.docker.memory // ""),
+        "desiredState": (.spec.desiredState // "active")
+    } | to_entries[] | .key + "=" + (.value | tostring)' "$file"
+}
+
+# Validate a host parameter: alphanumeric, hyphens, and underscores only.
+# Rejects path separators and dot sequences that could enable path traversal.
+# Usage: validate_host <host>
+validate_host() {
+    local host="$1"
+    if [[ -z "$host" ]]; then
+        return 0  # Empty host is valid (means "all hosts")
+    fi
+    if [[ ! "$host" =~ ^[a-zA-Z0-9_-]+$ ]]; then
+        echo "ERROR: Invalid host '${host}': must contain only alphanumeric characters, hyphens, or underscores." >&2
+        return 1
+    fi
+}
+
+# Get all agent YAML files for a given host and/or fleet.
+# When fleet_name is provided, only the agents in that fleet are returned.
+# When fleet_name is empty, all agents/ files plus all fleet members are returned.
+# Deduplicates output so a given agent path is only returned once.
+# Note: FLEET_TMPDIR for inline agents is set inside a process-substitution
+#       subshell when called via mapfile < <(...). Temp-file cleanup is
+#       best-effort via cleanup_fleet_tmpdir in the caller's EXIT trap.
+# Usage: get_agent_files [host] [fleet_name]
+get_agent_files() {
+    local host="${1:-}"
+    local fleet_name="${2:-}"
+    local repo_root
+    repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+    validate_host "$host" || return 1
+
+    # If scoped to a single fleet, resolve only that fleet's agents
+    if [[ -n "$fleet_name" ]]; then
+        local fleet_file
+        fleet_file="$(find_fleet_file "$fleet_name")" || return 1
+        resolve_fleet_files "$fleet_file"
+        return
+    fi
+
+    # General case: collect agents/ files and all fleet members, deduplicating.
+    # We output paths as we find them and track seen ones via an associative array.
+    declare -A _gaf_seen
+
+    # 1. Gather direct Agent YAML files from agents/
+    # `find` returns rc>0 when the search root does not exist (e.g. a host
+    # directory is removed). That is a legitimate "no files" outcome here, so
+    # we guard on existence and treat a missing root as an empty result set.
+    local raw_files=()
+    local search_root
+    if [[ -n "$host" ]]; then
+        search_root="${repo_root}/agents/${host}"
+    else
+        search_root="${repo_root}/agents"
+    fi
+    if [[ -d "$search_root" ]]; then
+        mapfile -t raw_files < <(
+            find "$search_root" -name "*.yaml" \
+                ! -path "*/_templates/*"
+        )
+    fi
+
+    for f in "${raw_files[@]+"${raw_files[@]}"}"; do
+        local kind
+        kind="$(yq eval '.kind // ""' "$f" 2>/dev/null)"
+        # Skip any Fleet files that may live under agents/; only emit Agent files
+        if [[ "$kind" != "Fleet" ]]; then
+            if [[ -z "${_gaf_seen[$f]+x}" ]]; then
+                _gaf_seen[$f]=1
+                echo "$f"
+            fi
+        fi
+    done
+
+    # 2. Discover Fleet YAML files in fleets/ and resolve their members
+    if [[ -d "${repo_root}/fleets" ]]; then
+        local fleet_files=()
+        mapfile -t fleet_files < <(find "${repo_root}/fleets" -name "*.yaml" 2>/dev/null | sort)
+        for fleet_file in "${fleet_files[@]+"${fleet_files[@]}"}"; do
+            local fleet_kind
+            fleet_kind="$(yq eval '.kind // ""' "$fleet_file" 2>/dev/null)"
+            if [[ "$fleet_kind" != "Fleet" ]]; then
+                continue
+            fi
+
+            # If host filter is set, only process fleets whose metadata.host matches
+            if [[ -n "$host" ]]; then
+                local fleet_host
+                fleet_host="$(yq eval '.metadata.host // ""' "$fleet_file" 2>/dev/null)"
+                if [[ "$fleet_host" != "$host" ]]; then
+                    continue
+                fi
+            fi
+
+            while IFS= read -r agent_file; do
+                if [[ -z "${_gaf_seen[$agent_file]+x}" ]]; then
+                    _gaf_seen[$agent_file]=1
+                    echo "$agent_file"
+                fi
+            done < <(resolve_fleet_files "$fleet_file")
+        done
+    fi
+}
+
+# Find a fleet YAML file by name.
+# Searches the fleets/ directory for a file where metadata.name matches.
+# Outputs the absolute path or exits with error if not found.
+# Usage: find_fleet_file <fleet-name>
+find_fleet_file() {
+    local fleet_name="$1"
+    local repo_root
+    repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+    local fleet_file=""
+    while IFS= read -r -d '' f; do
+        local name
+        name="$(yq eval '.metadata.name // ""' "$f" 2>/dev/null)"
+        if [[ "$name" == "$fleet_name" ]]; then
+            fleet_file="$f"
+            break
+        fi
+    done < <(find "${repo_root}/fleets" -name "*.yaml" -print0 2>/dev/null)
+
+    if [[ -z "$fleet_file" ]]; then
+        echo "ERROR: Fleet '${fleet_name}' not found in fleets/" >&2
+        return 1
+    fi
+    echo "$fleet_file"
+}
+
+# Resolve a fleet YAML into a list of agent YAML file paths.
+# Refs (ref: host/agent-name) are resolved to existing agent files.
+# Inline agents are written to temp files (caller must clean up FLEET_TMPDIR).
+# Sets global FLEET_TMPDIR if inline agents are created.
+# Usage: resolve_fleet_files <fleet-yaml-path> [host-filter]
+# When host-filter is non-empty, only refs whose host portion matches are emitted.
+# Outputs one file path per line.
+resolve_fleet_files() {
+    local fleet_file="$1"
+    local host_filter="${2:-}"
+    local repo_root
+    repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+    # Trap to clean up any FLEET_TMPDIR we create on error exit (#158)
+    _resolve_fleet_cleanup() {
+        if [[ -n "${FLEET_TMPDIR:-}" && -d "${FLEET_TMPDIR}" ]]; then
+            rm -rf "${FLEET_TMPDIR}"
+            FLEET_TMPDIR=""
+        fi
+    }
+    trap '_resolve_fleet_cleanup' ERR
+
+    local fleet_host
+    fleet_host="$(yq eval '.metadata.host // ""' "$fleet_file")"
+
+    local agent_count
+    agent_count="$(yq eval '.spec.agents | length' "$fleet_file")"
+
+    for (( i=0; i<agent_count; i++ )); do
+        local ref
+        ref="$(yq eval ".spec.agents[${i}].ref // \"\"" "$fleet_file")"
+
+        if [[ -n "$ref" ]]; then
+            # Resolve ref: host/agent-name -> agents/<host>/<name>.yaml
+            local ref_host ref_name
+            ref_host="${ref%%/*}"
+            ref_name="${ref#*/}"
+
+            # Apply host filter: skip refs that don't match the requested host
+            if [[ -n "$host_filter" && "$ref_host" != "$host_filter" ]]; then
+                continue
+            fi
+
+            local agent_file="${repo_root}/agents/${ref_host}/${ref_name}.yaml"
+            if [[ ! -f "$agent_file" ]]; then
+                echo "ERROR: Fleet ref '${ref}' not found — expected file at ${agent_file}" >&2
+                return 1
+            fi
+            echo "$agent_file"
+        else
+            # Inline agent definition — extract and write to a temp file
+            # Apply host filter: inline agents inherit the fleet's host
+            if [[ -n "$host_filter" && "$fleet_host" != "$host_filter" ]]; then
+                continue
+            fi
+
+            if [[ -z "${FLEET_TMPDIR:-}" ]]; then
+                FLEET_TMPDIR="$(mktemp -d)"
+            fi
+
+            local inline_name
+            inline_name="$(yq eval ".spec.agents[${i}].name // \"\"" "$fleet_file")"
+            if [[ -z "$inline_name" ]]; then
+                echo "ERROR: Inline agent at index ${i} in fleet has no name" >&2
+                return 1
+            fi
+
+            # Use the fleet's host for the inline agent metadata
+            local tmp_file="${FLEET_TMPDIR}/${inline_name}.yaml"
+            yq eval ".spec.agents[${i}] | {
+                \"apiVersion\": \"myrmidons/v1\",
+                \"kind\": \"Agent\",
+                \"metadata\": {
+                    \"name\": .name,
+                    \"host\": \"${fleet_host}\"
+                },
+                \"spec\": {
+                    \"label\": (.label // .name),
+                    \"program\": (.program // \"claude-code\"),
+                    \"model\": (.model // null),
+                    \"workingDirectory\": .workingDirectory,
+                    \"programArgs\": (.programArgs // \"\"),
+                    \"taskDescription\": (.taskDescription // \"\"),
+                    \"tags\": (.tags // []),
+                    \"owner\": (.owner // \"\"),
+                    \"role\": (.role // \"member\"),
+                    \"deployment\": (.deployment // {\"type\": \"local\"}),
+                    \"desiredState\": (.desiredState // \"active\")
+                }
+            }" "$fleet_file" > "$tmp_file"
+            echo "$tmp_file"
+        fi
+    done
+}
+
+# Clean up temp files created by resolve_fleet_files.
+# Usage: cleanup_fleet_tmpdir
+cleanup_fleet_tmpdir() {
+    if [[ -n "${FLEET_TMPDIR:-}" && -d "${FLEET_TMPDIR}" ]]; then
+        rm -rf "${FLEET_TMPDIR}"
+        FLEET_TMPDIR=""
+    fi
+}
+
+# Build a JSON create body from parsed YAML fields.
+# Usage: build_create_json name label program workingDirectory programArgs taskDescription tags owner role model deploymentType
+build_create_json() {
+    local name="$1" label="$2" program="$3" workdir="$4"
+    local args="$5" desc="$6" tags_csv="$7" owner="$8" role="$9"
+    local model="${10:-}" deploy_type="${11:-local}"
+
+    # Convert comma-separated tags to JSON array
+    local tags_json
+    if [[ -z "$tags_csv" ]]; then
+        tags_json="[]"
+    else
+        tags_json="$(echo "$tags_csv" | jq -Rc 'split(",")')"
+    fi
+
+    # model may be null/empty; represent as JSON null when absent
+    local model_json
+    if [[ -z "$model" ]]; then
+        model_json="null"
+    else
+        model_json="$(jq -n --arg m "$model" '$m')"
+    fi
+
+    # Note: $label is a reserved keyword in jq 1.6 (label-break syntax).
+    # Use $lbl as the variable name to avoid the parser conflict.
+    jq -n \
+        --arg name "$name" \
+        --arg lbl "$label" \
+        --arg program "$program" \
+        --arg workingDirectory "$workdir" \
+        --arg programArgs "$args" \
+        --arg taskDescription "$desc" \
+        --argjson tags "$tags_json" \
+        --arg owner "$owner" \
+        --arg role "$role" \
+        --argjson model "$model_json" \
+        --arg deploymentType "$deploy_type" \
+        '{
+            name: $name,
+            label: $lbl,
+            program: $program,
+            workingDirectory: $workingDirectory,
+            programArgs: $programArgs,
+            taskDescription: $taskDescription,
+            tags: $tags,
+            owner: $owner,
+            role: $role,
+            model: $model,
+            deployment: {type: $deploymentType}
+        }'
+}
+
+# Compare desired agent state (YAML fields) with actual state (JSON from API).
+# Outputs: "UNCHANGED", "CREATE", "UPDATE:<field1>,<field2>...", "WAKE", "HIBERNATE"
+#
+# Positional parameters:
+#   $1  name              — agent name (for context)
+#   $2  desired_state     — "active" | "hibernated"
+#   $3  actual_json       — full agent JSON from API
+#   $4  desired_label
+#   $5  desired_program
+#   $6  desired_workdir
+#   $7  desired_args
+#   $8  desired_desc
+#   $9  desired_tags_csv
+#   $10 desired_model
+#   $11 desired_owner
+#   $12 desired_role
+#   $13 desired_deploy_type
+compute_drift() {
+    if [[ $# -ne 13 ]]; then
+        echo "compute_drift requires exactly 13 arguments, got $#" >&2
+        return 1
+    fi
+    local name="$1"
+    local desired_state="$2"    # "active" | "hibernated"
+    local actual_json="$3"      # Full agent JSON from API
+
+    local actual_status
+    actual_status="$(echo "$actual_json" | jq -r '.status // "unknown"')"
+
+    # Check if wake/hibernate action is needed
+    if [[ "$desired_state" == "active" && "$actual_status" == "offline" ]]; then
+        echo "WAKE"
+        return
+    fi
+    if [[ "$desired_state" == "hibernated" ]] && \
+       [[ "$actual_status" == "active" || "$actual_status" == "online" ]]; then
+        echo "HIBERNATE"
+        return
+    fi
+
+    # Check field-level drift (simplified: check key fields)
+    local drifted_fields=()
+
+    local actual_label actual_program actual_workdir actual_args actual_desc actual_tags_sorted
+    local actual_model actual_owner actual_role actual_deploy_type
+    actual_label="$(echo "$actual_json" | jq -r '.label // ""')"
+    actual_program="$(echo "$actual_json" | jq -r '.program // ""')"
+    actual_workdir="$(echo "$actual_json" | jq -r '.workingDirectory // ""')"
+    actual_args="$(echo "$actual_json" | jq -r '.programArgs // ""')"
+    actual_desc="$(echo "$actual_json" | jq -r '.taskDescription // ""')"
+    # Tags: sorted comma-joined for stable comparison
+    actual_tags_sorted="$(echo "$actual_json" | jq -r '.tags // [] | sort | join(",")')"
+    # Normalize null model to empty string to avoid false positives
+    actual_model="$(echo "$actual_json" | jq -r '.model // ""')"
+    actual_owner="$(echo "$actual_json" | jq -r '.owner // ""')"
+    actual_role="$(echo "$actual_json" | jq -r '.role // ""')"
+    actual_deploy_type="$(echo "$actual_json" | jq -r '.deployment.type // "local"')"
+
+    # These are passed as positional args from the caller
+    local desired_label="$4"
+    local desired_program="$5"
+    local desired_workdir="$6"
+    local desired_args="$7"
+    local desired_desc="$8"
+    local desired_tags_csv="${9:-}"
+    local desired_model="${10:-}"
+    local desired_owner="${11:-}"
+    local desired_role="${12:-}"
+    local desired_deploy_type="${13:-local}"
+
+    # Normalize tilde paths before comparison
+    actual_workdir="$(normalize_path "$actual_workdir")"
+    desired_workdir="$(normalize_path "$desired_workdir")"
+
+    # Sort desired tags for stable comparison
+    local desired_tags_sorted=""
+    if [[ -n "$desired_tags_csv" ]]; then
+        desired_tags_sorted="$(echo "$desired_tags_csv" | tr ',' '\n' | sort | tr '\n' ',' | sed 's/,$//')"
+    fi
+
+    [[ "$actual_label" != "$desired_label" ]] && drifted_fields+=("label")
+    [[ "$actual_program" != "$desired_program" ]] && drifted_fields+=("program")
+    [[ "$actual_workdir" != "$desired_workdir" ]] && drifted_fields+=("workingDirectory")
+    [[ "$actual_args" != "$desired_args" ]] && drifted_fields+=("programArgs")
+    [[ "$actual_desc" != "$desired_desc" ]] && drifted_fields+=("taskDescription")
+    [[ "$actual_tags_sorted" != "$desired_tags_sorted" ]] && drifted_fields+=("tags")
+    [[ "$actual_model" != "$desired_model" ]] && drifted_fields+=("model")
+    [[ "$actual_owner" != "$desired_owner" ]] && drifted_fields+=("owner")
+    [[ "$actual_role" != "$desired_role" ]] && drifted_fields+=("role")
+    [[ "$actual_deploy_type" != "$desired_deploy_type" ]] && drifted_fields+=("deploymentType")
+
+    if [[ ${#drifted_fields[@]} -gt 0 ]]; then
+        local joined
+        joined="$(IFS=','; echo "${drifted_fields[*]}")"
+        echo "UPDATE:${joined}"
+    else
+        echo "UNCHANGED"
+    fi
+}
+
+# Expand ~ to $HOME so path comparisons are stable regardless of how the
+# path was entered (e.g. "~/foo" vs "/home/mvillmow/foo").
+normalize_path() {
+    local p="$1"
+    echo "${p/#\~/$HOME}"
+}
+
+# Report agents that exist in Agamemnon but are not managed by any YAML file.
+# Prints a log_warn line for each unmanaged agent.
+# Usage: report_unmanaged <agents_json> <yaml_file>...
+report_unmanaged() {
+    local agents_json="$1"
+    # Guard: nothing to check if Agamemnon returned no agents
+    [[ -z "$agents_json" || "$agents_json" == '[]' ]] && return 0
+    shift
+    # Guard: nothing to check if no YAML files are managed (#130)
+    [[ $# -eq 0 ]] && return 0
+    while IFS= read -r actual_name; do
+        log_warn "[-] UNMANAGED ${actual_name} (in Agamemnon but not in desired state — use --prune to remove)"
+    done < <(get_unmanaged_names "$agents_json" "$@")
+}
+
+# Find agent names that exist in Agamemnon but are not managed by any YAML file.
+# Outputs one unmanaged agent name per line.
+# Usage: get_unmanaged_names <agents_json> <yaml_file>...
+get_unmanaged_names() {
+    local agents_json="$1"
+    # Guard: nothing to check if Agamemnon returned no agents
+    [[ -z "$agents_json" || "$agents_json" == '[]' ]] && return 0
+    shift
+    local yaml_files=("$@")
+
+    # Collect managed names from YAML files; if no files provided, all agents are unmanaged.
+    local managed_names=()
+    if [[ ${#yaml_files[@]} -gt 0 ]]; then
+        while IFS= read -r n; do
+            [[ -n "$n" ]] && managed_names+=("$n")
+        done < <(yq eval '.metadata.name' "${yaml_files[@]}")
+    fi
+
+    # Emit names present in Agamemnon but absent from managed list
+    while IFS= read -r actual_name; do
+        local is_managed=0
+        for mn in "${managed_names[@]}"; do
+            [[ "$mn" == "$actual_name" ]] && is_managed=1 && break
+        done
+        if [[ $is_managed -eq 0 ]]; then
+            echo "$actual_name"
+        fi
+    done < <(echo "$agents_json" | jq -r '.[].name')
+}

--- a/tools/reconciler/scripts/lib/report.sh
+++ b/tools/reconciler/scripts/lib/report.sh
@@ -1,0 +1,442 @@
+#!/usr/bin/env bash
+# scripts/lib/report.sh — JSON reconciliation report builder
+#
+# Provides functions to build, accumulate, and emit a structured JSON report
+# of a reconciliation run. Used by apply.sh and status.sh.
+#
+# Report schema:
+# {
+#   "timestamp":      "<ISO-8601>",
+#   "host":           "<hostname or 'all'>",
+#   "agamemnon_url":  "<url>",
+#   "summary": {
+#     "created":    N,
+#     "updated":    N,
+#     "woken":      N,
+#     "hibernated": N,
+#     "unchanged":  N,
+#     "pruned":     N,
+#     "errors":     N
+#   },
+#   "agents": [
+#     {
+#       "name":    "<agent>",
+#       "host":    "<host>",
+#       "action":  "UNCHANGED|CREATE|UPDATE|WAKE|HIBERNATE|PRUNE|ERROR",
+#       "status":  { "desired": "...", "actual": "..." },
+#       "drift":   [ { "field": "...", "old": "...", "new": "..." }, ... ],
+#       "error":   "<message or null>"
+#     }
+#   ],
+#   "unmanaged": [ "<name>", ... ],
+#   "convergence": {
+#     "checked":  N,
+#     "verified": N,
+#     "failed":   N,
+#     "agents": [
+#       {
+#         "name":          "<agent>",
+#         "desired":       "active|hibernated",
+#         "actual_status": "<status or 'not_found'>",
+#         "converged":     true|false,
+#         "reason":        "<description>"
+#       }
+#     ]
+#   }
+# }
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Internal state — accumulated as the reconciliation run proceeds.
+# ---------------------------------------------------------------------------
+
+# Temporary file that accumulates per-agent JSON objects (one per line, NDJSON).
+_REPORT_AGENTS_TMP=""
+_REPORT_UNMANAGED_TMP=""
+_REPORT_CONVERGENCE_TMP=""
+
+# Initialise the report state.  Call once at the start of a reconciliation run.
+# Usage: report_init [host]
+report_init() {
+    local host="${1:-all}"
+    _REPORT_HOST="$host"
+    _REPORT_TIMESTAMP="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+    _REPORT_AGENTS_TMP="$(mktemp)"
+    _REPORT_UNMANAGED_TMP="$(mktemp)"
+    _REPORT_CONVERGENCE_TMP="$(mktemp)"
+}
+
+# Append one agent entry to the in-progress report.
+# Usage: report_add_agent <name> <host> <action> <desired_state> <actual_state> \
+#                         <drift_json_array> <error_or_empty>
+#
+# drift_json_array  — a JSON array string: '[{"field":"label","old":"A","new":"B"}]'
+#                     Pass '[]' when there is no drift.
+report_add_agent() {
+    local name="$1"
+    local host="$2"
+    local action="$3"
+    local desired_state="$4"
+    local actual_state="$5"
+    local drift_json="${6:-[]}"
+    local error_msg="${7:-}"
+
+    # Validate drift_json is at least a valid JSON array; fall back to [] on failure.
+    if ! echo "$drift_json" | jq -e . > /dev/null 2>&1; then
+        drift_json="[]"
+    fi
+
+    local error_val
+    if [[ -n "$error_msg" ]]; then
+        error_val="$(jq -n --arg e "$error_msg" '$e')"
+    else
+        error_val="null"
+    fi
+
+    jq -n \
+        --arg name "$name" \
+        --arg host "$host" \
+        --arg action "$action" \
+        --arg desired "$desired_state" \
+        --arg actual "$actual_state" \
+        --argjson drift "$drift_json" \
+        --argjson error "$error_val" \
+        '{name: $name, host: $host, action: $action,
+          status: {desired: $desired, actual: $actual},
+          drift: $drift, error: $error}' >> "$_REPORT_AGENTS_TMP"
+}
+
+# Record an unmanaged agent (present in Agamemnon but not in YAML).
+# Usage: report_add_unmanaged <name>
+report_add_unmanaged() {
+    local name="$1"
+    echo "$name" >> "$_REPORT_UNMANAGED_TMP"
+}
+
+# Append one convergence result entry for an agent.
+# Usage: report_add_convergence <name> <desired> <actual_status> <converged_bool> <reason>
+#   converged_bool — 0 for false, 1 for true
+report_add_convergence() {
+    local name="$1"
+    local desired="$2"
+    local actual_status="$3"
+    local converged_bool="$4"
+    local reason="$5"
+
+    local converged_json
+    if [[ "$converged_bool" == "1" ]]; then
+        converged_json="true"
+    else
+        converged_json="false"
+    fi
+
+    jq -n \
+        --arg name "$name" \
+        --arg desired "$desired" \
+        --arg actual_status "$actual_status" \
+        --argjson converged "$converged_json" \
+        --arg reason "$reason" \
+        '{name: $name, desired: $desired, actual_status: $actual_status,
+          converged: $converged, reason: $reason}' >> "$_REPORT_CONVERGENCE_TMP"
+}
+
+# Assemble and print the final JSON report to stdout.
+# Usage: report_emit <created> <updated> <woken> <hibernated> <unchanged> <pruned> <errors>
+report_emit() {
+    local created="${1:-0}"
+    local updated="${2:-0}"
+    local woken="${3:-0}"
+    local hibernated="${4:-0}"
+    local unchanged="${5:-0}"
+    local pruned="${6:-0}"
+    local errors="${7:-0}"
+
+    # Build agents JSON array from NDJSON temp file.
+    local agents_json="[]"
+    if [[ -s "$_REPORT_AGENTS_TMP" ]]; then
+        agents_json="$(jq -s '.' "$_REPORT_AGENTS_TMP")"
+    fi
+
+    # Build unmanaged JSON array from temp file.
+    local unmanaged_json="[]"
+    if [[ -s "$_REPORT_UNMANAGED_TMP" ]]; then
+        unmanaged_json="$(jq -Rn '[inputs]' < "$_REPORT_UNMANAGED_TMP")"
+    fi
+
+    # Build convergence JSON object from NDJSON temp file.
+    local convergence_agents_json="[]"
+    if [[ -s "$_REPORT_CONVERGENCE_TMP" ]]; then
+        convergence_agents_json="$(jq -s '.' "$_REPORT_CONVERGENCE_TMP")"
+    fi
+    local conv_checked conv_verified conv_failed
+    conv_checked="$(echo "$convergence_agents_json" | jq 'length')"
+    conv_verified="$(echo "$convergence_agents_json" | jq '[.[] | select(.converged == true)] | length')"
+    conv_failed="$(echo "$convergence_agents_json" | jq '[.[] | select(.converged == false)] | length')"
+
+    jq -n \
+        --arg timestamp "$_REPORT_TIMESTAMP" \
+        --arg host "${_REPORT_HOST:-all}" \
+        --arg url "${AGAMEMNON_URL:-http://localhost:8080}" \
+        --argjson created "$created" \
+        --argjson updated "$updated" \
+        --argjson woken "$woken" \
+        --argjson hibernated "$hibernated" \
+        --argjson unchanged "$unchanged" \
+        --argjson pruned "$pruned" \
+        --argjson errors "$errors" \
+        --argjson agents "$agents_json" \
+        --argjson unmanaged "$unmanaged_json" \
+        --argjson conv_checked "$conv_checked" \
+        --argjson conv_verified "$conv_verified" \
+        --argjson conv_failed "$conv_failed" \
+        --argjson conv_agents "$convergence_agents_json" \
+        '{
+            timestamp:     $timestamp,
+            host:          $host,
+            agamemnon_url: $url,
+            summary: {
+                created:    $created,
+                updated:    $updated,
+                woken:      $woken,
+                hibernated: $hibernated,
+                unchanged:  $unchanged,
+                pruned:     $pruned,
+                errors:     $errors
+            },
+            agents:    $agents,
+            unmanaged: $unmanaged,
+            convergence: {
+                checked:  $conv_checked,
+                verified: $conv_verified,
+                failed:   $conv_failed,
+                agents:   $conv_agents
+            }
+        }'
+}
+
+# Write the report to the canonical last-reconciliation file and a timestamped copy.
+# Usage: report_save <json_string> [report_dir]
+#
+# Writes two files:
+#   reports/last-reconciliation.json         — always the most recent snapshot
+#   reports/reconciliation-<timestamp>.json  — timestamped copy for history retention
+report_save() {
+    local json="$1"
+    local report_dir="${2:-}"
+
+    if [[ -z "$report_dir" ]]; then
+        local repo_root
+        repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+        report_dir="${repo_root}/reports"
+    fi
+
+    mkdir -p "$report_dir"
+
+    local timestamp
+    timestamp="$(date +%Y%m%d-%H%M%S)"
+    local timestamped_file="${report_dir}/reconciliation-${timestamp}.json"
+
+    # Write timestamped history copy
+    printf '%s\n' "$json" > "$timestamped_file"
+
+    # Write (or overwrite) the canonical latest snapshot
+    printf '%s\n' "$json" > "${report_dir}/last-reconciliation.json"
+}
+
+# POST the report JSON to the Agamemnon webhook endpoint.
+# Outputs a webhook_delivery JSON object to stdout indicating success/failure.
+# Usage: report_webhook <json_string> <webhook_url>
+# Output (stdout): JSON object — {"status":"success"|"failure","http_code":<N>}
+report_webhook() {
+    local json="$1"
+    local webhook_url="$2"
+
+    local http_code
+    local _had_xtrace=0
+    if [[ "$-" == *x* ]]; then _had_xtrace=1; fi
+    { set +x; } 2>/dev/null
+    http_code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 \
+        -X POST "$webhook_url" \
+        -H 'Content-Type: application/json' \
+        -d "$json" 2>/dev/null)" || http_code="0"
+    if [[ $_had_xtrace -eq 1 ]]; then set -x; fi
+
+    local status
+    if [[ "$http_code" =~ ^2 ]]; then
+        status="success"
+        echo "Webhook delivered to ${webhook_url} (HTTP ${http_code})" >&2
+    else
+        status="failure"
+        echo "WARNING: Webhook delivery failed to ${webhook_url} (HTTP ${http_code})" >&2
+    fi
+
+    jq -n --arg status "$status" --argjson code "${http_code:-0}" \
+        '{status: $status, http_code: $code}'
+}
+
+# Clean up temp files.  Call after report_emit (or on EXIT).
+report_cleanup() {
+    [[ -n "${_REPORT_AGENTS_TMP:-}" && -f "$_REPORT_AGENTS_TMP" ]] && rm -f "$_REPORT_AGENTS_TMP"
+    [[ -n "${_REPORT_UNMANAGED_TMP:-}" && -f "$_REPORT_UNMANAGED_TMP" ]] && rm -f "$_REPORT_UNMANAGED_TMP"
+    [[ -n "${_REPORT_CONVERGENCE_TMP:-}" && -f "$_REPORT_CONVERGENCE_TMP" ]] && rm -f "$_REPORT_CONVERGENCE_TMP"
+}
+
+# ---------------------------------------------------------------------------
+# Snapshot functions — capture agent state before apply or rollback (#228, #225)
+# ---------------------------------------------------------------------------
+
+# Write a snapshot of current agent state to the snapshot directory.
+# Adds context fields: user, git_branch, host, timestamp.
+#
+# Usage: snapshot_write <agents_json> <snapshot_dir> <host> [suffix]
+#   agents_json   — JSON array string of current agent objects from Agamemnon
+#   snapshot_dir  — directory to write snapshot files into
+#   host          — host argument passed to apply/rollback (or "all")
+#   suffix        — optional filename suffix before .json (e.g. "pre-rollback")
+#
+# Outputs the path of the written snapshot file.
+snapshot_write() {
+    local agents_json="$1"
+    local snapshot_dir="$2"
+    local host="${3:-all}"
+    local suffix="${4:-}"
+
+    mkdir -p "$snapshot_dir"
+
+    local timestamp git_branch run_user
+    timestamp="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+    git_branch="$(git -C "$(dirname "${BASH_SOURCE[0]}")/../.." rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")"
+    run_user="${USER:-unknown}"
+
+    local filename="${timestamp}"
+    [[ -n "$suffix" ]] && filename="${timestamp}.${suffix}"
+    local snapshot_file="${snapshot_dir}/${filename}.json"
+
+    jq -n \
+        --arg timestamp "$timestamp" \
+        --arg git_branch "$git_branch" \
+        --arg host "$host" \
+        --arg user "$run_user" \
+        --argjson agents "$agents_json" \
+        '{
+            context: {
+                timestamp:  $timestamp,
+                user:       $user,
+                git_branch: $git_branch,
+                host:       $host
+            },
+            agents: $agents
+        }' > "$snapshot_file"
+
+    echo "$snapshot_file"
+}
+
+# Prune old snapshots in a directory, keeping at most SNAPSHOT_KEEP files.
+# Skips files that contain a suffix (e.g. pre-rollback) from pruning count
+# to avoid deleting safety nets.
+#
+# Usage: snapshot_prune <snapshot_dir> [keep_count]
+snapshot_prune() {
+    local snapshot_dir="$1"
+    local keep="${2:-${SNAPSHOT_KEEP:-10}}"
+
+    [[ ! -d "$snapshot_dir" ]] && return 0
+
+    # Only count/prune regular (non-suffixed) snapshots:
+    # Suffixed snapshots (*.pre-rollback.json etc.) are retained separately.
+    # The first pass keeps stems with no dots; we use awk for the inverted
+    # match so an empty result returns rc=0 (grep -v returns 1 in that case,
+    # which would fail under `set -o pipefail`).
+    local regular_snapshots=()
+    mapfile -t regular_snapshots < <(
+        find "$snapshot_dir" -maxdepth 1 -name "*.json" \
+            | awk -F/ '{stem=$NF; sub(/\.json$/,"",stem); if (index(stem,".")==0) print}' \
+            | sort
+        # fallback: match ISO timestamp pattern only (no dots in stem)
+        find "$snapshot_dir" -maxdepth 1 -name "*T*Z.json" \
+            | awk '/\/[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z\.json$/' \
+            | sort
+    )
+
+    # Deduplicate
+    local -A seen=()
+    local deduped=()
+    for f in "${regular_snapshots[@]}"; do
+        [[ -z "${seen[$f]:-}" ]] && deduped+=("$f") && seen["$f"]=1
+    done
+
+    local count=${#deduped[@]}
+    if [[ $count -gt $keep ]]; then
+        local excess=$(( count - keep ))
+        # Remove oldest first (sort ascending, take head)
+        printf '%s\n' "${deduped[@]}" | sort | head -n "$excess" | xargs rm -f
+    fi
+}
+
+# Build a drift JSON array from an UPDATE:<fields> action string and the actual/desired values.
+# Usage: build_drift_json <action_string> <actual_json> \
+#                         <desired_label> <desired_program> <desired_workdir> \
+#                         <desired_args> <desired_desc> <desired_tags_csv> \
+#                         <desired_owner> <desired_role>
+# Outputs a JSON array like: [{"field":"label","old":"X","new":"Y"}, ...]
+build_drift_json() {
+    local action="$1"
+    local actual_json="$2"
+    local desired_label="$3"
+    local desired_program="$4"
+    local desired_workdir="$5"
+    local desired_args="$6"
+    local desired_desc="$7"
+    local desired_tags_csv="${8:-}"
+    local desired_owner="${9:-}"
+    local desired_role="${10:-}"
+
+    if [[ "$action" != UPDATE:* ]]; then
+        echo "[]"
+        return
+    fi
+
+    local changed_fields="${action#UPDATE:}"
+    IFS=',' read -ra fields <<< "$changed_fields"
+
+    # Map desired values by field name
+    declare -A desired_vals
+    desired_vals["label"]="$desired_label"
+    desired_vals["program"]="$desired_program"
+    desired_vals["workingDirectory"]="$(normalize_path "$desired_workdir")"
+    desired_vals["programArgs"]="$desired_args"
+    desired_vals["taskDescription"]="$desired_desc"
+    desired_vals["tags"]="$desired_tags_csv"
+    desired_vals["owner"]="$desired_owner"
+    desired_vals["role"]="$desired_role"
+
+    # Build JSON array using jq
+    local entries="[]"
+    for field in "${fields[@]}"; do
+        local old_val new_val
+
+        case "$field" in
+            label)            old_val="$(echo "$actual_json" | jq -r '.label // ""')" ;;
+            program)          old_val="$(echo "$actual_json" | jq -r '.program // ""')" ;;
+            workingDirectory) old_val="$(normalize_path "$(echo "$actual_json" | jq -r '.workingDirectory // ""')")" ;;
+            programArgs)      old_val="$(echo "$actual_json" | jq -r '.programArgs // ""')" ;;
+            taskDescription)  old_val="$(echo "$actual_json" | jq -r '.taskDescription // ""')" ;;
+            tags)             old_val="$(echo "$actual_json" | jq -r '.tags // [] | sort | join(",")')" ;;
+            owner)            old_val="$(echo "$actual_json" | jq -r '.owner // ""')" ;;
+            role)             old_val="$(echo "$actual_json" | jq -r '.role // ""')" ;;
+            *)                old_val="" ;;
+        esac
+
+        new_val="${desired_vals[$field]:-}"
+
+        entries="$(jq -n \
+            --argjson arr "$entries" \
+            --arg field "$field" \
+            --arg old "$old_val" \
+            --arg new "$new_val" \
+            '$arr + [{"field": $field, "old": $old, "new": $new}]')"
+    done
+
+    echo "$entries"
+}

--- a/tools/reconciler/scripts/new-agent.sh
+++ b/tools/reconciler/scripts/new-agent.sh
@@ -1,0 +1,547 @@
+#!/usr/bin/env bash
+# scripts/new-agent.sh — Scaffold a new agent YAML file from a template
+#
+# Prompts for required fields (interactive mode) or accepts them as flags
+# (--non-interactive), validates input, and writes the agent YAML to
+# agents/<host>/<name>.yaml.
+#
+# Usage (interactive):
+#   bash scripts/new-agent.sh
+#
+# Usage (non-interactive):
+#   bash scripts/new-agent.sh \
+#     --name my-agent \
+#     --host hermes \
+#     --program claude-code \
+#     --working-directory /home/mvillmow/MyProject \
+#     --task-description "What this agent does" \
+#     [--label "Display Name"] \
+#     [--desired-state active] \
+#     [--tags "tag1,tag2"]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+TEMPLATES_DIR="${REPO_ROOT}/agents/_templates"
+
+# shellcheck source=scripts/lib/prompt.sh
+source "${SCRIPT_DIR}/lib/prompt.sh"
+
+# ---------------------------------------------------------------------------
+# Colour helpers (same convention as other scripts)
+# ---------------------------------------------------------------------------
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+info()    { echo -e "${CYAN}${*}${RESET}"; }
+success() { echo -e "${GREEN}${*}${RESET}"; }
+warn()    { echo -e "${YELLOW}${*}${RESET}"; }
+error()   { echo -e "${RED}ERROR: ${*}${RESET}" >&2; }
+die()     { error "${*}"; exit 1; }
+
+# ---------------------------------------------------------------------------
+# Valid enum values
+# ---------------------------------------------------------------------------
+VALID_PROGRAMS=("claude-code" "aider" "none")
+VALID_DESIRED_STATES=("active" "hibernated")
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+NON_INTERACTIVE=false
+OPT_NAME=""
+OPT_HOST=""
+OPT_PROGRAM=""
+OPT_WORKING_DIR=""
+OPT_TASK_DESC=""
+OPT_LABEL=""
+OPT_DESIRED_STATE=""
+OPT_TAGS=""
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Scaffold a new agent YAML file from a template.
+
+Options:
+  --name NAME                  Agent name (lowercase, hyphens only)
+  --host HOST                  Target host (must match a directory in agents/)
+  --program PROGRAM            Program type: claude-code | aider | none
+  --working-directory DIR      Working directory for the agent
+  --task-description DESC      What this agent does
+  --label LABEL                Display name in Agamemnon UI (default: NAME)
+  --desired-state STATE        active | hibernated (default: active)
+  --tags TAG1,TAG2,...         Comma-separated list of tags (optional)
+  --non-interactive            Require all values via flags; do not prompt
+  -h, --help                   Show this help
+
+Without --non-interactive, any missing fields will be prompted interactively.
+
+Examples:
+  # Interactive
+  bash scripts/new-agent.sh
+
+  # Non-interactive
+  bash scripts/new-agent.sh \\
+    --name ci-agent \\
+    --host hermes \\
+    --program claude-code \\
+    --working-directory /home/mvillmow/CIProject \\
+    --task-description "Continuous integration helper"
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --name)               OPT_NAME="$2";          shift 2 ;;
+        --host)               OPT_HOST="$2";          shift 2 ;;
+        --program)            OPT_PROGRAM="$2";       shift 2 ;;
+        --working-directory)  OPT_WORKING_DIR="$2";   shift 2 ;;
+        --task-description)   OPT_TASK_DESC="$2";     shift 2 ;;
+        --label)              OPT_LABEL="$2";         shift 2 ;;
+        --desired-state)      OPT_DESIRED_STATE="$2"; shift 2 ;;
+        --tags)               OPT_TAGS="$2";          shift 2 ;;
+        --non-interactive)    NON_INTERACTIVE=true;   shift   ;;
+        -h|--help)            usage; exit 0 ;;
+        --) shift; break ;;
+        *) die "Unknown option: $1. Use --help for usage." ;;
+    esac
+done
+
+# ---------------------------------------------------------------------------
+# Validation helpers
+# ---------------------------------------------------------------------------
+validate_name() {
+    local name="$1"
+    if [[ -z "$name" ]]; then
+        return 1
+    fi
+    if [[ ! "$name" =~ ^[a-z0-9][a-z0-9-]*$ ]]; then
+        return 1
+    fi
+    return 0
+}
+
+validate_program() {
+    local prog="$1"
+    for valid in "${VALID_PROGRAMS[@]}"; do
+        [[ "$prog" == "$valid" ]] && return 0
+    done
+    return 1
+}
+
+validate_desired_state() {
+    local state="$1"
+    for valid in "${VALID_DESIRED_STATES[@]}"; do
+        [[ "$state" == "$valid" ]] && return 0
+    done
+    return 1
+}
+
+# ---------------------------------------------------------------------------
+# Template selection
+# ---------------------------------------------------------------------------
+select_template() {
+    local program="$1"
+    case "$program" in
+        claude-code) echo "${TEMPLATES_DIR}/claude-default.yaml" ;;
+        aider)       echo "${TEMPLATES_DIR}/aider-default.yaml"  ;;
+        none)        echo "${TEMPLATES_DIR}/worker-default.yaml" ;;
+        *)           die "No template for program: ${program}" ;;
+    esac
+}
+
+# ---------------------------------------------------------------------------
+# Interactive prompts
+# ---------------------------------------------------------------------------
+
+# prompt_field and prompt_enum collect free-text / enum data from the user.
+# They use bare `read -r -p` (no timeout) intentionally: a timeout would
+# silently corrupt required field values with an empty default. These are
+# data-entry reads, not yes/no confirmations. Use confirm_with_timeout() for
+# any confirmation prompt that should default-deny after a timeout.
+prompt_field() {
+    local prompt="$1"
+    local default="$2"
+    local result=""
+    if [[ -n "$default" ]]; then
+        # data-entry read — no timeout intentional (free-text input, not y/n)
+        read -r -p "$(echo -e "${BOLD}${prompt}${RESET} [${default}]: ")" result
+        echo "${result:-$default}"
+    else
+        while [[ -z "$result" ]]; do
+            # data-entry read — no timeout intentional (required field)
+            read -r -p "$(echo -e "${BOLD}${prompt}${RESET}: ")" result
+            if [[ -z "$result" ]]; then
+                warn "  This field is required."
+            fi
+        done
+        echo "$result"
+    fi
+}
+
+prompt_enum() {
+    local prompt="$1"
+    local default="$2"
+    shift 2
+    local options=("$@")
+    local joined
+    joined="$(IFS="|"; echo "${options[*]}")"
+    local result=""
+    while true; do
+        if [[ -n "$default" ]]; then
+            # data-entry read — no timeout intentional (enum selection)
+            read -r -p "$(echo -e "${BOLD}${prompt}${RESET} (${joined}) [${default}]: ")" result
+            result="${result:-$default}"
+        else
+            # data-entry read — no timeout intentional (required enum)
+            read -r -p "$(echo -e "${BOLD}${prompt}${RESET} (${joined}): ")" result
+        fi
+        for valid in "${options[@]}"; do
+            [[ "$result" == "$valid" ]] && { echo "$result"; return 0; }
+        done
+        warn "  Must be one of: ${joined}"
+    done
+}
+
+# ---------------------------------------------------------------------------
+# Tags formatting: "tag1,tag2" → YAML list items
+# ---------------------------------------------------------------------------
+format_tags_yaml() {
+    local tags_input="$1"
+    if [[ -z "$tags_input" ]]; then
+        echo "[]"
+        return
+    fi
+    local yaml="["
+    local first=true
+    IFS=',' read -ra tag_arr <<< "$tags_input"
+    for tag in "${tag_arr[@]}"; do
+        tag="$(echo "$tag" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+        [[ -z "$tag" ]] && continue
+        if $first; then
+            yaml+="${tag}"
+            first=false
+        else
+            yaml+=", ${tag}"
+        fi
+    done
+    yaml+="]"
+    echo "$yaml"
+}
+
+# ---------------------------------------------------------------------------
+# Collect field values
+# ---------------------------------------------------------------------------
+collect_fields() {
+    echo ""
+    info "=== New Agent Scaffolding ==="
+    echo ""
+
+    # Name
+    local name="${OPT_NAME}"
+    while true; do
+        if [[ -z "$name" ]]; then
+            name="$(prompt_field "Agent name (lowercase, hyphens only, e.g. my-agent)" "")"
+        fi
+        if validate_name "$name"; then
+            break
+        fi
+        error "Name must match ^[a-z0-9][a-z0-9-]*\$ (lowercase letters, digits, hyphens only)"
+        name=""
+    done
+
+    # Host
+    local host="${OPT_HOST}"
+    while true; do
+        if [[ -z "$host" ]]; then
+            host="$(prompt_field "Target host" "hermes")"
+        fi
+        local host_dir="${REPO_ROOT}/agents/${host}"
+        if [[ -d "$host_dir" ]]; then
+            break
+        fi
+        # Offer to create the directory
+        warn "Directory agents/${host}/ does not exist."
+        if confirm_with_timeout "Create agents/${host}/? [y/N]"; then
+            mkdir -p "$host_dir"
+            info "Created agents/${host}/"
+            break
+        else
+            warn "Host directory must exist. Choose an existing host or create the directory."
+            host=""
+            OPT_HOST=""  # allow re-prompt
+        fi
+    done
+
+    # Program
+    local program="${OPT_PROGRAM}"
+    while true; do
+        if [[ -z "$program" ]]; then
+            program="$(prompt_enum "Program type" "claude-code" "${VALID_PROGRAMS[@]}")"
+        fi
+        if validate_program "$program"; then
+            break
+        fi
+        error "Program must be one of: $(IFS=", "; echo "${VALID_PROGRAMS[*]}")"
+        program=""
+        OPT_PROGRAM=""
+    done
+
+    # Working directory
+    local working_dir="${OPT_WORKING_DIR}"
+    if [[ -z "$working_dir" ]]; then
+        working_dir="$(prompt_field "Working directory" "/home/mvillmow/${name}")"
+    fi
+    if [[ -z "$working_dir" ]]; then
+        die "Working directory is required."
+    fi
+
+    # Task description
+    local task_desc="${OPT_TASK_DESC}"
+    if [[ -z "$task_desc" ]]; then
+        task_desc="$(prompt_field "Task description" "Describe what this agent does")"
+    fi
+
+    # Label (display name)
+    local label="${OPT_LABEL}"
+    if [[ -z "$label" ]]; then
+        if $NON_INTERACTIVE; then
+            label="$name"
+        else
+            label="$(prompt_field "Display label (Agamemnon UI)" "$name")"
+        fi
+    fi
+
+    # Desired state
+    local desired_state="${OPT_DESIRED_STATE}"
+    while true; do
+        if [[ -z "$desired_state" ]]; then
+            desired_state="$(prompt_enum "Desired state" "active" "${VALID_DESIRED_STATES[@]}")"
+        fi
+        if validate_desired_state "$desired_state"; then
+            break
+        fi
+        error "Desired state must be one of: $(IFS=", "; echo "${VALID_DESIRED_STATES[*]}")"
+        desired_state=""
+        OPT_DESIRED_STATE=""
+    done
+
+    # Tags
+    local tags_input="${OPT_TAGS}"
+    if [[ -z "$tags_input" ]] && ! $NON_INTERACTIVE; then
+        # data-entry read — no timeout intentional (optional free-text field)
+        read -r -p "$(echo -e "${BOLD}Tags${RESET} (comma-separated, optional): ")" tags_input
+    fi
+
+    # Export collected values
+    FIELD_NAME="$name"
+    FIELD_HOST="$host"
+    FIELD_PROGRAM="$program"
+    FIELD_WORKING_DIR="$working_dir"
+    FIELD_TASK_DESC="$task_desc"
+    FIELD_LABEL="$label"
+    FIELD_DESIRED_STATE="$desired_state"
+    FIELD_TAGS="$tags_input"
+}
+
+# ---------------------------------------------------------------------------
+# Non-interactive validation: all required fields must be provided via flags
+# ---------------------------------------------------------------------------
+validate_non_interactive() {
+    local missing=()
+    [[ -z "$OPT_NAME" ]]        && missing+=("--name")
+    [[ -z "$OPT_HOST" ]]        && missing+=("--host")
+    [[ -z "$OPT_PROGRAM" ]]     && missing+=("--program")
+    [[ -z "$OPT_WORKING_DIR" ]] && missing+=("--working-directory")
+    [[ -z "$OPT_TASK_DESC" ]]   && missing+=("--task-description")
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        die "--non-interactive requires all fields. Missing: ${missing[*]}"
+    fi
+
+    if ! validate_name "$OPT_NAME"; then
+        die "Invalid --name '${OPT_NAME}': must match ^[a-z0-9][a-z0-9-]*\$"
+    fi
+    if ! validate_program "$OPT_PROGRAM"; then
+        die "Invalid --program '${OPT_PROGRAM}': must be one of $(IFS=", "; echo "${VALID_PROGRAMS[*]}")"
+    fi
+    if [[ -n "$OPT_DESIRED_STATE" ]] && ! validate_desired_state "$OPT_DESIRED_STATE"; then
+        die "Invalid --desired-state '${OPT_DESIRED_STATE}': must be one of $(IFS=", "; echo "${VALID_DESIRED_STATES[*]}")"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Generate the YAML file
+# ---------------------------------------------------------------------------
+generate_agent_yaml() {
+    local template
+    template="$(select_template "${FIELD_PROGRAM}")"
+
+    local output_file="${REPO_ROOT}/agents/${FIELD_HOST}/${FIELD_NAME}.yaml"
+
+    if [[ -f "$output_file" ]]; then
+        die "File already exists: agents/${FIELD_HOST}/${FIELD_NAME}.yaml\nDelete it first or choose a different name."
+    fi
+
+    local tags_yaml
+    tags_yaml="$(format_tags_yaml "${FIELD_TAGS}")"
+
+    # Escape special characters for sed replacement strings
+    escape_sed() { printf '%s\n' "$1" | sed 's/[\/&]/\\&/g'; }
+
+    local esc_name esc_host esc_label esc_working_dir esc_task_desc esc_desired_state esc_tags
+    esc_name="$(escape_sed "${FIELD_NAME}")"
+    esc_host="$(escape_sed "${FIELD_HOST}")"
+    esc_label="$(escape_sed "${FIELD_LABEL}")"
+    esc_working_dir="$(escape_sed "${FIELD_WORKING_DIR}")"
+    esc_desired_state="$(escape_sed "${FIELD_DESIRED_STATE}")"
+    esc_tags="$(escape_sed "${tags_yaml}")"
+    # Task description needs special handling for the sed expression
+    esc_task_desc="$(printf '%s\n' "${FIELD_TASK_DESC}" | sed 's/[\/&"]/\\&/g')"
+
+    # Apply field substitutions. The tags: key may span multiple lines in
+    # the worker template (list-style), so we use awk to collapse those
+    # trailing "    - item" lines after replacing the tags: line itself.
+    sed \
+        -e "s/^\(  name:\) CHANGE_ME\(.*\)$/  name: ${esc_name}/" \
+        -e "s/^\(  host:\) hermes\(.*\)$/  host: ${esc_host}/" \
+        -e "s/^\(  label:\) CHANGE_ME\(.*\)$/  label: ${esc_label}/" \
+        -e "s|^\(  workingDirectory:\).*$|  workingDirectory: ${esc_working_dir}|" \
+        -e "s/^\(  taskDescription:\).*$/  taskDescription: \"${esc_task_desc}\"/" \
+        -e "s/^\(  desiredState:\).*$/  desiredState: ${esc_desired_state}/" \
+        -e "s/^\(  tags:\).*$/  tags: ${esc_tags}/" \
+        "$template" \
+    | awk '
+        # After we rewrite "  tags: [...]", suppress any immediately
+        # following "    - item" lines from the original multi-line block.
+        /^  tags:/ { in_tags=1; print; next }
+        in_tags && /^    - / { next }   # skip old list items
+        { in_tags=0; print }
+    ' > "$output_file"
+
+    echo "$output_file"
+}
+
+# ---------------------------------------------------------------------------
+# Schema validation on the generated file
+# ---------------------------------------------------------------------------
+validate_generated_file() {
+    local output_file="$1"
+
+    info "\nValidating generated file..."
+
+    local errors=0
+
+    # YAML syntax
+    if ! yq eval '.' "$output_file" > /dev/null 2>&1; then
+        error "Generated file has invalid YAML syntax."
+        errors=$((errors + 1))
+    fi
+
+    # apiVersion
+    local api_version
+    api_version="$(yq eval '.apiVersion // ""' "$output_file")"
+    if [[ "$api_version" != "myrmidons/v1" ]]; then
+        error "apiVersion: expected myrmidons/v1, got '${api_version}'"
+        errors=$((errors + 1))
+    fi
+
+    # kind
+    local kind
+    kind="$(yq eval '.kind // ""' "$output_file")"
+    if [[ "$kind" != "Agent" ]]; then
+        error "kind: expected Agent, got '${kind}'"
+        errors=$((errors + 1))
+    fi
+
+    # Required fields
+    local name host program workdir
+    name="$(yq eval '.metadata.name // ""' "$output_file")"
+    host="$(yq eval '.metadata.host // ""' "$output_file")"
+    program="$(yq eval '.spec.program // ""' "$output_file")"
+    workdir="$(yq eval '.spec.workingDirectory // ""' "$output_file")"
+
+    [[ -z "$name" ]]    && { error "metadata.name is missing"; errors=$((errors + 1)); }
+    [[ -z "$host" ]]    && { error "metadata.host is missing"; errors=$((errors + 1)); }
+    [[ -z "$program" ]] && { error "spec.program is missing";  errors=$((errors + 1)); }
+    [[ -z "$workdir" ]] && { error "spec.workingDirectory is missing"; errors=$((errors + 1)); }
+
+    # No leftover placeholders
+    if grep -q "CHANGE_ME" "$output_file" 2>/dev/null; then
+        error "Generated file still contains CHANGE_ME placeholders."
+        errors=$((errors + 1))
+    fi
+
+    # desiredState enum
+    local ds
+    ds="$(yq eval '.spec.desiredState // ""' "$output_file")"
+    if [[ -n "$ds" ]] && ! validate_desired_state "$ds"; then
+        error "spec.desiredState: must be active or hibernated, got '${ds}'"
+        errors=$((errors + 1))
+    fi
+
+    if [[ $errors -gt 0 ]]; then
+        rm -f "$output_file"
+        die "Validation failed (${errors} error(s)). Generated file removed."
+    fi
+
+    success "  Validation passed."
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+main() {
+    # Verify yq is available
+    if ! command -v yq &>/dev/null; then
+        die "yq not found. Install from https://github.com/mikefarah/yq"
+    fi
+
+    if $NON_INTERACTIVE; then
+        validate_non_interactive
+        # Set defaults for optional fields
+        FIELD_NAME="$OPT_NAME"
+        FIELD_HOST="$OPT_HOST"
+        FIELD_PROGRAM="$OPT_PROGRAM"
+        FIELD_WORKING_DIR="$OPT_WORKING_DIR"
+        FIELD_TASK_DESC="$OPT_TASK_DESC"
+        FIELD_LABEL="${OPT_LABEL:-$OPT_NAME}"
+        FIELD_DESIRED_STATE="${OPT_DESIRED_STATE:-active}"
+        FIELD_TAGS="${OPT_TAGS:-}"
+
+        # Ensure host directory exists
+        local host_dir="${REPO_ROOT}/agents/${FIELD_HOST}"
+        if [[ ! -d "$host_dir" ]]; then
+            die "Host directory agents/${FIELD_HOST}/ does not exist. Create it first."
+        fi
+    else
+        collect_fields
+    fi
+
+    echo ""
+    info "Generating agent YAML..."
+    local output_file
+    output_file="$(generate_agent_yaml)"
+
+    validate_generated_file "$output_file"
+
+    local rel_path
+    rel_path="agents/${FIELD_HOST}/${FIELD_NAME}.yaml"
+
+    echo ""
+    success "Agent created: ${rel_path}"
+    echo ""
+    echo -e "${BOLD}Next steps:${RESET}"
+    echo "  just plan ${FIELD_HOST}          # Preview what will change"
+    echo "  just apply ${FIELD_HOST}         # Apply to Agamemnon"
+    echo "  git add ${rel_path}"
+    echo "  git commit -m 'add agent ${FIELD_NAME}'"
+}
+
+main

--- a/tools/reconciler/scripts/plan.sh
+++ b/tools/reconciler/scripts/plan.sh
@@ -1,0 +1,336 @@
+#!/usr/bin/env bash
+# scripts/plan.sh — Dry-run: show what apply.sh would do
+#
+# Compares desired state (YAML files) against actual state (Agamemnon API)
+# and prints what changes would be made. Makes NO changes.
+#
+# Usage:
+#   ./scripts/plan.sh                  # Plan all agents on all hosts
+#   ./scripts/plan.sh hermes           # Plan agents for a specific host
+#   ./scripts/plan.sh --output json    # Emit machine-readable JSON summary
+#
+# Exit codes:
+#   0 = no changes needed
+#   1 = changes would be made (or error)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# shellcheck source=scripts/lib/config.sh
+source "${SCRIPT_DIR}/lib/config.sh"
+# shellcheck source=scripts/lib/log.sh
+source "${SCRIPT_DIR}/lib/log.sh"
+# shellcheck source=scripts/lib/api.sh
+source "${SCRIPT_DIR}/lib/api.sh"
+# shellcheck source=scripts/lib/reconcile.sh
+source "${SCRIPT_DIR}/lib/reconcile.sh"
+# shellcheck source=scripts/lib/report.sh
+source "${SCRIPT_DIR}/lib/report.sh"
+
+load_config
+
+HOST=""
+FLEET_NAME=""
+OUTPUT_FORMAT="text"   # "text" | "json" (#179)
+PRUNE=0
+
+# Counters for JSON output
+CREATE_COUNT=0
+UPDATE_COUNT=0
+WAKE_COUNT=0
+HIBERNATE_COUNT=0
+UNCHANGED_COUNT=0
+
+# Accumulate planned_changes entries (one JSON object per line, NDJSON)
+_PLAN_CHANGES_TMP=""
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -h|--help)  usage; exit 0 ;;
+            --dry-run)  shift ;;
+            --fleet)    FLEET_NAME="$2"; shift 2 ;;
+            --output)   OUTPUT_FORMAT="$2"; shift 2 ;;
+            --webhook)  shift 2 ;;  # Accepted but ignored in plan
+            --prune)    PRUNE=1; shift ;;
+            -*) echo "ERROR: Unknown argument: $1" >&2; usage; exit 1 ;;
+            *) HOST="$1"; shift ;;
+        esac
+    done
+}
+
+usage() {
+    echo "Usage: $0 [host] [--fleet <name>] [--output json] [--prune]"
+    echo ""
+    echo "Shows what apply.sh would do without making any changes."
+    echo ""
+    echo "Options:"
+    echo "  host           Only plan agents for this host (default: all)"
+    echo "  --fleet <name> Only plan agents in the named fleet"
+    echo "  --output json  Emit a machine-readable JSON plan report to stdout"
+    echo "  --prune        Also show which unmanaged agents would be pruned"
+    echo "  -h, --help     Show this help"
+    echo ""
+    echo "Environment:"
+    echo "  AGAMEMNON_URL            Agamemnon base URL (default: http://localhost:8080)"
+    echo "  AGAMEMNON_API_KEY        Bearer token for Agamemnon API authentication"
+    echo "  MYRMIDONS_DEFAULT_OWNER  Fallback owner used when the API returns no owner"
+    echo ""
+    echo "Examples:"
+    echo "  $0                        # Plan all agents"
+    echo "  $0 hermes                 # Plan agents on hermes"
+    echo "  $0 --fleet dev-mesh       # Plan agents in the dev-mesh fleet"
+    echo "  $0 --output json          # Machine-readable JSON summary"
+    echo "  $0 hermes --output json | jq .summary"
+    echo "  $0 --prune                # Plan including unmanaged agent removal"
+}
+
+# plan_report_unmanaged wraps reconcile.sh's report_unmanaged to avoid
+# shadowing if a local function of the same name were ever defined here.
+# (#273: prevent name collision with reconcile.sh's report_unmanaged)
+plan_report_unmanaged() {
+    report_unmanaged "$@"
+}
+
+# Record one planned change entry into the temp file
+_plan_record_change() {
+    local name="$1"
+    local action="$2"       # CREATE | UPDATE | WAKE | HIBERNATE | UNCHANGED
+    local details="${3:-}"  # human-readable detail string
+
+    jq -n \
+        --arg name "$name" \
+        --arg action "$action" \
+        --arg details "$details" \
+        '{name: $name, action: $action, details: $details}' >> "$_PLAN_CHANGES_TMP"
+}
+
+main() {
+    parse_args "$@"
+
+    # Validate AGAMEMNON_URL format early (#118)
+    validate_agamemnon_url
+
+    # Validate HOST argument against known agents/ subdirectories (#149)
+    if [[ -n "$HOST" && ! -d "${REPO_ROOT}/agents/${HOST}" ]]; then
+        log_error "Host '${HOST}' not found — no agents/${HOST}/ directory exists."
+        log_error "  Known hosts: $(find "${REPO_ROOT}/agents" -mindepth 1 -maxdepth 1 -type d \
+            ! -name '_templates' -printf '%f ' 2>/dev/null || echo '(none)')"
+        exit 1
+    fi
+
+    check_deps
+    agamemnon_check_connection
+
+    # Initialise temp file for planned changes and register fleet cleanup
+    _PLAN_CHANGES_TMP="$(mktemp)"
+    trap 'rm -f "$_PLAN_CHANGES_TMP"; cleanup_fleet_tmpdir' EXIT
+
+    # NOTE: apply.sh fetches agents_json once and refreshes it after each
+    # change (cache optimization). In dry-run / plan mode no changes are made,
+    # so a single fetch is sufficient and the per-agent refresh is intentionally
+    # skipped. (#96)
+    local agents_json
+    agents_json="$(agamemnon_list_agents)"
+
+    local yaml_files
+    mapfile -t yaml_files < <(get_agent_files "$HOST" "$FLEET_NAME")
+
+    if [[ ${#yaml_files[@]} -eq 0 ]]; then
+        if [[ "$OUTPUT_FORMAT" == "json" ]]; then
+            _emit_json_plan 0
+        else
+            log_info "No agent YAML files found."
+        fi
+        exit 0
+    fi
+
+    local has_changes=0
+
+    if [[ "$OUTPUT_FORMAT" != "json" ]]; then
+        local prune_indicator=""
+        [[ $PRUNE -eq 1 ]] && prune_indicator=" +prune"
+        log_info "Plan for ${AGAMEMNON_URL} (dry-run${prune_indicator} — no changes will be made)"
+        log_info "================================================================"
+        log_info ""
+    fi
+
+    for yaml_file in "${yaml_files[@]}"; do
+        plan_agent "$yaml_file" "$agents_json" || has_changes=1
+    done
+
+    if [[ "$OUTPUT_FORMAT" != "json" ]]; then
+        # Report unmanaged agents (in Agamemnon but not in YAML).
+        # When --fleet is active, scope the check to only agents that belong to the
+        # fleet so agents managed by other fleets are not flagged as unmanaged.
+        local scoped_agents_json
+        if [[ -n "$FLEET_NAME" ]]; then
+            local fleet_names_json
+            fleet_names_json="$(for f in "${yaml_files[@]}"; do yq eval '.metadata.name' "$f"; done | jq -Rsc 'split("\n") | map(select(length > 0))')"
+            scoped_agents_json="$(echo "$agents_json" | jq --argjson names "$fleet_names_json" '[.[] | select(.name as $n | $names | index($n) != null)]')"
+        else
+            scoped_agents_json="$agents_json"
+        fi
+        log_info ""
+        log_info "Checking for unmanaged agents..."
+        if [[ $PRUNE -eq 1 ]]; then
+            local PRUNE_COUNT=0
+            # Show which unmanaged agents would be pruned
+            while IFS= read -r unmanaged_name; do
+                log_warn "[-] PRUNE ${unmanaged_name} (unmanaged — would be hibernated and deleted)"
+                PRUNE_COUNT=$((PRUNE_COUNT + 1))
+                has_changes=1
+            done < <(get_unmanaged_names "$scoped_agents_json" "${yaml_files[@]}")
+        else
+            plan_report_unmanaged "$scoped_agents_json" "${yaml_files[@]}"
+        fi
+
+        log_info ""
+        if [[ $has_changes -eq 0 ]]; then
+            log_info "No changes needed. Desired state matches actual state."
+            exit 0
+        else
+            local summary="created=${CREATE_COUNT} updated=${UPDATE_COUNT} woken=${WAKE_COUNT} hibernated=${HIBERNATE_COUNT}"
+            [[ $PRUNE -eq 1 ]] && summary="${summary} pruned=${PRUNE_COUNT:-0}"
+            log_warn "Summary: ${summary}"
+            log_warn "Changes would be made. Run ./scripts/apply.sh to apply."
+            exit 1
+        fi
+    else
+        _emit_json_plan "$has_changes"
+        exit "$has_changes"
+    fi
+}
+
+# Emit the JSON plan report and exit
+_emit_json_plan() {
+    local has_changes="$1"
+
+    # Build planned_changes JSON array from NDJSON temp file
+    local changes_json="[]"
+    if [[ -s "$_PLAN_CHANGES_TMP" ]]; then
+        changes_json="$(jq -s '.' "$_PLAN_CHANGES_TMP")"
+    fi
+
+    local timestamp
+    timestamp="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+
+    jq -n \
+        --arg timestamp "$timestamp" \
+        --arg host "${HOST:-all}" \
+        --arg url "${AGAMEMNON_URL:-http://localhost:8080}" \
+        --argjson changes_needed "$has_changes" \
+        --argjson agents_checked "$((CREATE_COUNT + UPDATE_COUNT + WAKE_COUNT + HIBERNATE_COUNT + UNCHANGED_COUNT))" \
+        --argjson to_create "$CREATE_COUNT" \
+        --argjson to_update "$UPDATE_COUNT" \
+        --argjson to_wake "$WAKE_COUNT" \
+        --argjson to_hibernate "$HIBERNATE_COUNT" \
+        --argjson unchanged "$UNCHANGED_COUNT" \
+        --argjson planned_changes "$changes_json" \
+        '{
+            timestamp:     $timestamp,
+            host:          $host,
+            agamemnon_url: $url,
+            summary: {
+                agents_checked: $agents_checked,
+                changes_needed: ($changes_needed == 1),
+                to_create:      $to_create,
+                to_update:      $to_update,
+                to_wake:        $to_wake,
+                to_hibernate:   $to_hibernate,
+                unchanged:      $unchanged
+            },
+            planned_changes: $planned_changes
+        }'
+}
+
+plan_agent() {
+    local yaml_file="$1"
+    local agents_json="$2"
+
+    # Parse YAML fields
+    local fields
+    declare -A fields
+    while IFS='=' read -r key value; do
+        fields["$key"]="${value}"
+    done < <(parse_agent_yaml "$yaml_file")
+
+    local name="${fields[name]}"
+    local desired_state="${fields[desiredState]:-active}"
+    local label="${fields[label]:-}"
+    local program="${fields[program]:-}"
+    local workdir="${fields[workingDirectory]:-}"
+    local args="${fields[programArgs]:-}"
+    local desc="${fields[taskDescription]:-}"
+    local tags="${fields[tags]:-}"
+    local model="${fields[model]:-}"
+    local owner="${fields[owner]:-}"
+    local role="${fields[role]:-member}"
+    local deploy_type="${fields[deploymentType]:-local}"
+
+    # Look up in actual state
+    local actual_json
+    actual_json="$(echo "$agents_json" | jq -r --arg name "$name" \
+        '.[] | select(.name == $name)')"
+
+    if [[ -z "$actual_json" ]]; then
+        if [[ "$OUTPUT_FORMAT" != "json" ]]; then
+            log_info "[+] CREATE ${name} (program=${program}, deploy=${deploy_type})"
+            if [[ "$desired_state" == "active" ]]; then
+                log_info "    └─ WAKE after create"
+            fi
+        fi
+        _plan_record_change "$name" "CREATE" \
+            "program=${program} deploy=${deploy_type} desired_state=${desired_state}"
+        ((CREATE_COUNT++))
+        return 1
+    fi
+
+    local action
+    action="$(compute_drift "$name" "$desired_state" "$actual_json" \
+        "$label" "$program" "$workdir" "$args" "$desc" \
+        "$tags" "$model" "$owner" "$role" "$deploy_type")"
+
+    case "$action" in
+        UNCHANGED)
+            if [[ "$OUTPUT_FORMAT" != "json" ]]; then
+                log_info "[=] UNCHANGED ${name}"
+            fi
+            _plan_record_change "$name" "UNCHANGED" ""
+            ((UNCHANGED_COUNT++))
+            ;;
+        WAKE)
+            if [[ "$OUTPUT_FORMAT" != "json" ]]; then
+                log_warn "[!] WAKE ${name} (desired=active, actual=$(echo "$actual_json" | jq -r '.status'))"
+            fi
+            _plan_record_change "$name" "WAKE" \
+                "desired=active actual=$(echo "$actual_json" | jq -r '.status')"
+            ((WAKE_COUNT++))
+            return 1
+            ;;
+        HIBERNATE)
+            if [[ "$OUTPUT_FORMAT" != "json" ]]; then
+                log_warn "[z] HIBERNATE ${name} (desired=hibernated, actual=$(echo "$actual_json" | jq -r '.status'))"
+            fi
+            _plan_record_change "$name" "HIBERNATE" \
+                "desired=hibernated actual=$(echo "$actual_json" | jq -r '.status')"
+            ((HIBERNATE_COUNT++))
+            return 1
+            ;;
+        UPDATE:*)
+            local fields_changed="${action#UPDATE:}"
+            if [[ "$OUTPUT_FORMAT" != "json" ]]; then
+                log_warn "[~] UPDATE ${name}: ${fields_changed} differ"
+            fi
+            _plan_record_change "$name" "UPDATE" "fields=${fields_changed}"
+            ((UPDATE_COUNT++))
+            return 1
+            ;;
+    esac
+
+    return 0
+}
+
+main "$@"

--- a/tools/reconciler/scripts/rollback.sh
+++ b/tools/reconciler/scripts/rollback.sh
@@ -1,0 +1,316 @@
+#!/usr/bin/env bash
+# scripts/rollback.sh — Restore the most recent pre-apply snapshot
+#
+# Reads the latest snapshot from .myrmidons/snapshots/ and restores all agents
+# to their captured state via the Agamemnon API. Works even if YAML files have
+# been modified since the apply that created the snapshot.
+#
+# Usage:
+#   ./scripts/rollback.sh                      # Restore most recent snapshot
+#   ./scripts/rollback.sh --list               # List available snapshots
+#   ./scripts/rollback.sh --snapshot FILE      # Restore a specific snapshot
+#   ./scripts/rollback.sh --snapshot-dir DIR   # Override snapshot directory
+#
+# Safety:
+#   - Dry-run with --dry-run to preview what would change
+#   - Validates snapshot JSON before applying
+#   - Hibernates running agents before reconfiguring them
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# shellcheck source=scripts/lib/api.sh
+source "${SCRIPT_DIR}/lib/api.sh"
+# shellcheck source=scripts/lib/report.sh
+source "${SCRIPT_DIR}/lib/report.sh"
+
+SNAPSHOT_DIR="${REPO_ROOT}/.myrmidons/snapshots"
+SNAPSHOT_FILE=""
+LIST_ONLY=0
+DRY_RUN=0
+
+RESTORED=0
+CREATED=0
+ERRORS=0
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --list)            LIST_ONLY=1; shift ;;
+            --dry-run)         DRY_RUN=1; shift ;;
+            --snapshot)        SNAPSHOT_FILE="$2"; shift 2 ;;
+            --snapshot-dir)    SNAPSHOT_DIR="$2"; shift 2 ;;
+            -h|--help)         usage; exit 0 ;;
+            *) echo "ERROR: Unknown argument: $1" >&2; usage; exit 1 ;;
+        esac
+    done
+}
+
+usage() {
+    cat <<EOF
+Usage: $0 [--snapshot FILE] [--snapshot-dir DIR] [--list] [--dry-run]
+
+Restores agents to their state captured in the most recent pre-apply snapshot.
+
+Options:
+  --list              List available snapshots and exit
+  --snapshot FILE     Restore from a specific snapshot file (default: most recent)
+  --snapshot-dir DIR  Directory where snapshots are stored (default: .myrmidons/snapshots)
+  --dry-run           Show what would be restored without making changes
+  -h, --help          Show this help
+
+Examples:
+  $0                                          # Restore most recent snapshot
+  $0 --list                                   # List snapshots
+  $0 --snapshot .myrmidons/snapshots/2024-01-15T10:30:00.json
+EOF
+}
+
+list_snapshots() {
+    if [[ ! -d "$SNAPSHOT_DIR" ]]; then
+        echo "No snapshots directory found at: ${SNAPSHOT_DIR}"
+        return 0
+    fi
+
+    local snapshots=()
+    mapfile -t snapshots < <(find "$SNAPSHOT_DIR" -name "*.json" | sort -r)
+
+    if [[ ${#snapshots[@]} -eq 0 ]]; then
+        echo "No snapshots found in: ${SNAPSHOT_DIR}"
+        return 0
+    fi
+
+    echo "Available snapshots (newest first):"
+    echo ""
+    local i=0
+    for snap in "${snapshots[@]}"; do
+        local basename
+        basename="$(basename "$snap")"
+        local agent_count
+        # Support both new format {context:{}, agents:[]} and legacy plain array
+        agent_count="$(jq 'if type == "object" and has("agents") then .agents | length elif type == "array" then length else 0 end' "$snap" 2>/dev/null || echo "?")"
+        local marker=""
+        [[ $i -eq 0 ]] && marker=" ← most recent"
+        printf "  %s  (%s agents)%s\n" "$basename" "$agent_count" "$marker"
+        i=$((i + 1))
+    done
+}
+
+find_latest_snapshot() {
+    if [[ ! -d "$SNAPSHOT_DIR" ]]; then
+        echo "ERROR: No snapshots directory found at: ${SNAPSHOT_DIR}" >&2
+        echo "  Run 'just apply' first to create a snapshot." >&2
+        return 1
+    fi
+
+    local latest
+    latest="$(find "$SNAPSHOT_DIR" -name "*.json" | sort -r | head -1)"
+
+    if [[ -z "$latest" ]]; then
+        echo "ERROR: No snapshots found in: ${SNAPSHOT_DIR}" >&2
+        echo "  Run 'just apply' first to create a snapshot." >&2
+        return 1
+    fi
+
+    echo "$latest"
+}
+
+validate_snapshot() {
+    local snapshot_file="$1"
+
+    if [[ ! -f "$snapshot_file" ]]; then
+        echo "ERROR: Snapshot file not found: ${snapshot_file}" >&2
+        return 1
+    fi
+
+    # Accept both new format {context:{},agents:[]} and legacy plain array
+    if ! jq -e '(type == "array") or (type == "object" and has("agents") and (.agents | type == "array"))' \
+            "$snapshot_file" > /dev/null 2>&1; then
+        echo "ERROR: Snapshot is not a valid JSON array: ${snapshot_file}" >&2
+        return 1
+    fi
+}
+
+# Extract the agents array from a snapshot file.
+# Handles both new {context,agents} format and legacy plain-array format.
+# Usage: extract_snapshot_agents <snapshot_file>  → JSON array on stdout
+extract_snapshot_agents() {
+    local snapshot_file="$1"
+    jq 'if type == "object" and has("agents") then .agents else . end' "$snapshot_file"
+}
+
+restore_agent() {
+    local agent_json="$1"
+    local current_agents_json="$2"
+
+    local name label program workdir args desc status
+    name="$(echo "$agent_json" | jq -r '.name // empty')"
+    label="$(echo "$agent_json" | jq -r '.label // ""')"
+    program="$(echo "$agent_json" | jq -r '.program // "claude-code"')"
+    workdir="$(echo "$agent_json" | jq -r '.workingDirectory // ""')"
+    args="$(echo "$agent_json" | jq -r '.programArgs // ""')"
+    desc="$(echo "$agent_json" | jq -r '.taskDescription // ""')"
+    status="$(echo "$agent_json" | jq -r '.status // "offline"')"
+
+    if [[ -z "$name" ]]; then
+        echo "  WARNING: Skipping agent with no name" >&2
+        return 0
+    fi
+
+    local current_agent
+    current_agent="$(echo "$current_agents_json" | jq -r --arg n "$name" '.[] | select(.name == $n)')"
+    local current_id=""
+    [[ -n "$current_agent" ]] && current_id="$(echo "$current_agent" | jq -r '.id')"
+
+    if [[ "$DRY_RUN" -eq 1 ]]; then
+        if [[ -z "$current_id" ]]; then
+            echo "  [DRY-RUN] Would create: ${name}"
+        else
+            echo "  [DRY-RUN] Would restore: ${name} (status=${status})"
+        fi
+        return 0
+    fi
+
+    if [[ -z "$current_id" ]]; then
+        # Agent no longer exists — recreate it
+        echo "  [+] Recreating: ${name}..."
+        local create_body
+        create_body="$(echo "$agent_json" | jq '{
+            name: .name,
+            label: (.label // ""),
+            program: (.program // "claude-code"),
+            workingDirectory: (.workingDirectory // ""),
+            programArgs: (.programArgs // ""),
+            taskDescription: (.taskDescription // ""),
+            tags: (.tags // []),
+            owner: (.owner // ""),
+            role: (.role // "member")
+        }')"
+
+        local result
+        if result="$(agamemnon_create_agent "$create_body" 2>&1)"; then
+            current_id="$(echo "$result" | jq -r '.id // empty')"
+            echo "    Created: id=${current_id}"
+            CREATED=$((CREATED + 1))
+        else
+            echo "    ERROR recreating ${name}: ${result}" >&2
+            ERRORS=$((ERRORS + 1))
+            return 0
+        fi
+    else
+        # Agent exists — patch it back to snapshot state
+        echo "  [~] Restoring: ${name}..."
+        local patch_body
+        patch_body="$(jq -n \
+            --arg lbl "$label" \
+            --arg program "$program" \
+            --arg workingDirectory "$workdir" \
+            --arg programArgs "$args" \
+            --arg taskDescription "$desc" \
+            '{label: $lbl, program: $program, workingDirectory: $workingDirectory,
+              programArgs: $programArgs, taskDescription: $taskDescription}')"
+
+        if ! agamemnon_update_agent "$current_id" "$patch_body" > /dev/null 2>&1; then
+            echo "    ERROR updating ${name}" >&2
+            ERRORS=$((ERRORS + 1))
+            return 0
+        fi
+        echo "    Patched."
+        RESTORED=$((RESTORED + 1))
+    fi
+
+    # Restore run state
+    if [[ -n "$current_id" ]]; then
+        local desired_active=0
+        [[ "$status" == "active" || "$status" == "online" ]] && desired_active=1
+
+        if [[ $desired_active -eq 1 ]]; then
+            echo "    Starting ${name}..."
+            if ! agamemnon_wake_agent "$current_id" > /dev/null; then
+                echo "    warn: wake failed for ${name} (best-effort restore continues)" >&2
+            fi
+        else
+            echo "    Hibernating ${name}..."
+            if ! agamemnon_hibernate_agent "$current_id" > /dev/null; then
+                echo "    warn: hibernate failed for ${name} (best-effort restore continues)" >&2
+            fi
+        fi
+    fi
+}
+
+main() {
+    parse_args "$@"
+
+    if [[ $LIST_ONLY -eq 1 ]]; then
+        list_snapshots
+        exit 0
+    fi
+
+    # Resolve snapshot file
+    if [[ -z "$SNAPSHOT_FILE" ]]; then
+        SNAPSHOT_FILE="$(find_latest_snapshot)"
+    fi
+
+    validate_snapshot "$SNAPSHOT_FILE"
+
+    local snapshot_basename
+    snapshot_basename="$(basename "$SNAPSHOT_FILE")"
+
+    echo "Rollback from snapshot: ${snapshot_basename}"
+    echo "Snapshot dir: ${SNAPSHOT_DIR}"
+    if [[ $DRY_RUN -eq 1 ]]; then
+        echo "(DRY RUN — no changes will be made)"
+    fi
+    echo "================================================"
+    echo ""
+
+    local snapshot_agents
+    snapshot_agents="$(extract_snapshot_agents "$SNAPSHOT_FILE")"
+
+    local agent_count
+    agent_count="$(echo "$snapshot_agents" | jq 'length')"
+    echo "Snapshot contains ${agent_count} agents."
+    echo ""
+
+    if [[ $DRY_RUN -eq 0 ]]; then
+        agamemnon_check_connection
+    fi
+
+    local current_agents_json="{}"
+    if [[ $DRY_RUN -eq 0 ]]; then
+        current_agents_json="$(agamemnon_list_agents)"
+    fi
+
+    # (#225) Snapshot current state before restoring, to enable chained rollbacks.
+    if [[ $DRY_RUN -eq 0 ]]; then
+        local pre_rollback_snap
+        pre_rollback_snap="$(snapshot_write "$current_agents_json" "$SNAPSHOT_DIR" "all" "pre-rollback")"
+        echo "Pre-rollback snapshot saved: ${pre_rollback_snap}"
+        echo ""
+    fi
+
+    # Restore each agent from the snapshot
+    while IFS= read -r agent_json; do
+        restore_agent "$agent_json" "$current_agents_json"
+        # Refresh after each change
+        if [[ $DRY_RUN -eq 0 ]]; then
+            current_agents_json="$(agamemnon_list_agents)"
+        fi
+    done < <(echo "$snapshot_agents" | jq -c '.[]')
+
+    echo ""
+    echo "================================================"
+    if [[ $DRY_RUN -eq 1 ]]; then
+        echo "Dry run complete. No changes made."
+    else
+        echo "Summary: restored=${RESTORED} created=${CREATED} errors=${ERRORS}"
+    fi
+
+    if [[ $ERRORS -gt 0 ]]; then
+        exit 1
+    fi
+}
+
+main "$@"

--- a/tools/reconciler/scripts/status.sh
+++ b/tools/reconciler/scripts/status.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+# scripts/status.sh — Compare desired vs actual state
+#
+# Shows a formatted table of all managed agents with their desired state,
+# actual state, and whether there's any drift.
+#
+# Usage:
+#   ./scripts/status.sh                      # Status of all agents
+#   ./scripts/status.sh hermes               # Status of agents on a specific host
+#   ./scripts/status.sh --output json        # Machine-readable JSON drift report
+#   ./scripts/status.sh hermes --output json
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=scripts/lib/config.sh
+source "${SCRIPT_DIR}/lib/config.sh"
+# shellcheck source=scripts/lib/log.sh
+source "${SCRIPT_DIR}/lib/log.sh"
+# shellcheck source=scripts/lib/api.sh
+source "${SCRIPT_DIR}/lib/api.sh"
+# shellcheck source=scripts/lib/reconcile.sh
+source "${SCRIPT_DIR}/lib/reconcile.sh"
+# shellcheck source=scripts/lib/report.sh
+source "${SCRIPT_DIR}/lib/report.sh"
+
+load_config
+
+HOST=""
+OUTPUT_FORMAT="text"   # "text" | "json"
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --output) OUTPUT_FORMAT="$2"; shift 2 ;;
+            -h|--help) usage; exit 0 ;;
+            *) HOST="$1"; shift ;;
+        esac
+    done
+}
+
+usage() {
+    cat <<EOF
+Usage: $0 [host] [--output json]
+
+Shows desired vs actual state for all managed agents.
+
+Options:
+  host           Only show agents for this host (default: all)
+  --output json  Emit a JSON drift report to stdout
+  -h, --help     Show this help
+
+Environment:
+  AGAMEMNON_URL            Agamemnon base URL (default: http://localhost:8080)
+  AGAMEMNON_API_KEY        Bearer token for Agamemnon API authentication
+  MYRMIDONS_DEFAULT_OWNER  Fallback owner used when the API returns no owner
+
+Examples:
+  $0                         # Human-readable table
+  $0 hermes                  # Filter to hermes host
+  $0 --output json | jq .    # Machine-readable drift report
+EOF
+}
+
+main() {
+    parse_args "$@"
+
+    # Validate AGAMEMNON_URL format early (#118)
+    validate_agamemnon_url
+
+    check_deps
+    agamemnon_check_connection
+
+    report_init "${HOST:-all}"
+    trap report_cleanup EXIT
+
+    local agents_json
+    agents_json="$(agamemnon_list_agents)"
+
+    # Precompute a name→status lookup map once (fixes O(N) jq calls for unmanaged agents, #114)
+    local status_map
+    status_map="$(echo "$agents_json" | jq 'map({key: .name, value: (.status // "unknown")}) | from_entries')"
+
+    local yaml_files
+    mapfile -t yaml_files < <(get_agent_files "$HOST")
+
+    if [[ "$OUTPUT_FORMAT" != "json" ]]; then
+        # Header
+        printf "%-22s %-10s %-12s %-12s %s\n" "AGENT" "HOST" "DESIRED" "ACTUAL" "DRIFT"
+        printf "%-22s %-10s %-12s %-12s %s\n" "-----" "----" "-------" "------" "-----"
+    fi
+
+    for yaml_file in "${yaml_files[@]}"; do
+        status_agent "$yaml_file" "$agents_json"
+    done
+
+    # Unmanaged agents
+    report_unmanaged "$agents_json" "$status_map" "${yaml_files[@]}"
+
+    if [[ "$OUTPUT_FORMAT" == "json" ]]; then
+        # Produce a drift-focused report (no action counters for status)
+        report_emit 0 0 0 0 0 0 0
+    fi
+}
+
+status_agent() {
+    local yaml_file="$1"
+    local agents_json="$2"
+
+    local name host desired_state label program workdir args desc tags model owner role deploy_type
+    name="$(yq eval '.metadata.name' "$yaml_file")"
+    host="$(yq eval '.metadata.host // "hermes"' "$yaml_file")"
+    desired_state="$(yq eval '.spec.desiredState // "active"' "$yaml_file")"
+    label="$(yq eval '.spec.label // ""' "$yaml_file")"
+    program="$(yq eval '.spec.program // ""' "$yaml_file")"
+    workdir="$(yq eval '.spec.workingDirectory // ""' "$yaml_file")"
+    args="$(yq eval '.spec.programArgs // ""' "$yaml_file")"
+    desc="$(yq eval '.spec.taskDescription // ""' "$yaml_file")"
+    tags="$(yq eval '.spec.tags // [] | join(",")' "$yaml_file")"
+    model="$(yq eval '.spec.model // ""' "$yaml_file")"
+    owner="$(yq eval '.spec.owner // ""' "$yaml_file")"
+    role="$(yq eval '.spec.role // "member"' "$yaml_file")"
+    deploy_type="$(yq eval '.spec.deployment.type // "local"' "$yaml_file")"
+
+    local actual_json
+    actual_json="$(echo "$agents_json" | jq -r --arg n "$name" '.[] | select(.name == $n)')"
+
+    if [[ -z "$actual_json" ]]; then
+        if [[ "${LOG_FORMAT:-text}" == "json" ]]; then
+            jq -n --arg name "$name" --arg host "$host" \
+                --arg desired "$desired_state" --arg actual "MISSING" --arg drift "NEEDS CREATE" \
+                '{agent:$name,host:$host,desired:$desired,actual:$actual,drift:$drift}'
+        elif [[ "$OUTPUT_FORMAT" != "json" ]]; then
+            printf "%-22s %-10s %-12s %-12s %s\n" \
+                "${name:0:21}" "${host:0:9}" "$desired_state" "MISSING" "NEEDS CREATE"
+        fi
+        report_add_agent "$name" "$host" "CREATE" "$desired_state" "MISSING" "[]" ""
+        return
+    fi
+
+    local actual_status
+    actual_status="$(echo "$actual_json" | jq -r '.status // "unknown"')"
+
+    local drift
+    drift="$(compute_drift "$name" "$desired_state" "$actual_json" \
+        "$label" "$program" "$workdir" "$args" "$desc" "$tags" "$model" "$owner" "$role" "$deploy_type")"
+
+    local drift_json="[]"
+    if [[ "$drift" == UPDATE:* ]]; then
+        drift_json="$(build_drift_json "$drift" "$actual_json" \
+            "$label" "$program" "$workdir" "$args" "$desc" "$tags" "$owner" "$role")"
+    fi
+
+    local action
+    case "$drift" in
+        UNCHANGED)  action="UNCHANGED" ;;
+        WAKE)       action="WAKE" ;;
+        HIBERNATE)  action="HIBERNATE" ;;
+        UPDATE:*)   action="UPDATE" ;;
+        *)          action="$drift" ;;
+    esac
+
+    report_add_agent "$name" "$host" "$action" "$desired_state" "$actual_status" "$drift_json" ""
+
+    if [[ "${LOG_FORMAT:-text}" == "json" ]]; then
+        local drift_display
+        case "$drift" in
+            UNCHANGED) drift_display="ok" ;;
+            WAKE)      drift_display="NEEDS WAKE" ;;
+            HIBERNATE) drift_display="NEEDS HIBERNATE" ;;
+            UPDATE:*)  drift_display="drifted: ${drift#UPDATE:}" ;;
+            *)         drift_display="$drift" ;;
+        esac
+        jq -n --arg name "$name" --arg host "$host" \
+            --arg desired "$desired_state" --arg actual "$actual_status" --arg drift "$drift_display" \
+            '{agent:$name,host:$host,desired:$desired,actual:$actual,drift:$drift}'
+    elif [[ "$OUTPUT_FORMAT" != "json" ]]; then
+        local drift_display
+        case "$drift" in
+            UNCHANGED)
+                drift_display="ok"
+                ;;
+            WAKE)
+                drift_display="NEEDS WAKE"
+                ;;
+            HIBERNATE)
+                drift_display="NEEDS HIBERNATE"
+                ;;
+            UPDATE:*)
+                drift_display="drifted: ${drift#UPDATE:}"
+                ;;
+            *)
+                drift_display="$drift"
+                ;;
+        esac
+
+        printf "%-22s %-10s %-12s %-12s %s\n" \
+            "${name:0:21}" "${host:0:9}" "$desired_state" "$actual_status" "$drift_display"
+    fi
+}
+
+report_unmanaged() {
+    local agents_json="$1"
+    local status_map="$2"
+    shift 2
+
+    while IFS= read -r actual_name; do
+        # Use precomputed map for O(1) status lookup instead of a per-agent jq call (#114)
+        local actual_status
+        actual_status="$(echo "$status_map" | jq -r --arg n "$actual_name" '.[$n] // "unknown"')"
+
+        report_add_unmanaged "$actual_name"
+
+        if [[ "${LOG_FORMAT:-text}" == "json" ]]; then
+            jq -n --arg name "$actual_name" --arg actual "$actual_status" \
+                '{agent:$name,host:"-",desired:"-",actual:$actual,drift:"UNMANAGED"}'
+        elif [[ "$OUTPUT_FORMAT" != "json" ]]; then
+            printf "%-22s %-10s %-12s %-12s %s\n" \
+                "${actual_name:0:21}" "-" "-" "$actual_status" "UNMANAGED"
+        fi
+    done < <(get_unmanaged_names "$agents_json" "$@")
+}
+
+main "$@"

--- a/tools/reconciler/tests/fixtures/agent-docker.yaml
+++ b/tools/reconciler/tests/fixtures/agent-docker.yaml
@@ -1,0 +1,16 @@
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: docker-agent
+  host: hermes
+spec:
+  label: Docker Agent
+  program: claude-code
+  workingDirectory: /workspace
+  deployment:
+    type: docker
+    docker:
+      image: my-claude:latest
+      cpus: "2"
+      memory: "4g"
+  desiredState: active

--- a/tools/reconciler/tests/fixtures/agent-hibernated.yaml
+++ b/tools/reconciler/tests/fixtures/agent-hibernated.yaml
@@ -1,0 +1,18 @@
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: sleeping-agent
+  host: hermes
+spec:
+  label: Sleeping Agent
+  program: aider
+  model: gpt-4o
+  workingDirectory: /home/mvillmow/SleepProject
+  programArgs: ""
+  taskDescription: "A hibernated agent"
+  tags: [hibernated]
+  owner: mvillmow
+  role: member
+  deployment:
+    type: local
+  desiredState: hibernated

--- a/tools/reconciler/tests/fixtures/agent-minimal.yaml
+++ b/tools/reconciler/tests/fixtures/agent-minimal.yaml
@@ -1,0 +1,10 @@
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: minimal-agent
+  host: hermes
+spec:
+  program: claude-code
+  workingDirectory: /tmp/minimal
+  deployment:
+    type: local

--- a/tools/reconciler/tests/fixtures/agent-no-tags.yaml
+++ b/tools/reconciler/tests/fixtures/agent-no-tags.yaml
@@ -1,0 +1,16 @@
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: notags-agent
+  host: hermes
+spec:
+  label: No Tags Agent
+  program: claude-code
+  workingDirectory: /home/mvillmow/NoTags
+  programArgs: ""
+  taskDescription: "Agent with no tags"
+  owner: mvillmow
+  role: member
+  deployment:
+    type: local
+  desiredState: active

--- a/tools/reconciler/tests/fixtures/agent-valid.yaml
+++ b/tools/reconciler/tests/fixtures/agent-valid.yaml
@@ -1,0 +1,18 @@
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: test-agent
+  host: hermes
+spec:
+  label: Test Agent
+  program: claude-code
+  model: null
+  workingDirectory: /home/mvillmow/TestProject
+  programArgs: "--verbose"
+  taskDescription: "A test agent for unit tests"
+  tags: [testing, ci]
+  owner: mvillmow
+  role: member
+  deployment:
+    type: local
+  desiredState: active

--- a/tools/reconciler/tests/fixtures/agents/hermes/duplicate-name-a.yaml
+++ b/tools/reconciler/tests/fixtures/agents/hermes/duplicate-name-a.yaml
@@ -1,0 +1,18 @@
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: test-duplicate-name
+  host: hermes
+spec:
+  label: Duplicate-Name-A
+  program: claude-code
+  model: null
+  workingDirectory: /tmp
+  programArgs: ""
+  taskDescription: "First agent with duplicate name"
+  tags: [test]
+  owner: mvillmow
+  role: member
+  deployment:
+    type: local
+  desiredState: active

--- a/tools/reconciler/tests/fixtures/agents/hermes/duplicate-name-b.yaml
+++ b/tools/reconciler/tests/fixtures/agents/hermes/duplicate-name-b.yaml
@@ -1,0 +1,18 @@
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: test-duplicate-name
+  host: hermes
+spec:
+  label: Duplicate-Name-B
+  program: aider
+  model: null
+  workingDirectory: /tmp
+  programArgs: ""
+  taskDescription: "Second agent with duplicate name"
+  tags: [test]
+  owner: mvillmow
+  role: member
+  deployment:
+    type: local
+  desiredState: active

--- a/tools/reconciler/tests/fixtures/agents/hermes/invalid-docker-no-image.yaml
+++ b/tools/reconciler/tests/fixtures/agents/hermes/invalid-docker-no-image.yaml
@@ -1,0 +1,18 @@
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: test-docker-no-image
+  host: hermes
+spec:
+  label: Invalid-Docker-No-Image
+  program: claude-code
+  model: null
+  workingDirectory: /tmp
+  programArgs: ""
+  taskDescription: "Docker agent missing image field"
+  tags: [test]
+  owner: mvillmow
+  role: member
+  deployment:
+    type: docker
+  desiredState: active

--- a/tools/reconciler/tests/fixtures/agents/hermes/invalid-label-mismatch.yaml
+++ b/tools/reconciler/tests/fixtures/agents/hermes/invalid-label-mismatch.yaml
@@ -1,0 +1,18 @@
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: test-label-mismatch
+  host: hermes
+spec:
+  label: WrongLabelName
+  program: claude-code
+  model: null
+  workingDirectory: /tmp
+  programArgs: ""
+  taskDescription: "Agent where filename stem does not match lowercase(spec.label)"
+  tags: [test]
+  owner: mvillmow
+  role: member
+  deployment:
+    type: local
+  desiredState: active

--- a/tools/reconciler/tests/fixtures/agents/hermes/invalid-program.yaml
+++ b/tools/reconciler/tests/fixtures/agents/hermes/invalid-program.yaml
@@ -1,0 +1,18 @@
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: test-invalid-program
+  host: hermes
+spec:
+  label: Invalid-Program
+  program: badvalue
+  model: null
+  workingDirectory: /tmp
+  programArgs: ""
+  taskDescription: "Agent with invalid program value"
+  tags: [test]
+  owner: mvillmow
+  role: member
+  deployment:
+    type: local
+  desiredState: active

--- a/tools/reconciler/tests/fixtures/agents/hermes/valid-agent.yaml
+++ b/tools/reconciler/tests/fixtures/agents/hermes/valid-agent.yaml
@@ -1,0 +1,18 @@
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: test-valid-agent
+  host: hermes
+spec:
+  label: Valid-Agent
+  program: claude-code
+  model: null
+  workingDirectory: /tmp
+  programArgs: ""
+  taskDescription: "A valid agent for testing"
+  tags: [test]
+  owner: mvillmow
+  role: member
+  deployment:
+    type: local
+  desiredState: active

--- a/tools/reconciler/tests/fixtures/agents/hermes/valid-docker-agent.yaml
+++ b/tools/reconciler/tests/fixtures/agents/hermes/valid-docker-agent.yaml
@@ -1,0 +1,22 @@
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: test-valid-docker-agent
+  host: hermes
+spec:
+  label: Valid-Docker-Agent
+  program: claude-code
+  model: null
+  workingDirectory: /tmp
+  programArgs: ""
+  taskDescription: "A valid docker agent for testing"
+  tags: [test]
+  owner: mvillmow
+  role: member
+  deployment:
+    type: docker
+    docker:
+      image: achaean-claude:latest
+      cpus: 2
+      memory: 4g
+  desiredState: active

--- a/tools/reconciler/tests/fixtures/agents/wrongdir/invalid-host-mismatch.yaml
+++ b/tools/reconciler/tests/fixtures/agents/wrongdir/invalid-host-mismatch.yaml
@@ -1,0 +1,18 @@
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: test-host-mismatch
+  host: hermes
+spec:
+  label: Invalid-Host-Mismatch
+  program: claude-code
+  model: null
+  workingDirectory: /tmp
+  programArgs: ""
+  taskDescription: "Agent where host does not match directory"
+  tags: [test]
+  owner: mvillmow
+  role: member
+  deployment:
+    type: local
+  desiredState: active

--- a/tools/reconciler/tests/fixtures/convergence-routes-create-once.json
+++ b/tools/reconciler/tests/fixtures/convergence-routes-create-once.json
@@ -1,0 +1,55 @@
+{
+  "routes": [
+    {
+      "method": "GET",
+      "path": "/v1/agents",
+      "status": 200,
+      "body": [],
+      "once": true
+    },
+    {
+      "method": "POST",
+      "path": "/v1/agents",
+      "status": 201,
+      "body": {
+        "id": "cid2",
+        "name": "convergence-agent",
+        "status": "offline",
+        "label": "Convergence Agent",
+        "program": "claude-code",
+        "workingDirectory": "/tmp/conv",
+        "programArgs": "",
+        "taskDescription": "convergence integration test",
+        "tags": [],
+        "owner": "ci",
+        "role": "member"
+      }
+    },
+    {
+      "method": "POST",
+      "path": "/v1/agents/*/start",
+      "status": 200,
+      "body": {
+        "id": "cid2",
+        "name": "convergence-agent",
+        "status": "active"
+      }
+    }
+  ],
+  "default_status": 200,
+  "default_body": [
+    {
+      "id": "cid2",
+      "name": "convergence-agent",
+      "status": "active",
+      "label": "Convergence Agent",
+      "program": "claude-code",
+      "workingDirectory": "/tmp/conv",
+      "programArgs": "",
+      "taskDescription": "convergence integration test",
+      "tags": [],
+      "owner": "ci",
+      "role": "member"
+    }
+  ]
+}

--- a/tools/reconciler/tests/fixtures/convergence-routes-fail.json
+++ b/tools/reconciler/tests/fixtures/convergence-routes-fail.json
@@ -1,0 +1,40 @@
+{
+  "routes": [
+    {
+      "method": "POST",
+      "path": "/api/v1/agents",
+      "status": 201,
+      "body": {
+        "id": "cid1",
+        "name": "convergence-agent",
+        "status": "offline"
+      }
+    },
+    {
+      "method": "PATCH",
+      "path": "/api/v1/agents/*",
+      "status": 200,
+      "body": {
+        "id": "cid1",
+        "name": "convergence-agent",
+        "status": "offline"
+      }
+    }
+  ],
+  "default_status": 200,
+  "default_body": [
+    {
+      "id": "cid1",
+      "name": "convergence-agent",
+      "status": "offline",
+      "label": "Convergence Agent",
+      "program": "claude-code",
+      "workingDirectory": "/tmp/conv",
+      "programArgs": "",
+      "taskDescription": "convergence integration test",
+      "tags": [],
+      "owner": "ci",
+      "role": "member"
+    }
+  ]
+}

--- a/tools/reconciler/tests/fixtures/convergence-routes-json-fail.json
+++ b/tools/reconciler/tests/fixtures/convergence-routes-json-fail.json
@@ -1,0 +1,40 @@
+{
+  "routes": [
+    {
+      "method": "POST",
+      "path": "/api/v1/agents",
+      "status": 201,
+      "body": {
+        "id": "cid1",
+        "name": "convergence-agent",
+        "status": "offline"
+      }
+    },
+    {
+      "method": "PATCH",
+      "path": "/api/v1/agents/*",
+      "status": 200,
+      "body": {
+        "id": "cid1",
+        "name": "convergence-agent",
+        "status": "offline"
+      }
+    }
+  ],
+  "default_status": 200,
+  "default_body": [
+    {
+      "id": "cid1",
+      "name": "convergence-agent",
+      "status": "offline",
+      "label": "Convergence Agent",
+      "program": "claude-code",
+      "workingDirectory": "/tmp/conv",
+      "programArgs": "",
+      "taskDescription": "convergence integration test",
+      "tags": [],
+      "owner": "ci",
+      "role": "member"
+    }
+  ]
+}

--- a/tools/reconciler/tests/fixtures/convergence-routes-json-ok.json
+++ b/tools/reconciler/tests/fixtures/convergence-routes-json-ok.json
@@ -1,0 +1,31 @@
+{
+  "routes": [
+    {
+      "method": "PATCH",
+      "path": "/api/v1/agents/*",
+      "status": 200,
+      "body": {
+        "id": "cid1",
+        "name": "convergence-agent",
+        "status": "active",
+        "label": "Convergence Agent"
+      }
+    }
+  ],
+  "default_status": 200,
+  "default_body": [
+    {
+      "id": "cid1",
+      "name": "convergence-agent",
+      "status": "active",
+      "label": "OldLabel",
+      "program": "claude-code",
+      "workingDirectory": "/tmp/conv",
+      "programArgs": "",
+      "taskDescription": "convergence integration test",
+      "tags": [],
+      "owner": "ci",
+      "role": "member"
+    }
+  ]
+}

--- a/tools/reconciler/tests/fixtures/convergence-routes-ok.json
+++ b/tools/reconciler/tests/fixtures/convergence-routes-ok.json
@@ -1,0 +1,31 @@
+{
+  "routes": [
+    {
+      "method": "PATCH",
+      "path": "/api/v1/agents/*",
+      "status": 200,
+      "body": {
+        "id": "cid1",
+        "name": "convergence-agent",
+        "status": "active",
+        "label": "Convergence Agent"
+      }
+    }
+  ],
+  "default_status": 200,
+  "default_body": [
+    {
+      "id": "cid1",
+      "name": "convergence-agent",
+      "status": "active",
+      "label": "OldLabel",
+      "program": "claude-code",
+      "workingDirectory": "/tmp/conv",
+      "programArgs": "",
+      "taskDescription": "convergence integration test",
+      "tags": [],
+      "owner": "ci",
+      "role": "member"
+    }
+  ]
+}

--- a/tools/reconciler/tests/fixtures/convergence-routes-prune-absent.json
+++ b/tools/reconciler/tests/fixtures/convergence-routes-prune-absent.json
@@ -1,0 +1,37 @@
+{
+  "routes": [
+    {
+      "method": "PATCH",
+      "path": "/api/v1/agents/*",
+      "status": 200,
+      "body": {
+        "id": "cid1",
+        "name": "convergence-agent",
+        "status": "active",
+        "label": "Convergence Agent"
+      }
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/v1/agents/*",
+      "status": 200,
+      "body": {}
+    }
+  ],
+  "default_status": 200,
+  "default_body": [
+    {
+      "id": "cid1",
+      "name": "convergence-agent",
+      "status": "active",
+      "label": "OldLabel",
+      "program": "claude-code",
+      "workingDirectory": "/tmp/conv",
+      "programArgs": "",
+      "taskDescription": "convergence integration test",
+      "tags": [],
+      "owner": "ci",
+      "role": "member"
+    }
+  ]
+}

--- a/tools/reconciler/tests/fixtures/convergence-routes-prune-stuck.json
+++ b/tools/reconciler/tests/fixtures/convergence-routes-prune-stuck.json
@@ -1,0 +1,50 @@
+{
+  "routes": [
+    {
+      "method": "PATCH",
+      "path": "/api/v1/agents/*",
+      "status": 200,
+      "body": {
+        "id": "cid1",
+        "name": "convergence-agent",
+        "status": "active",
+        "label": "Convergence Agent"
+      }
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/v1/agents/*",
+      "status": 200,
+      "body": {}
+    }
+  ],
+  "default_status": 200,
+  "default_body": [
+    {
+      "id": "cid1",
+      "name": "convergence-agent",
+      "status": "active",
+      "label": "OldLabel",
+      "program": "claude-code",
+      "workingDirectory": "/tmp/conv",
+      "programArgs": "",
+      "taskDescription": "convergence integration test",
+      "tags": [],
+      "owner": "ci",
+      "role": "member"
+    },
+    {
+      "id": "cid2",
+      "name": "stray-agent",
+      "status": "offline",
+      "label": "Stray Agent",
+      "program": "claude-code",
+      "workingDirectory": "/tmp/stray",
+      "programArgs": "",
+      "taskDescription": "unmanaged stray agent",
+      "tags": [],
+      "owner": "ci",
+      "role": "member"
+    }
+  ]
+}

--- a/tools/reconciler/tests/fixtures/convergence-routes-prune.json
+++ b/tools/reconciler/tests/fixtures/convergence-routes-prune.json
@@ -1,0 +1,45 @@
+{
+  "routes": [
+    {
+      "method": "PATCH",
+      "path": "/api/v1/agents/*",
+      "status": 200,
+      "body": { "id": "uid1", "name": "unmanaged-prune-agent", "status": "offline" }
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/v1/agents/*",
+      "status": 200,
+      "body": {}
+    }
+  ],
+  "default_status": 200,
+  "default_body": [
+    {
+      "id": "cid1",
+      "name": "convergence-agent",
+      "status": "active",
+      "label": "Convergence Agent",
+      "program": "claude-code",
+      "workingDirectory": "/tmp/conv",
+      "programArgs": "",
+      "taskDescription": "convergence integration test",
+      "tags": [],
+      "owner": "ci",
+      "role": "member"
+    },
+    {
+      "id": "uid1",
+      "name": "unmanaged-prune-agent",
+      "status": "active",
+      "label": "Unmanaged Prune Agent",
+      "program": "claude-code",
+      "workingDirectory": "/tmp/unmanaged",
+      "programArgs": "",
+      "taskDescription": "unmanaged agent that should be pruned",
+      "tags": [],
+      "owner": "ci",
+      "role": "member"
+    }
+  ]
+}

--- a/tools/reconciler/tests/fixtures/convergence-routes-wake-once.json
+++ b/tools/reconciler/tests/fixtures/convergence-routes-wake-once.json
@@ -1,0 +1,52 @@
+{
+  "routes": [
+    {
+      "method": "GET",
+      "path": "/v1/agents",
+      "status": 200,
+      "body": [
+        {
+          "id": "cid1",
+          "name": "convergence-agent",
+          "status": "offline",
+          "label": "Convergence Agent",
+          "program": "claude-code",
+          "workingDirectory": "/tmp/conv",
+          "programArgs": "",
+          "taskDescription": "convergence integration test",
+          "tags": [],
+          "owner": "ci",
+          "role": "member"
+        }
+      ],
+      "once": true
+    },
+    {
+      "method": "PATCH",
+      "path": "/v1/agents/*",
+      "status": 200,
+      "body": {
+        "id": "cid1",
+        "name": "convergence-agent",
+        "status": "active",
+        "label": "Convergence Agent"
+      }
+    }
+  ],
+  "default_status": 200,
+  "default_body": [
+    {
+      "id": "cid1",
+      "name": "convergence-agent",
+      "status": "active",
+      "label": "Convergence Agent",
+      "program": "claude-code",
+      "workingDirectory": "/tmp/conv",
+      "programArgs": "",
+      "taskDescription": "convergence integration test",
+      "tags": [],
+      "owner": "ci",
+      "role": "member"
+    }
+  ]
+}

--- a/tools/reconciler/tests/fixtures/prune-convergence-fail.json
+++ b/tools/reconciler/tests/fixtures/prune-convergence-fail.json
@@ -1,0 +1,39 @@
+{
+  "routes": [
+    {
+      "method": "DELETE",
+      "path": "/v1/agents/*",
+      "status": 200,
+      "body": {}
+    }
+  ],
+  "default_status": 200,
+  "default_body": [
+    {
+      "id": "mid1",
+      "name": "managed-agent",
+      "status": "active",
+      "label": "Managed Agent",
+      "program": "claude-code",
+      "workingDirectory": "/tmp/managed",
+      "programArgs": "",
+      "taskDescription": "managed agent for prune convergence test",
+      "tags": [],
+      "owner": "ci",
+      "role": "member"
+    },
+    {
+      "id": "uid1",
+      "name": "unmanaged-agent",
+      "status": "active",
+      "label": "Unmanaged Agent",
+      "program": "claude-code",
+      "workingDirectory": "/tmp/unmanaged",
+      "programArgs": "",
+      "taskDescription": "unmanaged prune convergence test",
+      "tags": [],
+      "owner": "ci",
+      "role": "member"
+    }
+  ]
+}

--- a/tools/reconciler/tests/fixtures/prune-convergence-ok.json
+++ b/tools/reconciler/tests/fixtures/prune-convergence-ok.json
@@ -1,0 +1,94 @@
+{
+  "routes": [
+    {
+      "method": "GET",
+      "path": "/v1/agents",
+      "status": 200,
+      "body": [
+        {
+          "id": "mid1",
+          "name": "managed-agent",
+          "status": "active",
+          "label": "Managed Agent",
+          "program": "claude-code",
+          "workingDirectory": "/tmp/managed",
+          "programArgs": "",
+          "taskDescription": "managed agent for prune convergence test",
+          "tags": [],
+          "owner": "ci",
+          "role": "member"
+        },
+        {
+          "id": "uid1",
+          "name": "unmanaged-agent",
+          "status": "active",
+          "label": "Unmanaged Agent",
+          "program": "claude-code",
+          "workingDirectory": "/tmp/unmanaged",
+          "programArgs": "",
+          "taskDescription": "unmanaged prune convergence test",
+          "tags": [],
+          "owner": "ci",
+          "role": "member"
+        }
+      ],
+      "once": true
+    },
+    {
+      "method": "GET",
+      "path": "/v1/agents",
+      "status": 200,
+      "body": [
+        {
+          "id": "mid1",
+          "name": "managed-agent",
+          "status": "active",
+          "label": "Managed Agent",
+          "program": "claude-code",
+          "workingDirectory": "/tmp/managed",
+          "programArgs": "",
+          "taskDescription": "managed agent for prune convergence test",
+          "tags": [],
+          "owner": "ci",
+          "role": "member"
+        },
+        {
+          "id": "uid1",
+          "name": "unmanaged-agent",
+          "status": "active",
+          "label": "Unmanaged Agent",
+          "program": "claude-code",
+          "workingDirectory": "/tmp/unmanaged",
+          "programArgs": "",
+          "taskDescription": "unmanaged prune convergence test",
+          "tags": [],
+          "owner": "ci",
+          "role": "member"
+        }
+      ],
+      "once": true
+    },
+    {
+      "method": "DELETE",
+      "path": "/v1/agents/*",
+      "status": 200,
+      "body": {}
+    }
+  ],
+  "default_status": 200,
+  "default_body": [
+    {
+      "id": "mid1",
+      "name": "managed-agent",
+      "status": "active",
+      "label": "Managed Agent",
+      "program": "claude-code",
+      "workingDirectory": "/tmp/managed",
+      "programArgs": "",
+      "taskDescription": "managed agent for prune convergence test",
+      "tags": [],
+      "owner": "ci",
+      "role": "member"
+    }
+  ]
+}

--- a/tools/reconciler/tests/helpers/mock_server.py
+++ b/tools/reconciler/tests/helpers/mock_server.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""
+Minimal mock HTTP server for Myrmidons test suite.
+
+Reads response configuration from:
+  1. Optional routes config file (--routes flag or second CLI arg):
+       JSON array: [{"method": "GET", "path": "/api/v1/agents", "status": 200, "body": {...}}, ...]
+       JSON object: {"routes": [...], "default_status": 200, "default_body": {}}
+     Routes are matched in order; first match wins.
+     Paths support a trailing wildcard segment: "/api/v1/agents/*" matches
+     "/api/v1/agents/foo" and "/api/v1/agents/abc123".
+
+     One-shot routes ("once": true):
+       Add "once": true to a route to consume it after its first match.
+       Lifecycle:
+         - On the first request that matches the route's method+path, the
+           server returns the route's status/body AND removes the route
+           from the in-memory routes list.
+         - Subsequent requests with the same method+path no longer see
+           that route; they fall through to the next matching route (in
+           definition order) or to default_status/default_body.
+         - One-shot consumption is per-process and is NOT reset on its
+           own — it only resets when the server is restarted (which
+           reloads the routes config from disk).
+       Use case: stateful request sequencing across multiple calls to
+       the same endpoint — e.g. the first GET returns a populated list
+       and subsequent GETs return an empty list, simulating a resource
+       that is drained after being read.
+       Example routes config:
+         [
+           {"method": "GET", "path": "/api/v1/agents",
+            "status": 200, "body": [{"id": "a1"}], "once": true},
+           {"method": "GET", "path": "/api/v1/agents",
+            "status": 200, "body": []}
+         ]
+       The first GET /api/v1/agents returns [{"id": "a1"}]; every later
+       GET /api/v1/agents returns [].
+  2. Environment variables (fallback):
+     MOCK_STATUS  — HTTP status code to return (default: 200)
+     MOCK_BODY    — Response body JSON string (default: {})
+
+Usage:
+  MOCK_STATUS=200 MOCK_BODY='[...]' python3 mock_server.py <PORT>
+  python3 mock_server.py <PORT> --routes <routes_config.json>
+  python3 mock_server.py <PORT> <routes_config.json>   # legacy positional form
+"""
+import fnmatch
+import os
+import sys
+import json
+from http.server import HTTPServer, BaseHTTPRequestHandler
+
+STATUS = int(os.environ.get("MOCK_STATUS", "200"))
+BODY = os.environ.get("MOCK_BODY", "{}")
+ROUTES_CONFIG = None
+
+
+def _load_routes(config_path):
+    """Load and normalise a routes config file.
+
+    Accepts two formats:
+    - Flat array: [{"method": ..., "path": ..., "status": ..., "body": ...}, ...]
+    - Object: {"routes": [...], "default_status": ..., "default_body": ...}
+
+    Returns a dict with "routes", optional "default_status", optional "default_body".
+    """
+    try:
+        with open(config_path, "r") as f:
+            raw = json.load(f)
+    except FileNotFoundError:
+        print(f"Error loading routes config: file not found: {config_path}", file=sys.stderr)
+        sys.exit(1)
+    except json.JSONDecodeError as e:
+        print(f"Error loading routes config: invalid JSON: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    if isinstance(raw, list):
+        return {"routes": raw}
+    if isinstance(raw, dict):
+        return raw
+    print("Error loading routes config: expected a JSON array or object", file=sys.stderr)
+    sys.exit(1)
+
+
+def _parse_args():
+    """Return (port, routes_config_path_or_None)."""
+    args = sys.argv[1:]
+    port = 18080
+    routes_path = None
+
+    i = 0
+    positional = []
+    while i < len(args):
+        if args[i] == "--routes":
+            if i + 1 >= len(args):
+                print("Error: --routes requires a file path argument", file=sys.stderr)
+                sys.exit(1)
+            routes_path = args[i + 1]
+            i += 2
+        else:
+            positional.append(args[i])
+            i += 1
+
+    if positional:
+        try:
+            port = int(positional[0])
+        except ValueError:
+            print(f"Error: invalid port number: {positional[0]}", file=sys.stderr)
+            sys.exit(1)
+        # Legacy form: second positional arg is the routes config file
+        if len(positional) > 1 and routes_path is None:
+            routes_path = positional[1]
+
+    return port, routes_path
+
+
+def _path_matches(pattern, path):
+    """Return True if *path* matches *pattern*.
+
+    Supports a single trailing wildcard segment:
+      /api/v1/agents/*  matches  /api/v1/agents/foo
+    Exact matches are checked first.
+    """
+    if pattern == path:
+        return True
+    # Use fnmatch for simple glob-style wildcard support
+    return fnmatch.fnmatch(path, pattern)
+
+
+# ---------------------------------------------------------------------------
+# Parse arguments and load optional routes config
+# ---------------------------------------------------------------------------
+
+_port, _routes_path = _parse_args()
+if _routes_path is not None:
+    ROUTES_CONFIG = _load_routes(_routes_path)
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, fmt, *args):
+        pass  # suppress request logging
+
+    def do_GET(self):
+        self._respond("GET")
+
+    def do_POST(self):
+        self._respond("POST")
+
+    def do_PATCH(self):
+        self._respond("PATCH")
+
+    def do_DELETE(self):
+        self._respond("DELETE")
+
+    def _respond(self, method):
+        status, body = self._get_response(method)
+        # body may be a dict/list (from JSON routes config) — serialise it
+        if not isinstance(body, str):
+            body = json.dumps(body)
+        encoded = body.encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(encoded)))
+        self.end_headers()
+        self.wfile.write(encoded)
+
+    def _get_response(self, method):
+        """Get response status and body for the given method and path.
+
+        If routes config is available, match by method+path (wildcard-aware).
+        Routes with ``"once": true`` are consumed (removed) after the first
+        match and subsequent requests fall through to the next route or the
+        default_body, enabling stateful request sequencing (e.g. first GET
+        returns data, subsequent GETs return empty list).
+        Otherwise fall back to env vars.
+        """
+        if ROUTES_CONFIG is None:
+            return STATUS, BODY
+
+        routes = ROUTES_CONFIG.get("routes", [])
+        # Try to find a matching route (first match wins)
+        for i, route in enumerate(routes):
+            route_method = route.get("method", "").upper()
+            route_path = route.get("path", "")
+            if route_method == method and _path_matches(route_path, self.path):
+                status = route.get("status", 200)
+                body = route.get("body", "{}")
+                if route.get("once", False):
+                    routes.pop(i)
+                return status, body
+
+        # Fall back to default_status/default_body from config, or env vars
+        default_status = ROUTES_CONFIG.get("default_status", STATUS)
+        default_body = ROUTES_CONFIG.get("default_body", BODY)
+        return default_status, default_body
+
+
+if __name__ == "__main__":
+    httpd = HTTPServer(("127.0.0.1", _port), Handler)
+    httpd.serve_forever()

--- a/tools/reconciler/tests/integration/test_apply_prune_convergence.bats
+++ b/tools/reconciler/tests/integration/test_apply_prune_convergence.bats
@@ -1,0 +1,143 @@
+#!/usr/bin/env bats
+# tests/integration/test_apply_prune_convergence.bats
+#
+# Integration tests for the --prune path through verify_convergence (#409).
+#
+# These tests invoke apply.sh --prune end-to-end against a mock Agamemnon server
+# using a routes config file. The mock API returns an "unmanaged-agent" that is
+# NOT present in any YAML under the test host directory, so handle_unmanaged()
+# prunes it and _PRUNED_NAMES gets populated.
+#
+# Routes design for "fail" scenario (prune-convergence-fail.json):
+#   - All GET /api/v1/agents → unmanaged-agent still present (stateless default)
+#   - DELETE /api/v1/agents/* → 200
+#
+#   The convergence re-fetch still sees the agent → verify_convergence fails →
+#   apply.sh exits 1.
+#
+# Routes design for "ok" scenario (prune-convergence-ok.json):
+#   - First GET /api/v1/agents → unmanaged-agent in list (once: true route)
+#   - DELETE /api/v1/agents/* → 200
+#   - All subsequent GETs → [] (default_body is empty list)
+#
+#   handle_unmanaged() sees the agent on the initial list and prunes it.
+#   verify_convergence re-fetches and gets [] → agent gone → exits 0.
+#
+# Covers issue #409 (missing integration test for _PRUNED_NAMES convergence path).
+
+# shellcheck source=scripts/lib/api.sh
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+FIXTURES_DIR="${SCRIPT_DIR}/tests/fixtures"
+HELPERS_DIR="${SCRIPT_DIR}/tests/helpers"
+APPLY_SH="${SCRIPT_DIR}/scripts/apply.sh"
+MOCK_PORT=18090
+MOCK_PID_FILE="/tmp/bats-prune-convergence-mock-$$.pid"
+
+# ---------------------------------------------------------------------------
+# Mock server helpers
+# ---------------------------------------------------------------------------
+
+_start_mock_server_routes() {
+    local routes_file="$1"
+    python3 "${HELPERS_DIR}/mock_server.py" "$MOCK_PORT" --routes "$routes_file" \
+        > /dev/null 2>&1 &
+    echo $! > "$MOCK_PID_FILE"
+    sleep 0.3
+}
+
+_stop_mock_server() {
+    if [[ -f "$MOCK_PID_FILE" ]]; then
+        kill "$(cat "$MOCK_PID_FILE")" 2>/dev/null || true
+        rm -f "$MOCK_PID_FILE"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Setup / teardown
+# ---------------------------------------------------------------------------
+
+_PRUNE_TEST_HOST=""
+_PRUNE_SNAPSHOT_DIR=""
+_PRUNE_LOCK_FILE=""
+
+_setup_test_agent() {
+    _PRUNE_TEST_HOST="prunetest-$$-${RANDOM}"
+    mkdir -p "${SCRIPT_DIR}/agents/${_PRUNE_TEST_HOST}"
+    # Create a managed agent YAML — its name differs from "unmanaged-agent" so
+    # handle_unmanaged() will flag "unmanaged-agent" as unmanaged and prune it.
+    printf 'apiVersion: myrmidons/v1\nkind: Agent\nmetadata:\n  name: managed-agent\n  host: %s\nspec:\n  label: Managed Agent\n  program: claude-code\n  model: null\n  workingDirectory: /tmp/managed\n  programArgs: ""\n  taskDescription: "managed agent for prune convergence test"\n  tags: []\n  owner: ci\n  role: member\n  deployment:\n    type: local\n  desiredState: active\n' \
+        "$_PRUNE_TEST_HOST" \
+        > "${SCRIPT_DIR}/agents/${_PRUNE_TEST_HOST}/managed-agent.yaml"
+}
+
+_cleanup_test_agent() {
+    if [[ -n "${_PRUNE_TEST_HOST:-}" ]]; then
+        rm -rf "${SCRIPT_DIR}/agents/${_PRUNE_TEST_HOST}"
+        _PRUNE_TEST_HOST=""
+    fi
+}
+
+setup() {
+    export AGAMEMNON_URL="http://127.0.0.1:${MOCK_PORT}"
+    export NO_COLOR=1
+    export HIBERNATE_SETTLE_SECONDS=0
+    _PRUNE_SNAPSHOT_DIR="$(mktemp -d)"
+    _PRUNE_LOCK_FILE="$(mktemp -u /tmp/bats-prune-lock-$$.XXXXXX)"
+    export AIM_LOCK_FILE="$_PRUNE_LOCK_FILE"
+    _setup_test_agent
+}
+
+teardown() {
+    _stop_mock_server
+    _cleanup_test_agent
+    rm -rf "${_PRUNE_SNAPSHOT_DIR:-}"
+    rm -f "${_PRUNE_LOCK_FILE:-}"
+    unset NO_COLOR HIBERNATE_SETTLE_SECONDS AIM_LOCK_FILE
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: exit code 1 when pruned agent is still returned by the API
+#
+# Routes design (prune-convergence-fail.json):
+#   All GET /api/v1/agents  → unmanaged-agent present (default_body)
+#   DELETE /api/v1/agents/* → 200
+#
+# handle_unmanaged() prunes "unmanaged-agent"; verify_convergence re-fetches
+# and still sees it in the list → reports convergence failure → apply exits 1.
+# ---------------------------------------------------------------------------
+
+@test "apply --prune: exit code 1 when pruned agent still returned by API after deletion" {
+    _start_mock_server_routes "${FIXTURES_DIR}/prune-convergence-fail.json"
+
+    run bash "$APPLY_SH" "$_PRUNE_TEST_HOST" --prune --yes \
+        --snapshot-dir "$_PRUNE_SNAPSHOT_DIR" 2>&1 || true
+
+    [[ "$status" -eq 1 ]]
+    [[ "$output" == *"[-] Pruning unmanaged: unmanaged-agent"* ]]
+    [[ "$output" == *"pruned but still present in API (convergence failed)"* ]]
+    [[ "$output" == *"Convergence:"*"failed"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 2: exit code 0 when pruned agent is no longer returned by the API
+#
+# Routes design (prune-convergence-ok.json):
+#   First GET /api/v1/agents → unmanaged-agent present (once: true route)
+#   DELETE /api/v1/agents/* → 200
+#   Subsequent GETs         → [] (default_body)
+#
+# handle_unmanaged() sees the agent on the initial list and prunes it.
+# verify_convergence re-fetches, gets [] → agent is gone → exits 0.
+# ---------------------------------------------------------------------------
+
+@test "apply --prune: exit code 0 when pruned agent no longer returned by API" {
+    _start_mock_server_routes "${FIXTURES_DIR}/prune-convergence-ok.json"
+
+    run bash "$APPLY_SH" "$_PRUNE_TEST_HOST" --prune --yes \
+        --snapshot-dir "$_PRUNE_SNAPSHOT_DIR" 2>&1
+
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"[-] Pruning unmanaged: unmanaged-agent"* ]]
+    [[ "$output" != *"pruned but still present in API"* ]]
+}

--- a/tools/reconciler/tests/integration/test_apply_rollback_roundtrip.bats
+++ b/tools/reconciler/tests/integration/test_apply_rollback_roundtrip.bats
@@ -1,0 +1,243 @@
+#!/usr/bin/env bats
+# tests/integration/test_apply_rollback_roundtrip.bats
+#
+# Integration test: full apply -> rollback round-trip (#227)
+#
+# Mocks the Agamemnon API, runs apply.sh to snapshot + reconcile, then
+# runs rollback.sh and verifies the pre-rollback snapshot is created and
+# the restore is attempted.
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+HELPERS_DIR="${SCRIPT_DIR}/tests/helpers"
+MOCK_PORT=18082
+MOCK_PID_FILE="/tmp/bats-roundtrip-mock-$$.pid"
+
+# ---------------------------------------------------------------------------
+# Mock server helpers
+# ---------------------------------------------------------------------------
+
+_start_mock_server() {
+    local http_status="${1:-200}"
+    local body="${2}"
+    [[ -z "$body" ]] && body='[]'
+
+    MOCK_STATUS="$http_status" MOCK_BODY="$body" \
+        python3 "${HELPERS_DIR}/mock_server.py" "$MOCK_PORT" \
+        > /dev/null 2>&1 &
+    echo $! > "$MOCK_PID_FILE"
+    sleep 0.3
+}
+
+_stop_mock_server() {
+    if [[ -f "$MOCK_PID_FILE" ]]; then
+        kill "$(cat "$MOCK_PID_FILE")" 2>/dev/null || true
+        rm -f "$MOCK_PID_FILE"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Setup / teardown
+# ---------------------------------------------------------------------------
+
+setup() {
+    export AGAMEMNON_URL="http://127.0.0.1:${MOCK_PORT}"
+
+    # Isolated temp workspace for this test run
+    TEST_WORKSPACE="$(mktemp -d)"
+    export TEST_WORKSPACE
+
+    # Create minimal agents directory with one agent YAML
+    mkdir -p "${TEST_WORKSPACE}/agents/hermes"
+    printf 'apiVersion: myrmidons/v1\nkind: Agent\nmetadata:\n  name: roundtrip-agent\n  host: hermes\nspec:\n  label: RoundTrip Agent\n  program: claude-code\n  model: null\n  workingDirectory: /tmp/roundtrip\n  programArgs: ""\n  taskDescription: "Integration test agent"\n  tags: [integration, test]\n  owner: testuser\n  role: member\n  deployment:\n    type: local\n  desiredState: active\n' \
+        > "${TEST_WORKSPACE}/agents/hermes/roundtrip-agent.yaml"
+
+    SNAPSHOT_DIR="${TEST_WORKSPACE}/.myrmidons/snapshots"
+    export SNAPSHOT_DIR
+}
+
+teardown() {
+    _stop_mock_server
+    rm -rf "${TEST_WORKSPACE:-}"
+}
+
+# ---------------------------------------------------------------------------
+# Helper: count files matching a pattern in SNAPSHOT_DIR
+# ---------------------------------------------------------------------------
+
+_count_snapshots() {
+    local pattern="${1:-*.json}"
+    find "$SNAPSHOT_DIR" -maxdepth 1 -name "$pattern" 2>/dev/null | wc -l
+}
+
+# ---------------------------------------------------------------------------
+# Test: apply creates a pre-apply snapshot with context fields (#228)
+# ---------------------------------------------------------------------------
+
+@test "apply: creates snapshot with context fields (user, git_branch, host, timestamp)" {
+    # Mock: health check OK, list returns empty (no existing agents)
+    _start_mock_server 200 '[]'
+
+    # Run apply.sh, pointing snapshot-dir to our isolated workspace
+    run bash "${SCRIPT_DIR}/scripts/apply.sh" \
+        --snapshot-dir "$SNAPSHOT_DIR" \
+        2>&1 || true
+
+    # A snapshot file must have been written
+    local snap_count
+    snap_count="$(_count_snapshots '*.json')"
+    [[ "$snap_count" -ge 1 ]]
+
+    # Find the snapshot and verify context fields
+    local snap_file
+    snap_file="$(find "$SNAPSHOT_DIR" -maxdepth 1 -name '*.json' | head -1)"
+    [[ -f "$snap_file" ]]
+
+    local snap_json
+    snap_json="$(cat "$snap_file")"
+
+    # Must have a context object
+    echo "$snap_json" | jq -e '.context' > /dev/null
+
+    # context.user must be non-empty
+    local ctx_user
+    ctx_user="$(echo "$snap_json" | jq -r '.context.user')"
+    [[ -n "$ctx_user" && "$ctx_user" != "null" ]]
+
+    # context.git_branch must be non-empty
+    local ctx_branch
+    ctx_branch="$(echo "$snap_json" | jq -r '.context.git_branch')"
+    [[ -n "$ctx_branch" && "$ctx_branch" != "null" ]]
+
+    # context.timestamp must match ISO-8601 pattern
+    local ctx_ts
+    ctx_ts="$(echo "$snap_json" | jq -r '.context.timestamp')"
+    [[ "$ctx_ts" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]
+
+    # context.host field must be present
+    echo "$snap_json" | jq -e '.context.host' > /dev/null
+
+    # agents array must be present
+    echo "$snap_json" | jq -e '.agents | type == "array"' > /dev/null
+}
+
+# ---------------------------------------------------------------------------
+# Test: apply -> rollback round-trip (#227)
+# Apply runs, writes a snapshot. Rollback reads it, writes pre-rollback
+# snapshot, and attempts to restore.
+# ---------------------------------------------------------------------------
+
+@test "round-trip: apply creates snapshot, rollback creates pre-rollback snapshot" {
+    # Mock: health OK, list returns one agent already existing
+    local existing_agent
+    existing_agent='[{"id":"existing-id","name":"roundtrip-agent","status":"active","label":"RoundTrip Agent","program":"claude-code","workingDirectory":"/tmp/roundtrip","programArgs":"","taskDescription":"Integration test agent","tags":["integration","test"],"owner":"testuser","role":"member"}]'
+    _start_mock_server 200 "$existing_agent"
+
+    # Step 1: run apply.sh -- should write a pre-apply snapshot
+    run bash "${SCRIPT_DIR}/scripts/apply.sh" \
+        --snapshot-dir "$SNAPSHOT_DIR" \
+        2>&1 || true
+
+    # Verify at least one snapshot was created
+    local snap_count_before
+    snap_count_before="$(_count_snapshots '*.json')"
+    [[ "$snap_count_before" -ge 1 ]]
+
+    _stop_mock_server
+
+    # Step 2: restart mock so rollback can call agamemnon_check_connection and list
+    _start_mock_server 200 "$existing_agent"
+
+    # Step 3: run rollback.sh pointing at our snapshot dir.
+    # It should: (a) find the snapshot, (b) list current agents, (c) write pre-rollback snapshot
+    run bash "${SCRIPT_DIR}/scripts/rollback.sh" \
+        --snapshot-dir "$SNAPSHOT_DIR" \
+        2>&1 || true
+
+    # A pre-rollback snapshot must now exist (filename contains "pre-rollback")
+    local pre_rollback_count
+    pre_rollback_count="$(_count_snapshots '*.pre-rollback.json')"
+    [[ "$pre_rollback_count" -ge 1 ]]
+
+    # The rollback output must mention the pre-rollback snapshot
+    [[ "$output" == *"pre-rollback"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test: rollback --dry-run does NOT write a pre-rollback snapshot (#225)
+# ---------------------------------------------------------------------------
+
+@test "rollback --dry-run: does not write pre-rollback snapshot" {
+    # Create a minimal snapshot manually so rollback has something to read
+    mkdir -p "$SNAPSHOT_DIR"
+    local ts
+    ts="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+    jq -n \
+        --arg ts "$ts" \
+        '{context:{timestamp:$ts,user:"ci",git_branch:"main",host:"all"},agents:[{"id":"a1","name":"roundtrip-agent","status":"active"}]}' \
+        > "${SNAPSHOT_DIR}/${ts}.json"
+
+    run bash "${SCRIPT_DIR}/scripts/rollback.sh" \
+        --snapshot-dir "$SNAPSHOT_DIR" \
+        --dry-run \
+        2>&1
+
+    # No pre-rollback snapshot should have been written during dry-run
+    local pre_rollback_count
+    pre_rollback_count="$(_count_snapshots '*.pre-rollback.json')"
+    [[ "$pre_rollback_count" -eq 0 ]]
+
+    # Output should contain DRY-RUN or Dry run marker
+    [[ "$output" == *"DRY-RUN"* || "$output" == *"Dry run"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test: rollback can restore from a snapshot written by apply (#227 full cycle)
+# ---------------------------------------------------------------------------
+
+@test "round-trip: rollback reads apply snapshot and attempts restore of each agent" {
+    # Write a snapshot that looks like it came from apply
+    mkdir -p "$SNAPSHOT_DIR"
+    local ts
+    ts="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+    jq -n \
+        --arg ts "$ts" \
+        '{
+            context: {timestamp:$ts, user:"testuser", git_branch:"main", host:"hermes"},
+            agents: [{
+                id: "agent-id-1",
+                name: "roundtrip-agent",
+                status: "active",
+                label: "RoundTrip Agent",
+                program: "claude-code",
+                workingDirectory: "/tmp/roundtrip",
+                programArgs: "",
+                taskDescription: "Integration test agent",
+                tags: ["integration","test"],
+                owner: "testuser",
+                role: "member"
+            }]
+        }' > "${SNAPSHOT_DIR}/${ts}.json"
+
+    # Mock: current live state (agent exists, will be patched during restore)
+    local live_agents
+    live_agents='[{"id":"agent-id-1","name":"roundtrip-agent","status":"active","label":"RoundTrip Agent","program":"claude-code","workingDirectory":"/tmp/roundtrip","programArgs":"","taskDescription":"Integration test agent","tags":["integration","test"],"owner":"testuser","role":"member"}]'
+    _start_mock_server 200 "$live_agents"
+
+    run bash "${SCRIPT_DIR}/scripts/rollback.sh" \
+        --snapshot-dir "$SNAPSHOT_DIR" \
+        2>&1 || true
+
+    # Rollback must mention the agent being processed
+    [[ "$output" == *"roundtrip-agent"* ]]
+
+    # A pre-rollback snapshot must have been created
+    local pre_rollback_count
+    pre_rollback_count="$(_count_snapshots '*.pre-rollback.json')"
+    [[ "$pre_rollback_count" -ge 1 ]]
+
+    # Verify the pre-rollback snapshot is valid JSON with context
+    local pre_snap
+    pre_snap="$(find "$SNAPSHOT_DIR" -maxdepth 1 -name '*.pre-rollback.json' | head -1)"
+    jq -e '.context' "$pre_snap" > /dev/null
+    jq -e '.agents | type == "array"' "$pre_snap" > /dev/null
+}

--- a/tools/reconciler/tests/integration/test_diff.bats
+++ b/tools/reconciler/tests/integration/test_diff.bats
@@ -1,0 +1,466 @@
+#!/usr/bin/env bats
+# tests/integration/test_diff.bats
+#
+# Shell-level tests for scripts/diff.sh against a mock Agamemnon server.
+# Verifies output format, exit codes, and correct drift detection.
+#
+# Covers issue #199.
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+FIXTURES_DIR="${SCRIPT_DIR}/tests/fixtures"
+HELPERS_DIR="${SCRIPT_DIR}/tests/helpers"
+DIFF_SH="${SCRIPT_DIR}/scripts/diff.sh"
+MOCK_PORT=18084
+MOCK_PID_FILE="/tmp/bats-diff-mock-$$.pid"
+
+# ---------------------------------------------------------------------------
+# Mock server helpers
+# ---------------------------------------------------------------------------
+
+_start_mock_server() {
+    local http_status="${1:-200}"
+    local body="${2}"
+    [[ -z "$body" ]] && body='[]'
+
+    MOCK_STATUS="$http_status" MOCK_BODY="$body" \
+        python3 "${HELPERS_DIR}/mock_server.py" "$MOCK_PORT" \
+        > /dev/null 2>&1 &
+    echo $! > "$MOCK_PID_FILE"
+    sleep 0.3
+}
+
+_stop_mock_server() {
+    if [[ -f "$MOCK_PID_FILE" ]]; then
+        kill "$(cat "$MOCK_PID_FILE")" 2>/dev/null || true
+        rm -f "$MOCK_PID_FILE"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Setup: create a unique temp host directory under the real agents/ tree
+# so diff.sh's BASH_SOURCE-based repo root discovery finds the YAML files.
+# ---------------------------------------------------------------------------
+
+_DIFF_TEST_HOST=""
+
+_setup_test_agent() {
+    local agent_yaml="$1"
+    _DIFF_TEST_HOST="difftest-$$-${RANDOM}"
+    mkdir -p "${SCRIPT_DIR}/agents/${_DIFF_TEST_HOST}"
+    cp "$agent_yaml" "${SCRIPT_DIR}/agents/${_DIFF_TEST_HOST}/"
+}
+
+_cleanup_test_agent() {
+    if [[ -n "${_DIFF_TEST_HOST:-}" ]]; then
+        rm -rf "${SCRIPT_DIR}/agents/${_DIFF_TEST_HOST}"
+        _DIFF_TEST_HOST=""
+    fi
+}
+
+setup() {
+    export AGAMEMNON_URL="http://127.0.0.1:${MOCK_PORT}"
+    # Disable ANSI colors so output comparisons work reliably
+    export NO_COLOR=1
+}
+
+teardown() {
+    _stop_mock_server
+    _cleanup_test_agent
+    unset NO_COLOR
+}
+
+# ---------------------------------------------------------------------------
+# Helper: place a YAML fixture in a temp host dir and run diff.sh
+# ---------------------------------------------------------------------------
+
+_run_diff() {
+    local agent_yaml="$1"
+    shift  # remaining args forwarded to diff.sh
+
+    _setup_test_agent "$agent_yaml"
+    run bash "$DIFF_SH" "$_DIFF_TEST_HOST" "$@"
+    _cleanup_test_agent
+}
+
+# ---------------------------------------------------------------------------
+# Exit codes
+# ---------------------------------------------------------------------------
+
+@test "diff.sh: exits 0 when agent matches Agamemnon exactly (no drift)" {
+    local mock_body
+    mock_body='[{
+        "id": "abc-123",
+        "name": "test-agent",
+        "status": "active",
+        "label": "Test Agent",
+        "program": "claude-code",
+        "workingDirectory": "/home/mvillmow/TestProject",
+        "programArgs": "--verbose",
+        "taskDescription": "A test agent for unit tests",
+        "tags": ["ci", "testing"],
+        "owner": "mvillmow",
+        "role": "member"
+    }]'
+    _start_mock_server 200 "$mock_body"
+
+    _run_diff "${FIXTURES_DIR}/agent-valid.yaml"
+
+    [[ "$status" -eq 0 ]]
+}
+
+@test "diff.sh: exits 1 when agent is absent from Agamemnon (CREATE drift)" {
+    _start_mock_server 200 '[]'
+
+    _run_diff "${FIXTURES_DIR}/agent-valid.yaml"
+
+    [[ "$status" -eq 1 ]]
+}
+
+@test "diff.sh: exits 1 when label has drifted" {
+    local mock_body
+    mock_body='[{
+        "id": "abc-123",
+        "name": "test-agent",
+        "status": "active",
+        "label": "Old Label",
+        "program": "claude-code",
+        "workingDirectory": "/home/mvillmow/TestProject",
+        "programArgs": "--verbose",
+        "taskDescription": "A test agent for unit tests",
+        "tags": ["ci", "testing"],
+        "owner": "mvillmow",
+        "role": "member"
+    }]'
+    _start_mock_server 200 "$mock_body"
+
+    _run_diff "${FIXTURES_DIR}/agent-valid.yaml"
+
+    [[ "$status" -eq 1 ]]
+}
+
+@test "diff.sh: exits 1 when agent needs WAKE (offline but desired active)" {
+    local mock_body
+    mock_body='[{
+        "id": "abc-123",
+        "name": "test-agent",
+        "status": "offline",
+        "label": "Test Agent",
+        "program": "claude-code",
+        "workingDirectory": "/home/mvillmow/TestProject",
+        "programArgs": "--verbose",
+        "taskDescription": "A test agent for unit tests",
+        "tags": ["ci", "testing"],
+        "owner": "mvillmow",
+        "role": "member"
+    }]'
+    _start_mock_server 200 "$mock_body"
+
+    _run_diff "${FIXTURES_DIR}/agent-valid.yaml"
+
+    [[ "$status" -eq 1 ]]
+}
+
+@test "diff.sh: exits 1 when agent needs HIBERNATE (active but desired hibernated)" {
+    local mock_body
+    mock_body='[{
+        "id": "abc-456",
+        "name": "sleeping-agent",
+        "status": "active",
+        "label": "Sleeping Agent",
+        "program": "aider",
+        "workingDirectory": "/home/mvillmow/SleepProject",
+        "programArgs": "",
+        "taskDescription": "A hibernated agent",
+        "tags": ["hibernated"],
+        "owner": "mvillmow",
+        "role": "member"
+    }]'
+    _start_mock_server 200 "$mock_body"
+
+    _run_diff "${FIXTURES_DIR}/agent-hibernated.yaml"
+
+    [[ "$status" -eq 1 ]]
+}
+
+# ---------------------------------------------------------------------------
+# Output format: no-drift case
+# ---------------------------------------------------------------------------
+
+@test "diff.sh: prints 'No drift detected' message when no drift" {
+    local mock_body
+    mock_body='[{
+        "id": "abc-123",
+        "name": "test-agent",
+        "status": "active",
+        "label": "Test Agent",
+        "program": "claude-code",
+        "workingDirectory": "/home/mvillmow/TestProject",
+        "programArgs": "--verbose",
+        "taskDescription": "A test agent for unit tests",
+        "tags": ["ci", "testing"],
+        "owner": "mvillmow",
+        "role": "member"
+    }]'
+    _start_mock_server 200 "$mock_body"
+
+    _run_diff "${FIXTURES_DIR}/agent-valid.yaml"
+
+    [[ "$output" == *"No drift detected"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Output format: drift cases
+# ---------------------------------------------------------------------------
+
+@test "diff.sh: includes agent name in output when CREATE drift detected" {
+    _start_mock_server 200 '[]'
+
+    _run_diff "${FIXTURES_DIR}/agent-valid.yaml"
+
+    [[ "$output" == *"test-agent"* ]]
+}
+
+@test "diff.sh: shows [+] marker when agent would be created" {
+    _start_mock_server 200 '[]'
+
+    _run_diff "${FIXTURES_DIR}/agent-valid.yaml"
+
+    [[ "$output" == *"[+]"* ]]
+}
+
+@test "diff.sh: shows [!] marker when agent needs WAKE" {
+    local mock_body
+    mock_body='[{
+        "id": "abc-123",
+        "name": "test-agent",
+        "status": "offline",
+        "label": "Test Agent",
+        "program": "claude-code",
+        "workingDirectory": "/home/mvillmow/TestProject",
+        "programArgs": "--verbose",
+        "taskDescription": "A test agent for unit tests",
+        "tags": ["ci", "testing"],
+        "owner": "mvillmow",
+        "role": "member"
+    }]'
+    _start_mock_server 200 "$mock_body"
+
+    _run_diff "${FIXTURES_DIR}/agent-valid.yaml"
+
+    [[ "$output" == *"[!]"* ]]
+}
+
+@test "diff.sh: shows [z] marker when agent needs HIBERNATE" {
+    local mock_body
+    mock_body='[{
+        "id": "abc-456",
+        "name": "sleeping-agent",
+        "status": "active",
+        "label": "Sleeping Agent",
+        "program": "aider",
+        "workingDirectory": "/home/mvillmow/SleepProject",
+        "programArgs": "",
+        "taskDescription": "A hibernated agent",
+        "tags": ["hibernated"],
+        "owner": "mvillmow",
+        "role": "member"
+    }]'
+    _start_mock_server 200 "$mock_body"
+
+    _run_diff "${FIXTURES_DIR}/agent-hibernated.yaml"
+
+    [[ "$output" == *"[z]"* ]]
+}
+
+@test "diff.sh: shows [~] marker when scalar field has drifted" {
+    local mock_body
+    mock_body='[{
+        "id": "abc-123",
+        "name": "test-agent",
+        "status": "active",
+        "label": "Stale Label",
+        "program": "claude-code",
+        "workingDirectory": "/home/mvillmow/TestProject",
+        "programArgs": "--verbose",
+        "taskDescription": "A test agent for unit tests",
+        "tags": ["ci", "testing"],
+        "owner": "mvillmow",
+        "role": "member"
+    }]'
+    _start_mock_server 200 "$mock_body"
+
+    _run_diff "${FIXTURES_DIR}/agent-valid.yaml"
+
+    [[ "$output" == *"[~]"* ]]
+}
+
+@test "diff.sh: shows drifted field name in output for label drift" {
+    local mock_body
+    mock_body='[{
+        "id": "abc-123",
+        "name": "test-agent",
+        "status": "active",
+        "label": "Stale Label",
+        "program": "claude-code",
+        "workingDirectory": "/home/mvillmow/TestProject",
+        "programArgs": "--verbose",
+        "taskDescription": "A test agent for unit tests",
+        "tags": ["ci", "testing"],
+        "owner": "mvillmow",
+        "role": "member"
+    }]'
+    _start_mock_server 200 "$mock_body"
+
+    _run_diff "${FIXTURES_DIR}/agent-valid.yaml"
+
+    [[ "$output" == *"label"* ]]
+}
+
+@test "diff.sh: shows old and new values in output for label drift" {
+    local mock_body
+    mock_body='[{
+        "id": "abc-123",
+        "name": "test-agent",
+        "status": "active",
+        "label": "Stale Label",
+        "program": "claude-code",
+        "workingDirectory": "/home/mvillmow/TestProject",
+        "programArgs": "--verbose",
+        "taskDescription": "A test agent for unit tests",
+        "tags": ["ci", "testing"],
+        "owner": "mvillmow",
+        "role": "member"
+    }]'
+    _start_mock_server 200 "$mock_body"
+
+    _run_diff "${FIXTURES_DIR}/agent-valid.yaml"
+
+    # Should show old value and new value (arrow format: old → new)
+    [[ "$output" == *"Stale Label"* ]]
+    [[ "$output" == *"Test Agent"* ]]
+}
+
+@test "diff.sh: shows tag changes when tags have drifted" {
+    local mock_body
+    mock_body='[{
+        "id": "abc-123",
+        "name": "test-agent",
+        "status": "active",
+        "label": "Test Agent",
+        "program": "claude-code",
+        "workingDirectory": "/home/mvillmow/TestProject",
+        "programArgs": "--verbose",
+        "taskDescription": "A test agent for unit tests",
+        "tags": ["old-tag"],
+        "owner": "mvillmow",
+        "role": "member"
+    }]'
+    _start_mock_server 200 "$mock_body"
+
+    _run_diff "${FIXTURES_DIR}/agent-valid.yaml"
+
+    [[ "$status" -eq 1 ]]
+    [[ "$output" == *"tags"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing: --agent filter
+# ---------------------------------------------------------------------------
+
+@test "diff.sh: --agent filter limits output to named agent" {
+    # Two agents in Agamemnon; only the matching one should appear
+    local mock_body
+    mock_body='[{
+        "id": "abc-123",
+        "name": "test-agent",
+        "status": "offline",
+        "label": "Test Agent",
+        "program": "claude-code",
+        "workingDirectory": "/home/mvillmow/TestProject",
+        "programArgs": "--verbose",
+        "taskDescription": "A test agent for unit tests",
+        "tags": ["ci", "testing"],
+        "owner": "mvillmow",
+        "role": "member"
+    }]'
+    _start_mock_server 200 "$mock_body"
+
+    _run_diff "${FIXTURES_DIR}/agent-valid.yaml" --agent test-agent
+
+    [[ "$output" == *"test-agent"* ]]
+}
+
+@test "diff.sh: --agent filter with non-matching name produces no drift output" {
+    local mock_body
+    mock_body='[{
+        "id": "abc-123",
+        "name": "test-agent",
+        "status": "offline",
+        "label": "Test Agent",
+        "program": "claude-code",
+        "workingDirectory": "/home/mvillmow/TestProject",
+        "programArgs": "--verbose",
+        "taskDescription": "A test agent for unit tests",
+        "tags": ["ci", "testing"],
+        "owner": "mvillmow",
+        "role": "member"
+    }]'
+    _start_mock_server 200 "$mock_body"
+
+    _run_diff "${FIXTURES_DIR}/agent-valid.yaml" --agent nonexistent-agent
+
+    # No drift because the filter excludes the drifting agent
+    [[ "$status" -eq 0 ]]
+}
+
+# ---------------------------------------------------------------------------
+# API connection handling
+# ---------------------------------------------------------------------------
+
+@test "diff.sh: fails gracefully when Agamemnon is unreachable" {
+    # Don't start mock server → connection refused
+    export AGAMEMNON_URL="http://127.0.0.1:19999"
+
+    _setup_test_agent "${FIXTURES_DIR}/agent-valid.yaml"
+    run bash "$DIFF_SH" "$_DIFF_TEST_HOST"
+    _cleanup_test_agent
+
+    [[ "$status" -ne 0 ]]
+}
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+@test "diff.sh: minimal agent YAML produces valid diff output" {
+    _start_mock_server 200 '[]'
+
+    _run_diff "${FIXTURES_DIR}/agent-minimal.yaml"
+
+    # agent-minimal.yaml has name=minimal-agent; should show as [+] CREATE
+    [[ "$output" == *"[+]"* ]]
+    [[ "$output" == *"minimal-agent"* ]]
+}
+
+@test "diff.sh: program drift is detected and reported" {
+    local mock_body
+    mock_body='[{
+        "id": "abc-123",
+        "name": "test-agent",
+        "status": "active",
+        "label": "Test Agent",
+        "program": "aider",
+        "workingDirectory": "/home/mvillmow/TestProject",
+        "programArgs": "--verbose",
+        "taskDescription": "A test agent for unit tests",
+        "tags": ["ci", "testing"],
+        "owner": "mvillmow",
+        "role": "member"
+    }]'
+    _start_mock_server 200 "$mock_body"
+
+    _run_diff "${FIXTURES_DIR}/agent-valid.yaml"
+
+    [[ "$status" -eq 1 ]]
+    [[ "$output" == *"program"* ]]
+}

--- a/tools/reconciler/tests/integration/test_plan_json_output.bats
+++ b/tools/reconciler/tests/integration/test_plan_json_output.bats
@@ -1,0 +1,303 @@
+#!/usr/bin/env bats
+# tests/integration/test_plan_json_output.bats
+#
+# Integration tests for plan.sh --output json.
+# Runs plan.sh against a mock Agamemnon API and validates that:
+#   - The output is valid JSON
+#   - The top-level schema fields (timestamp, host, agamemnon_url, summary, planned_changes) are present
+#   - summary counts match the expected planned actions
+#   - planned_changes entries have name/action/details fields
+#
+# Covers issue #183.
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+FIXTURES_DIR="${SCRIPT_DIR}/tests/fixtures"
+HELPERS_DIR="${SCRIPT_DIR}/tests/helpers"
+PLAN_SH="${SCRIPT_DIR}/scripts/plan.sh"
+MOCK_PORT=18083
+MOCK_PID_FILE="/tmp/bats-plan-json-mock-$$.pid"
+
+# ---------------------------------------------------------------------------
+# Mock server helpers
+# ---------------------------------------------------------------------------
+
+_start_mock_server() {
+    local http_status="${1:-200}"
+    local body="${2}"
+    [[ -z "$body" ]] && body='[]'
+
+    MOCK_STATUS="$http_status" MOCK_BODY="$body" \
+        python3 "${HELPERS_DIR}/mock_server.py" "$MOCK_PORT" \
+        > /dev/null 2>&1 &
+    echo $! > "$MOCK_PID_FILE"
+    sleep 0.3
+}
+
+_stop_mock_server() {
+    if [[ -f "$MOCK_PID_FILE" ]]; then
+        kill "$(cat "$MOCK_PID_FILE")" 2>/dev/null || true
+        rm -f "$MOCK_PID_FILE"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Setup: create a minimal temp repo root so plan.sh can find agents/
+# ---------------------------------------------------------------------------
+
+setup() {
+    export AGAMEMNON_URL="http://127.0.0.1:${MOCK_PORT}"
+    export NO_COLOR=1
+
+    # Build a temp repo root that mirrors the real one:
+    #   <root>/scripts/ → symlinked to real scripts/
+    #   <root>/agents/testhost/<agent>.yaml
+    REPO_TMP="$(mktemp -d)"
+    mkdir -p "${REPO_TMP}/agents/testhost"
+
+    # Symlink scripts/ into temp root so BASH_SOURCE resolves plan.sh → lib/
+    ln -s "${SCRIPT_DIR}/scripts" "${REPO_TMP}/scripts"
+}
+
+teardown() {
+    _stop_mock_server
+    [[ -n "${REPO_TMP:-}" ]] && rm -rf "$REPO_TMP"
+    unset NO_COLOR
+}
+
+# ---------------------------------------------------------------------------
+# Helper: place a YAML file in the temp repo and run plan.sh --output json
+# plan.sh finds agents/ relative to its own BASH_SOURCE directory.
+# Since scripts/ is a symlink resolving to the real scripts/, the repo root
+# computed by BASH_SOURCE is the real repo root — not REPO_TMP.
+# We therefore copy the agent YAML into the real agents/ under a temp host dir
+# and pass that host name to plan.sh to scope the search.
+# ---------------------------------------------------------------------------
+
+# Unique host name per test to avoid collisions
+_PLAN_TEST_HOST=""
+
+_setup_test_agent() {
+    local agent_yaml="$1"
+    # Use a unique host dir under the real agents/ directory
+    _PLAN_TEST_HOST="plantest-$$-${RANDOM}"
+    mkdir -p "${SCRIPT_DIR}/agents/${_PLAN_TEST_HOST}"
+    cp "$agent_yaml" "${SCRIPT_DIR}/agents/${_PLAN_TEST_HOST}/"
+}
+
+_cleanup_test_agent() {
+    if [[ -n "${_PLAN_TEST_HOST:-}" ]]; then
+        rm -rf "${SCRIPT_DIR}/agents/${_PLAN_TEST_HOST}"
+        _PLAN_TEST_HOST=""
+    fi
+}
+
+# Run plan.sh --output json with a given agent fixture, scoped to the temp host.
+# Sets $output and $status from bats `run`.
+_run_plan_json() {
+    local agent_yaml="$1"
+    shift  # remaining args forwarded to plan.sh
+
+    _setup_test_agent "$agent_yaml"
+    run bash "$PLAN_SH" "$_PLAN_TEST_HOST" --output json "$@"
+    _cleanup_test_agent
+}
+
+# ---------------------------------------------------------------------------
+# Tests: schema and JSON validity
+# ---------------------------------------------------------------------------
+
+@test "plan.sh --output json: produces valid JSON (CREATE scenario)" {
+    # Mock: Agamemnon returns empty list → agent would be created
+    _start_mock_server 200 '[]'
+
+    _run_plan_json "${FIXTURES_DIR}/agent-valid.yaml"
+
+    # Output must parse as JSON regardless of exit code
+    echo "$output" | jq . > /dev/null
+}
+
+@test "plan.sh --output json: top-level schema fields are present" {
+    _start_mock_server 200 '[]'
+
+    _run_plan_json "${FIXTURES_DIR}/agent-valid.yaml"
+
+    echo "$output" | jq -e 'has("timestamp")'        > /dev/null
+    echo "$output" | jq -e 'has("host")'             > /dev/null
+    echo "$output" | jq -e 'has("agamemnon_url")'    > /dev/null
+    echo "$output" | jq -e 'has("summary")'          > /dev/null
+    echo "$output" | jq -e 'has("planned_changes")'  > /dev/null
+}
+
+@test "plan.sh --output json: summary has all expected keys" {
+    _start_mock_server 200 '[]'
+
+    _run_plan_json "${FIXTURES_DIR}/agent-valid.yaml"
+
+    echo "$output" | jq -e '.summary | has("agents_checked")'  > /dev/null
+    echo "$output" | jq -e '.summary | has("changes_needed")'  > /dev/null
+    echo "$output" | jq -e '.summary | has("to_create")'       > /dev/null
+    echo "$output" | jq -e '.summary | has("to_update")'       > /dev/null
+    echo "$output" | jq -e '.summary | has("to_wake")'         > /dev/null
+    echo "$output" | jq -e '.summary | has("to_hibernate")'    > /dev/null
+    echo "$output" | jq -e '.summary | has("unchanged")'       > /dev/null
+}
+
+@test "plan.sh --output json: planned_changes is a JSON array" {
+    _start_mock_server 200 '[]'
+
+    _run_plan_json "${FIXTURES_DIR}/agent-valid.yaml"
+
+    arr_kind="$(echo "$output" | jq -r '.planned_changes | type')"
+    [[ "$arr_kind" == "array" ]]
+}
+
+# ---------------------------------------------------------------------------
+# Tests: CREATE scenario
+# ---------------------------------------------------------------------------
+
+@test "plan.sh --output json: to_create incremented when agent absent from Agamemnon" {
+    _start_mock_server 200 '[]'
+
+    _run_plan_json "${FIXTURES_DIR}/agent-valid.yaml"
+
+    to_create="$(echo "$output" | jq -r '.summary.to_create')"
+    [[ "$to_create" -ge 1 ]]
+}
+
+@test "plan.sh --output json: changes_needed is true when CREATE detected" {
+    _start_mock_server 200 '[]'
+
+    _run_plan_json "${FIXTURES_DIR}/agent-valid.yaml"
+
+    changes_needed="$(echo "$output" | jq -r '.summary.changes_needed')"
+    [[ "$changes_needed" == "true" ]]
+}
+
+@test "plan.sh --output json: planned_changes entries have name, action, details fields" {
+    _start_mock_server 200 '[]'
+
+    _run_plan_json "${FIXTURES_DIR}/agent-valid.yaml"
+
+    len="$(echo "$output" | jq '.planned_changes | length')"
+    [[ "$len" -ge 1 ]]
+
+    echo "$output" | jq -e '.planned_changes[0] | has("name")'    > /dev/null
+    echo "$output" | jq -e '.planned_changes[0] | has("action")'  > /dev/null
+    echo "$output" | jq -e '.planned_changes[0] | has("details")' > /dev/null
+}
+
+@test "plan.sh --output json: CREATE action recorded in planned_changes" {
+    _start_mock_server 200 '[]'
+
+    _run_plan_json "${FIXTURES_DIR}/agent-valid.yaml"
+
+    action="$(echo "$output" | jq -r '.planned_changes[0].action')"
+    [[ "$action" == "CREATE" ]]
+}
+
+@test "plan.sh --output json: agent name is correct in planned_changes" {
+    _start_mock_server 200 '[]'
+
+    _run_plan_json "${FIXTURES_DIR}/agent-valid.yaml"
+
+    name="$(echo "$output" | jq -r '.planned_changes[0].name')"
+    [[ "$name" == "test-agent" ]]
+}
+
+# ---------------------------------------------------------------------------
+# Tests: UNCHANGED scenario
+# ---------------------------------------------------------------------------
+
+@test "plan.sh --output json: UNCHANGED when agent matches Agamemnon exactly" {
+    local mock_body
+    mock_body='[{
+        "id": "abc-123",
+        "name": "test-agent",
+        "status": "active",
+        "label": "Test Agent",
+        "program": "claude-code",
+        "workingDirectory": "/home/mvillmow/TestProject",
+        "programArgs": "--verbose",
+        "taskDescription": "A test agent for unit tests",
+        "tags": ["ci", "testing"],
+        "owner": "mvillmow",
+        "role": "member"
+    }]'
+    _start_mock_server 200 "$mock_body"
+
+    _run_plan_json "${FIXTURES_DIR}/agent-valid.yaml"
+
+    echo "$output" | jq . > /dev/null
+
+    changes_needed="$(echo "$output" | jq -r '.summary.changes_needed')"
+    [[ "$changes_needed" == "false" ]]
+
+    unchanged="$(echo "$output" | jq -r '.summary.unchanged')"
+    [[ "$unchanged" -eq 1 ]]
+}
+
+@test "plan.sh --output json: UNCHANGED exits 0" {
+    local mock_body
+    mock_body='[{
+        "id": "abc-123",
+        "name": "test-agent",
+        "status": "active",
+        "label": "Test Agent",
+        "program": "claude-code",
+        "workingDirectory": "/home/mvillmow/TestProject",
+        "programArgs": "--verbose",
+        "taskDescription": "A test agent for unit tests",
+        "tags": ["ci", "testing"],
+        "owner": "mvillmow",
+        "role": "member"
+    }]'
+    _start_mock_server 200 "$mock_body"
+
+    _run_plan_json "${FIXTURES_DIR}/agent-valid.yaml"
+
+    [[ "$status" -eq 0 ]]
+}
+
+@test "plan.sh --output json: CREATE exits 1" {
+    _start_mock_server 200 '[]'
+
+    _run_plan_json "${FIXTURES_DIR}/agent-valid.yaml"
+
+    [[ "$status" -eq 1 ]]
+}
+
+# ---------------------------------------------------------------------------
+# Tests: metadata fields
+# ---------------------------------------------------------------------------
+
+@test "plan.sh --output json: agamemnon_url field matches AGAMEMNON_URL env var" {
+    _start_mock_server 200 '[]'
+
+    _run_plan_json "${FIXTURES_DIR}/agent-valid.yaml"
+
+    url="$(echo "$output" | jq -r '.agamemnon_url')"
+    [[ "$url" == "http://127.0.0.1:${MOCK_PORT}" ]]
+}
+
+@test "plan.sh --output json: host field reflects the host argument" {
+    _start_mock_server 200 '[]'
+
+    # The test host is set inside _run_plan_json; capture it before running
+    _setup_test_agent "${FIXTURES_DIR}/agent-valid.yaml"
+    local test_host="$_PLAN_TEST_HOST"
+    run bash "$PLAN_SH" "$test_host" --output json
+    _cleanup_test_agent
+
+    host="$(echo "$output" | jq -r '.host')"
+    [[ "$host" == "$test_host" ]]
+}
+
+@test "plan.sh --output json: stdout contains only valid JSON with no preamble" {
+    _start_mock_server 200 '[]'
+
+    _run_plan_json "${FIXTURES_DIR}/agent-valid.yaml"
+
+    # jq -r 'type' fails on non-JSON; must return 'object'
+    parsed="$(echo "$output" | jq -r 'type')"
+    [[ "$parsed" == "object" ]]
+}

--- a/tools/reconciler/tests/integration/test_reconcile_workflow.bats
+++ b/tools/reconciler/tests/integration/test_reconcile_workflow.bats
@@ -1,0 +1,367 @@
+#!/usr/bin/env bats
+# tests/integration/test_reconcile_workflow.bats
+#
+# Integration tests for end-to-end reconciliation workflows.
+# Exercises the full parse → compute_drift → build_create_json pipeline
+# and verifies API function behaviour against a mock HTTP server.
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+FIXTURES_DIR="${SCRIPT_DIR}/tests/fixtures"
+HELPERS_DIR="${SCRIPT_DIR}/tests/helpers"
+MOCK_PORT=18081
+MOCK_PID_FILE="/tmp/bats-integ-mock-$$.pid"
+
+# ---------------------------------------------------------------------------
+# Mock server helpers
+# ---------------------------------------------------------------------------
+
+_start_mock_server() {
+    local http_status="${1:-200}"
+    # Avoid ":-{}" bash brace-default parsing issue; use explicit fallback.
+    local body="${2}"
+    [[ -z "$body" ]] && body='{}'
+
+    MOCK_STATUS="$http_status" MOCK_BODY="$body" \
+        python3 "${HELPERS_DIR}/mock_server.py" "$MOCK_PORT" \
+        > /dev/null 2>&1 &
+    echo $! > "$MOCK_PID_FILE"
+    sleep 0.2
+}
+
+_stop_mock_server() {
+    if [[ -f "$MOCK_PID_FILE" ]]; then
+        kill "$(cat "$MOCK_PID_FILE")" 2>/dev/null || true
+        rm -f "$MOCK_PID_FILE"
+    fi
+}
+
+setup() {
+    export AGAMEMNON_URL="http://127.0.0.1:${MOCK_PORT}"
+    # shellcheck source=/dev/null
+    source "${SCRIPT_DIR}/scripts/lib/reconcile.sh"
+    # shellcheck source=/dev/null
+    source "${SCRIPT_DIR}/scripts/lib/api.sh"
+}
+
+teardown() {
+    _stop_mock_server
+}
+
+# ---------------------------------------------------------------------------
+# Workflow: CREATE — agent exists in YAML but not in Agamemnon
+# ---------------------------------------------------------------------------
+
+@test "workflow: CREATE — parse YAML then build create JSON for new agent" {
+    # Parse the valid agent fixture
+    declare -A fields
+    while IFS='=' read -r key value; do
+        fields["$key"]="$value"
+    done < <(parse_agent_yaml "${FIXTURES_DIR}/agent-valid.yaml")
+
+    # Build the create JSON
+    create_json="$(build_create_json \
+        "${fields[name]}" \
+        "${fields[label]}" \
+        "${fields[program]}" \
+        "${fields[workingDirectory]}" \
+        "${fields[programArgs]}" \
+        "${fields[taskDescription]}" \
+        "${fields[tags]}" \
+        "${fields[owner]}" \
+        "${fields[role]}")"
+
+    # Verify the JSON is valid and has correct fields
+    echo "$create_json" | jq . > /dev/null
+    [[ "$(echo "$create_json" | jq -r '.name')" == "test-agent" ]]
+    [[ "$(echo "$create_json" | jq -r '.program')" == "claude-code" ]]
+    [[ "$(echo "$create_json" | jq -r '.workingDirectory')" == "/home/mvillmow/TestProject" ]]
+}
+
+@test "workflow: CREATE — create_agent call succeeds against mock server" {
+    _start_mock_server 201 '{"id":"new-uuid","name":"test-agent","status":"offline"}'
+
+    body='{"name":"test-agent","program":"claude-code","workingDirectory":"/tmp"}'
+    result="$(agamemnon_create_agent "$body")"
+    [[ "$(echo "$result" | jq -r '.id')" == "new-uuid" ]]
+    [[ "$(echo "$result" | jq -r '.name')" == "test-agent" ]]
+}
+
+# ---------------------------------------------------------------------------
+# Workflow: UNCHANGED — agent matches desired state
+# ---------------------------------------------------------------------------
+
+@test "workflow: UNCHANGED — agent matches desired state exactly" {
+    # Parse agent YAML
+    declare -A fields
+    while IFS='=' read -r key value; do
+        fields["$key"]="$value"
+    done < <(parse_agent_yaml "${FIXTURES_DIR}/agent-valid.yaml")
+
+    # Simulate API response matching the YAML
+    actual_json="$(jq -n \
+        --arg lbl "${fields[label]}" \
+        --arg program "${fields[program]}" \
+        --arg workingDirectory "${fields[workingDirectory]}" \
+        --arg programArgs "${fields[programArgs]}" \
+        --arg taskDescription "${fields[taskDescription]}" \
+        --arg owner "${fields[owner]}" \
+        --arg role "${fields[role]}" \
+        --arg model "${fields[model]}" \
+        '{
+            status: "active",
+            label: $lbl,
+            program: $program,
+            workingDirectory: $workingDirectory,
+            programArgs: $programArgs,
+            taskDescription: $taskDescription,
+            tags: ["testing","ci"],
+            owner: $owner,
+            role: $role,
+            model: $model,
+            deployment: {type: "local"}
+        }')"
+
+    result="$(compute_drift \
+        "${fields[name]}" \
+        "${fields[desiredState]}" \
+        "$actual_json" \
+        "${fields[label]}" \
+        "${fields[program]}" \
+        "${fields[workingDirectory]}" \
+        "${fields[programArgs]}" \
+        "${fields[taskDescription]}" \
+        "${fields[tags]}" \
+        "${fields[model]:-}" \
+        "${fields[owner]:-}" \
+        "${fields[role]:-}" \
+        "${fields[deploymentType]:-local}")"
+
+    [[ "$result" == "UNCHANGED" ]]
+}
+
+# ---------------------------------------------------------------------------
+# Workflow: WAKE — agent is offline but should be active
+# ---------------------------------------------------------------------------
+
+@test "workflow: WAKE — offline agent with active desired state" {
+    declare -A fields
+    while IFS='=' read -r key value; do
+        fields["$key"]="$value"
+    done < <(parse_agent_yaml "${FIXTURES_DIR}/agent-valid.yaml")
+
+    # Simulate agent is offline in Agamemnon
+    actual_json="$(jq -n \
+        --arg lbl "${fields[label]}" \
+        --arg program "${fields[program]}" \
+        --arg workingDirectory "${fields[workingDirectory]}" \
+        --arg programArgs "${fields[programArgs]}" \
+        --arg taskDescription "${fields[taskDescription]}" \
+        --arg owner "${fields[owner]}" \
+        --arg role "${fields[role]}" \
+        --arg model "${fields[model]}" \
+        '{
+            status: "offline",
+            label: $lbl,
+            program: $program,
+            workingDirectory: $workingDirectory,
+            programArgs: $programArgs,
+            taskDescription: $taskDescription,
+            tags: ["testing","ci"],
+            owner: $owner,
+            role: $role,
+            model: $model,
+            deployment: {type: "local"}
+        }')"
+
+    result="$(compute_drift \
+        "${fields[name]}" \
+        "active" \
+        "$actual_json" \
+        "${fields[label]}" \
+        "${fields[program]}" \
+        "${fields[workingDirectory]}" \
+        "${fields[programArgs]}" \
+        "${fields[taskDescription]}" \
+        "${fields[tags]}" \
+        "${fields[model]:-}" \
+        "${fields[owner]:-}" \
+        "${fields[role]:-}" \
+        "${fields[deploymentType]:-local}")"
+
+    [[ "$result" == "WAKE" ]]
+}
+
+@test "workflow: WAKE — wake_agent API call succeeds" {
+    _start_mock_server 200 '{"id":"abc123","status":"active"}'
+    result="$(agamemnon_wake_agent "abc123")"
+    [[ "$(echo "$result" | jq -r '.status')" == "active" ]]
+}
+
+# ---------------------------------------------------------------------------
+# Workflow: HIBERNATE — agent is active but should be hibernated
+# ---------------------------------------------------------------------------
+
+@test "workflow: HIBERNATE — active agent with hibernated desired state" {
+    declare -A fields
+    while IFS='=' read -r key value; do
+        fields["$key"]="$value"
+    done < <(parse_agent_yaml "${FIXTURES_DIR}/agent-hibernated.yaml")
+
+    actual_json="$(jq -n \
+        --arg lbl "${fields[label]}" \
+        --arg program "${fields[program]}" \
+        --arg workingDirectory "${fields[workingDirectory]}" \
+        --arg programArgs "${fields[programArgs]}" \
+        --arg taskDescription "${fields[taskDescription]}" \
+        --arg owner "${fields[owner]}" \
+        --arg role "${fields[role]}" \
+        --arg model "${fields[model]}" \
+        '{
+            status: "active",
+            label: $lbl,
+            program: $program,
+            workingDirectory: $workingDirectory,
+            programArgs: $programArgs,
+            taskDescription: $taskDescription,
+            tags: ["hibernated"],
+            owner: $owner,
+            role: $role,
+            model: $model,
+            deployment: {type: "local"}
+        }')"
+
+    result="$(compute_drift \
+        "${fields[name]}" \
+        "hibernated" \
+        "$actual_json" \
+        "${fields[label]}" \
+        "${fields[program]}" \
+        "${fields[workingDirectory]}" \
+        "${fields[programArgs]}" \
+        "${fields[taskDescription]}" \
+        "${fields[tags]}" \
+        "${fields[model]:-}" \
+        "${fields[owner]:-}" \
+        "${fields[role]:-}" \
+        "${fields[deploymentType]:-local}")"
+
+    [[ "$result" == "HIBERNATE" ]]
+}
+
+@test "workflow: HIBERNATE — hibernate_agent API call succeeds" {
+    _start_mock_server 200 '{"id":"abc123","status":"offline"}'
+    result="$(agamemnon_hibernate_agent "abc123")"
+    [[ "$(echo "$result" | jq -r '.status')" == "offline" ]]
+}
+
+# ---------------------------------------------------------------------------
+# Workflow: UPDATE — agent exists but fields have drifted
+# ---------------------------------------------------------------------------
+
+@test "workflow: UPDATE — detect label drift and trigger update" {
+    declare -A fields
+    while IFS='=' read -r key value; do
+        fields["$key"]="$value"
+    done < <(parse_agent_yaml "${FIXTURES_DIR}/agent-valid.yaml")
+
+    # Simulate Agamemnon has a stale label
+    actual_json="$(jq -n \
+        --arg program "${fields[program]}" \
+        --arg workingDirectory "${fields[workingDirectory]}" \
+        --arg programArgs "${fields[programArgs]}" \
+        --arg taskDescription "${fields[taskDescription]}" \
+        --arg owner "${fields[owner]}" \
+        --arg role "${fields[role]}" \
+        --arg model "${fields[model]}" \
+        '{
+            status: "active",
+            label: "Stale Label",
+            program: $program,
+            workingDirectory: $workingDirectory,
+            programArgs: $programArgs,
+            taskDescription: $taskDescription,
+            tags: ["testing","ci"],
+            owner: $owner,
+            role: $role,
+            model: $model,
+            deployment: {type: "local"}
+        }')"
+
+    result="$(compute_drift \
+        "${fields[name]}" \
+        "${fields[desiredState]}" \
+        "$actual_json" \
+        "${fields[label]}" \
+        "${fields[program]}" \
+        "${fields[workingDirectory]}" \
+        "${fields[programArgs]}" \
+        "${fields[taskDescription]}" \
+        "${fields[tags]}" \
+        "${fields[model]:-}" \
+        "${fields[owner]:-}" \
+        "${fields[role]:-}" \
+        "${fields[deploymentType]:-local}")"
+
+    [[ "$result" == UPDATE:* ]]
+    [[ "$result" == *"label"* ]]
+}
+
+@test "workflow: UPDATE — update_agent API call succeeds" {
+    _start_mock_server 200 '{"id":"abc123","label":"New Label","status":"active"}'
+    result="$(agamemnon_update_agent "abc123" '{"label":"New Label"}')"
+    [[ "$(echo "$result" | jq -r '.label')" == "New Label" ]]
+}
+
+# ---------------------------------------------------------------------------
+# Workflow: API failure handling
+# ---------------------------------------------------------------------------
+
+@test "workflow: API failures are propagated — list fails on 500" {
+    _start_mock_server 500 '{"error":"internal server error"}'
+    run agamemnon_list_agents
+    [[ "$status" -ne 0 ]]
+}
+
+@test "workflow: lookup by name works via list then filter" {
+    local agents_json='[{"id":"id-xyz","name":"test-agent","status":"active"},{"id":"id-abc","name":"other-agent","status":"offline"}]'
+    _start_mock_server 200 "$agents_json"
+    agent_id="$(agamemnon_id_by_name "test-agent")"
+    [[ "$agent_id" == "id-xyz" ]]
+}
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+@test "edge case: minimal YAML parses and produces valid create JSON" {
+    declare -A fields
+    while IFS='=' read -r key value; do
+        fields["$key"]="$value"
+    done < <(parse_agent_yaml "${FIXTURES_DIR}/agent-minimal.yaml")
+
+    create_json="$(build_create_json \
+        "${fields[name]}" \
+        "${fields[label]:-}" \
+        "${fields[program]}" \
+        "${fields[workingDirectory]}" \
+        "${fields[programArgs]:-}" \
+        "${fields[taskDescription]:-}" \
+        "${fields[tags]:-}" \
+        "${fields[owner]:-}" \
+        "${fields[role]:-member}")"
+
+    echo "$create_json" | jq . > /dev/null
+    [[ "$(echo "$create_json" | jq -r '.name')" == "minimal-agent" ]]
+}
+
+@test "edge case: docker agent YAML parses docker fields correctly" {
+    declare -A fields
+    while IFS='=' read -r key value; do
+        fields["$key"]="$value"
+    done < <(parse_agent_yaml "${FIXTURES_DIR}/agent-docker.yaml")
+
+    [[ "${fields[deploymentType]}" == "docker" ]]
+    [[ "${fields[dockerImage]}" == "my-claude:latest" ]]
+    [[ "${fields[dockerCpus]}" == "2" ]]
+    [[ "${fields[dockerMemory]}" == "4g" ]]
+}

--- a/tools/reconciler/tests/integration/test_verify_convergence.bats
+++ b/tools/reconciler/tests/integration/test_verify_convergence.bats
@@ -1,0 +1,394 @@
+#!/usr/bin/env bats
+# tests/integration/test_verify_convergence.bats
+#
+# Integration tests for the verify_convergence call path in apply.sh (#374).
+#
+# These tests invoke apply.sh end-to-end against a mock Agamemnon server using
+# a routes config file.
+#
+# Routes design for "ok" scenario (convergence-routes-ok.json):
+#   - All GET /api/v1/agents → agent exists with status=active, label="OldLabel"
+#     (the stale label triggers an UPDATE action in the reconciler)
+#   - PATCH /api/v1/agents/* → 200 (update succeeds)
+#
+# The stale label forces compute_drift to return UPDATE, which populates
+# _MODIFIED_NAMES. verify_convergence then re-fetches, sees status=active,
+# and reports "[ok] converged" — proving the re-fetch path is exercised.
+#
+# Routes design for "fail" scenario (convergence-routes-fail.json):
+#   - All GET /api/v1/agents → agent exists with status=offline, desired=active
+#     (triggers WAKE; re-fetch also returns offline → convergence fails)
+#   - PATCH /api/v1/agents/* → 200 (wake succeeds per API, but agent stays offline)
+#
+# Covers issue #374 (missing integration test for F-03 convergence bug).
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+FIXTURES_DIR="${SCRIPT_DIR}/tests/fixtures"
+HELPERS_DIR="${SCRIPT_DIR}/tests/helpers"
+APPLY_SH="${SCRIPT_DIR}/scripts/apply.sh"
+MOCK_PORT=18086
+MOCK_PID_FILE="/tmp/bats-convergence-mock-$$.pid"
+
+# ---------------------------------------------------------------------------
+# Mock server helpers
+# ---------------------------------------------------------------------------
+
+_start_mock_server_routes() {
+    local routes_file="$1"
+    python3 "${HELPERS_DIR}/mock_server.py" "$MOCK_PORT" --routes "$routes_file" \
+        > /dev/null 2>&1 &
+    echo $! > "$MOCK_PID_FILE"
+    sleep 0.3
+}
+
+_stop_mock_server() {
+    if [[ -f "$MOCK_PID_FILE" ]]; then
+        kill "$(cat "$MOCK_PID_FILE")" 2>/dev/null || true
+        rm -f "$MOCK_PID_FILE"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Extract the first complete JSON object from a string (ignoring trailing text).
+# Uses Python's json decoder which stops at the end of the first valid object.
+_extract_json_block() {
+    local text="$1"
+    # Pass text via env var to avoid SC2259 (pipe + heredoc conflict).
+    TEXT="$text" python3 - <<'PYEOF' 2>/dev/null || true
+import sys, json, os
+data = os.environ.get("TEXT", "")
+idx = data.find('{')
+if idx < 0:
+    sys.exit(0)
+decoder = json.JSONDecoder()
+try:
+    obj, _ = decoder.raw_decode(data, idx)
+    print(json.dumps(obj))
+except json.JSONDecodeError:
+    pass
+PYEOF
+}
+
+# ---------------------------------------------------------------------------
+# Setup / teardown
+# ---------------------------------------------------------------------------
+
+_CONV_TEST_HOST=""
+_CONV_SNAPSHOT_DIR=""
+
+_setup_test_agent() {
+    _CONV_TEST_HOST="convtest-$$-${RANDOM}"
+    mkdir -p "${SCRIPT_DIR}/agents/${_CONV_TEST_HOST}"
+    printf 'apiVersion: myrmidons/v1\nkind: Agent\nmetadata:\n  name: convergence-agent\n  host: %s\nspec:\n  label: Convergence Agent\n  program: claude-code\n  model: null\n  workingDirectory: /tmp/conv\n  programArgs: ""\n  taskDescription: "convergence integration test"\n  tags: []\n  owner: ci\n  role: member\n  deployment:\n    type: local\n  desiredState: active\n' \
+        "$_CONV_TEST_HOST" \
+        > "${SCRIPT_DIR}/agents/${_CONV_TEST_HOST}/convergence-agent.yaml"
+}
+
+_cleanup_test_agent() {
+    if [[ -n "${_CONV_TEST_HOST:-}" ]]; then
+        rm -rf "${SCRIPT_DIR}/agents/${_CONV_TEST_HOST}"
+        _CONV_TEST_HOST=""
+    fi
+}
+
+setup() {
+    export AGAMEMNON_URL="http://127.0.0.1:${MOCK_PORT}"
+    export NO_COLOR=1
+    _CONV_SNAPSHOT_DIR="$(mktemp -d)"
+    _setup_test_agent
+}
+
+teardown() {
+    _stop_mock_server
+    _cleanup_test_agent
+    rm -rf "${_CONV_SNAPSHOT_DIR:-}"
+    unset NO_COLOR
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: happy path — agent has drifted label, UPDATE applied, convergence ok
+#
+# Routes design (convergence-routes-ok.json):
+#   All GET /api/v1/agents    → agent active, label="OldLabel" (label drift triggers UPDATE)
+#   PATCH /api/v1/agents/*    → 200 active (update applied successfully)
+#
+# Expected: apply.sh patches the label drift and verify_convergence sees
+# status=active after the re-fetch, reporting "[ok] converged".
+# ---------------------------------------------------------------------------
+
+@test "verify_convergence: re-fetch confirms active status after UPDATE — reports [ok]" {
+    _start_mock_server_routes "${FIXTURES_DIR}/convergence-routes-ok.json"
+
+    run bash "$APPLY_SH" "$_CONV_TEST_HOST" --yes \
+        --snapshot-dir "$_CONV_SNAPSHOT_DIR" 2>&1 || true
+
+    [[ "$output" == *"[ok] convergence-agent: converged"* ]]
+    [[ "$output" == *"Convergence:"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 2: verify_convergence calls agamemnon_list_agents (not cached state)
+#
+# The same routes setup as test 1. If verify_convergence had used the pre-apply
+# agents_json cache (as the shadowing bug F-03 effectively did), it would not
+# reach the re-fetch code path at all and _MODIFIED_NAMES would be checked
+# against stale data. The "[ok]" result proves the canonical verify_convergence
+# definition (with the re-fetch) is the one being called.
+# ---------------------------------------------------------------------------
+
+@test "verify_convergence: calls agamemnon_list_agents for re-fetch, not cached pre-apply state" {
+    _start_mock_server_routes "${FIXTURES_DIR}/convergence-routes-ok.json"
+
+    run bash "$APPLY_SH" "$_CONV_TEST_HOST" --yes \
+        --snapshot-dir "$_CONV_SNAPSHOT_DIR" 2>&1 || true
+
+    # Must NOT report NOT converged — that would indicate cached offline state was used
+    [[ "$output" != *"NOT converged"* ]]
+
+    # Must report successfully converged — proves the re-fetch returned "active"
+    [[ "$output" == *"[ok] convergence-agent: converged"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 3: non-convergence detected — mock always returns offline
+#
+# Routes design (convergence-routes-fail.json):
+#   All GET /api/v1/agents  → agent offline  (desired=active, triggers WAKE)
+#   PATCH /api/v1/agents/*  → 200 offline    (wake API call succeeds but agent stays offline)
+#
+# Expected: apply.sh issues the WAKE call but the convergence re-fetch still
+# sees status=offline. verify_convergence reports "[!] NOT converged".
+# ---------------------------------------------------------------------------
+
+@test "verify_convergence: reports NOT converged when re-fetch shows agent still offline" {
+    _start_mock_server_routes "${FIXTURES_DIR}/convergence-routes-fail.json"
+
+    run bash "$APPLY_SH" "$_CONV_TEST_HOST" --yes \
+        --snapshot-dir "$_CONV_SNAPSHOT_DIR" 2>&1 || true
+
+    [[ "$output" == *"NOT converged"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 4: prune-convergence path — pruned agent still present in API
+#
+# Routes design (convergence-routes-prune.json):
+#   All GET /api/v1/agents  → two agents: convergence-agent (managed, active)
+#                             and unmanaged-prune-agent (unmanaged, active)
+#   PATCH /api/v1/agents/*  → 200 offline  (hibernate succeeds)
+#   DELETE /api/v1/agents/* → 200          (delete appears to succeed)
+#   default_body            → still returns both agents (delete had no effect)
+#
+# With --prune, apply.sh calls handle_unmanaged for unmanaged-prune-agent,
+# which hibernates then deletes it. The mock DELETE returns 200 but the
+# subsequent GET still returns the agent. verify_convergence checks
+# _PRUNED_NAMES and finds unmanaged-prune-agent still present, reporting
+# "pruned but still present in API (convergence failed)".
+# ---------------------------------------------------------------------------
+
+@test "verify_convergence: detects pruned agent still present in API — reports convergence failed" {
+    _start_mock_server_routes "${FIXTURES_DIR}/convergence-routes-prune.json"
+
+    run bash "$APPLY_SH" "$_CONV_TEST_HOST" --prune --yes \
+        --snapshot-dir "$_CONV_SNAPSHOT_DIR" 2>&1 || true
+
+    [[ "$output" == *"pruned but still present in API (convergence failed)"* ]]
+}
+
+# ---------------------------------------------------------------------------
+
+# Test 5: WAKE convergence using once route (issue #433)
+#
+# Routes design (convergence-routes-wake-once.json):
+#   First GET /api/v1/agents (once) → agent offline  (triggers WAKE)
+#   PATCH /api/v1/agents/*          → 200 active
+#   All subsequent GET              → agent active  (default_body)
+#
+# The once route drives WAKE on the first list. The re-fetch after WAKE
+# hits the default_body and sees status=active, so verify_convergence
+# reports "[ok] converged" — without any label-drift workaround.
+# ---------------------------------------------------------------------------
+
+@test "verify_convergence: WAKE — once route drives offline→active state transition, reports [ok]" {
+    _start_mock_server_routes "${FIXTURES_DIR}/convergence-routes-wake-once.json"
+
+    run bash "$APPLY_SH" "$_CONV_TEST_HOST" --yes \
+        --snapshot-dir "$_CONV_SNAPSHOT_DIR" 2>&1 || true
+
+    [[ "$output" == *"[ok] convergence-agent: converged"* ]]
+    [[ "$output" != *"NOT converged"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 6: CREATE convergence using once route (issue #433)
+#
+# Routes design (convergence-routes-create-once.json):
+#   First GET /api/v1/agents (once) → []  (agent absent — triggers CREATE)
+#   POST /api/v1/agents             → 201 active
+#   All subsequent GET              → agent active  (default_body)
+#
+# The once route makes the first list return empty, forcing a CREATE.
+# The re-fetch after CREATE hits the default_body and sees status=active,
+# so verify_convergence reports "[ok] converged".
+# ---------------------------------------------------------------------------
+
+@test "verify_convergence: CREATE — once route drives absent→active state transition, reports [ok]" {
+    _start_mock_server_routes "${FIXTURES_DIR}/convergence-routes-create-once.json"
+
+    run bash "$APPLY_SH" "$_CONV_TEST_HOST" --yes \
+        --snapshot-dir "$_CONV_SNAPSHOT_DIR" 2>&1 || true
+
+    [[ "$output" == *"[ok] convergence-agent: converged"* ]]
+    [[ "$output" != *"NOT converged"* ]]
+}
+
+# Test 7: JSON output includes convergence key with per-agent results (success)
+#
+# Routes design (convergence-routes-json-ok.json):
+#   All GET /api/v1/agents → agent active, label="OldLabel" (label drift → UPDATE)
+#   PATCH /api/v1/agents/* → 200 active
+#
+# Expected: JSON report has .convergence.verified == 1, .convergence.failed == 0,
+# and .convergence.agents[0].converged == true with name == "convergence-agent".
+# ---------------------------------------------------------------------------
+
+@test "verify_convergence: JSON output includes convergence key with per-agent results on success" {
+    _start_mock_server_routes "${FIXTURES_DIR}/convergence-routes-json-ok.json"
+
+    local report_dir
+    report_dir="$(mktemp -d)"
+
+    run bash "$APPLY_SH" "$_CONV_TEST_HOST" --yes \
+        --output json \
+        --snapshot-dir "$_CONV_SNAPSHOT_DIR" 2>&1 || true
+
+    local full_json
+    full_json="$(_extract_json_block "$output")"
+
+    if [[ -n "$full_json" ]]; then
+        local conv_verified conv_failed agent_name agent_converged
+        conv_verified="$(echo "$full_json" | jq -r '.convergence.verified // empty' 2>/dev/null || echo "")"
+        conv_failed="$(echo "$full_json" | jq -r '.convergence.failed // empty' 2>/dev/null || echo "")"
+        agent_name="$(echo "$full_json" | jq -r '.convergence.agents[0].name // empty' 2>/dev/null || echo "")"
+        agent_converged="$(echo "$full_json" | jq -r '.convergence.agents[0].converged // empty' 2>/dev/null || echo "")"
+
+        [[ "$conv_verified" == "1" ]]
+        [[ "$conv_failed" == "0" ]]
+        [[ "$agent_name" == "convergence-agent" ]]
+        [[ "$agent_converged" == "true" ]]
+    else
+        # Fallback: verify output contains convergence key at minimum
+        [[ "$output" == *'"convergence"'* ]]
+    fi
+
+    rm -rf "$report_dir"
+}
+
+# ---------------------------------------------------------------------------
+# Test 8: JSON output marks agent as failed when convergence fails
+#
+# Routes design (convergence-routes-json-fail.json):
+#   All GET /api/v1/agents → agent offline (desired=active → WAKE issued)
+#   PATCH /api/v1/agents/* → 200 but agent stays offline
+#
+# Expected: .convergence.failed == 1, .convergence.agents[0].converged == false.
+# ---------------------------------------------------------------------------
+
+@test "verify_convergence: JSON output marks agent as failed when not converged" {
+    _start_mock_server_routes "${FIXTURES_DIR}/convergence-routes-json-fail.json"
+
+    run bash "$APPLY_SH" "$_CONV_TEST_HOST" --yes \
+        --output json \
+        --snapshot-dir "$_CONV_SNAPSHOT_DIR" 2>&1 || true
+
+    local full_json
+    full_json="$(_extract_json_block "$output")"
+
+    if [[ -n "$full_json" ]]; then
+        local conv_failed agent_converged
+        conv_failed="$(echo "$full_json" | jq -r '.convergence.failed // empty' 2>/dev/null || echo "")"
+        agent_converged="$(echo "$full_json" | jq -r '.convergence.agents[0].converged | if . == null then "" else tostring end' 2>/dev/null || echo "")"
+
+        [[ "$conv_failed" == "1" ]]
+        [[ "$agent_converged" == "false" ]]
+    else
+        [[ "$output" == *'"convergence"'* ]]
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Test 9: JSON output convergence key is always present, even with no modified agents
+#
+# When nothing drifts, verify_convergence returns early (0 modified, 0 pruned).
+# The JSON report should still contain .convergence with checked/verified/failed == 0
+# and an empty agents array — not absent.
+# ---------------------------------------------------------------------------
+
+@test "verify_convergence: JSON convergence key present with zeros when no agents modified" {
+    # Use ok routes but agent already matches desired state (no label drift).
+    # We achieve "no drift" by creating an agent whose YAML matches the mock exactly.
+    _stop_mock_server
+
+    local no_drift_host="nodrift-$$-${RANDOM}"
+    mkdir -p "${SCRIPT_DIR}/agents/${no_drift_host}"
+    printf 'apiVersion: myrmidons/v1\nkind: Agent\nmetadata:\n  name: no-drift-agent\n  host: %s\nspec:\n  label: No Drift Agent\n  program: claude-code\n  model: null\n  workingDirectory: /tmp/nodrift\n  programArgs: ""\n  taskDescription: "no drift test"\n  tags: []\n  owner: ci\n  role: member\n  deployment:\n    type: local\n  desiredState: active\n' \
+        "$no_drift_host" \
+        > "${SCRIPT_DIR}/agents/${no_drift_host}/no-drift-agent.yaml"
+
+    # Mock returns an agent that matches the YAML exactly (no drift)
+    local no_drift_routes
+    no_drift_routes="$(mktemp --suffix=.json)"
+    cat > "$no_drift_routes" <<'EOF'
+{
+  "routes": [],
+  "default_status": 200,
+  "default_body": [
+    {
+      "id": "nd1",
+      "name": "no-drift-agent",
+      "status": "active",
+      "label": "No Drift Agent",
+      "program": "claude-code",
+      "workingDirectory": "/tmp/nodrift",
+      "programArgs": "",
+      "taskDescription": "no drift test",
+      "tags": [],
+      "owner": "ci",
+      "role": "member"
+    }
+  ]
+}
+EOF
+
+    python3 "${HELPERS_DIR}/mock_server.py" "$MOCK_PORT" --routes "$no_drift_routes" \
+        > /dev/null 2>&1 &
+    echo $! > "$MOCK_PID_FILE"
+    sleep 0.3
+
+    run bash "$APPLY_SH" "$no_drift_host" --yes \
+        --output json \
+        --snapshot-dir "$_CONV_SNAPSHOT_DIR" 2>&1 || true
+
+    rm -rf "${SCRIPT_DIR}/agents/${no_drift_host}" "$no_drift_routes"
+
+    local full_json
+    full_json="$(_extract_json_block "$output")"
+
+    if [[ -n "$full_json" ]]; then
+        local conv_checked conv_verified conv_failed conv_agents_type
+        conv_checked="$(echo "$full_json" | jq -r '.convergence.checked // empty' 2>/dev/null || echo "")"
+        conv_verified="$(echo "$full_json" | jq -r '.convergence.verified // empty' 2>/dev/null || echo "")"
+        conv_failed="$(echo "$full_json" | jq -r '.convergence.failed // empty' 2>/dev/null || echo "")"
+        conv_agents_type="$(echo "$full_json" | jq -r '.convergence.agents | type' 2>/dev/null || echo "")"
+
+        [[ "$conv_checked" == "0" ]]
+        [[ "$conv_verified" == "0" ]]
+        [[ "$conv_failed" == "0" ]]
+        [[ "$conv_agents_type" == "array" ]]
+    else
+        [[ "$output" == *'"convergence"'* ]]
+    fi
+}

--- a/tools/reconciler/tests/test-api-retry.sh
+++ b/tools/reconciler/tests/test-api-retry.sh
@@ -1,0 +1,427 @@
+#!/usr/bin/env bash
+# tests/test-api-retry.sh — Unit tests for _agamemnon_curl_retry()
+#
+# Tests retry logic, exponential backoff, transient vs permanent error
+# classification, and AGAMEMNON_TIMEOUT env var handling in api.sh.
+#
+# Usage:
+#   ./tests/test-api-retry.sh
+#
+# Exit codes:
+#   0 = all tests passed
+#   1 = one or more tests failed
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+PASS=0
+FAIL=0
+
+# ── Test harness ──────────────────────────────────────────────────────────────
+
+_pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+_fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+assert_eq() {
+    local desc="$1" expected="$2" actual="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        _pass "$desc"
+    else
+        _fail "$desc — expected '${expected}', got '${actual}'"
+    fi
+}
+
+assert_zero() {
+    local desc="$1" actual="$2"
+    if [[ "$actual" -eq 0 ]]; then
+        _pass "$desc"
+    else
+        _fail "$desc — expected exit 0, got ${actual}"
+    fi
+}
+
+assert_nonzero() {
+    local desc="$1" actual="$2"
+    if [[ "$actual" -ne 0 ]]; then
+        _pass "$desc"
+    else
+        _fail "$desc — expected non-zero exit, got 0"
+    fi
+}
+
+assert_contains() {
+    local desc="$1" needle="$2" haystack="$3"
+    if [[ "$haystack" == *"$needle"* ]]; then
+        _pass "$desc"
+    else
+        _fail "$desc — expected to find '${needle}' in: ${haystack}"
+    fi
+}
+
+# ── Mock infrastructure ───────────────────────────────────────────────────────
+# Because _agamemnon_curl_retry calls curl inside $() subshells, we track
+# call counts and sequence state via temp files so mutations survive the
+# subshell boundary.
+
+_CALL_FILE=""
+_SEQ_FILE=""
+_BODY_FILE=""
+_STDERR_FILE=""
+
+setup_mock() {
+    _CALL_FILE="$(mktemp)"
+    _SEQ_FILE="$(mktemp)"
+    _BODY_FILE="$(mktemp)"
+    _STDERR_FILE="$(mktemp)"
+    echo 0 > "$_CALL_FILE"
+    echo '{"ok":true}' > "$_BODY_FILE"
+}
+
+teardown_mock() {
+    rm -f "$_CALL_FILE" "$_SEQ_FILE" "$_BODY_FILE" "$_STDERR_FILE"
+}
+
+# Set a single response for all calls: exit_code http_code
+mock_single() {
+    local exit_code="$1" http_code="$2"
+    echo "${exit_code},${http_code}" > "$_SEQ_FILE"
+}
+
+# Set a sequence of responses: each arg is "exit_code,http_code"
+# The last entry repeats indefinitely.
+mock_sequence() {
+    local IFS='|'
+    echo "$*" > "$_SEQ_FILE"
+}
+
+# Override curl so tests don't hit the network.
+# Reads sequence from _SEQ_FILE, writes body from _BODY_FILE to -o target,
+# outputs http_code, returns exit_code.
+#
+# Handles both space-separated and equals-sign forms of flags:
+#   --max-time 30   (space form)
+#   --max-time=30   (equals sign form, issue #265)
+#   -o file         (space form)
+#   -o=file         (equals sign form)
+curl() {
+    # Increment call count
+    local count
+    count=$(<"$_CALL_FILE")
+    echo $((count + 1)) > "$_CALL_FILE"
+
+    # Read next sequence entry
+    local seq entry rest exit_code http_code
+    seq=$(<"$_SEQ_FILE")
+    entry="${seq%%|*}"
+    rest="${seq#*|}"
+    exit_code="${entry%%,*}"
+    http_code="${entry#*,}"
+
+    # Advance sequence (last entry repeats)
+    if [[ "$rest" != "$seq" ]]; then
+        echo "$rest" > "$_SEQ_FILE"
+    fi
+
+    # Write body to -o file, handling both "-o file" and "-o=file" / "--output=file"
+    local args=("$@")
+    local i
+    for (( i=0; i<${#args[@]}; i++ )); do
+        case "${args[$i]}" in
+            -o)
+                # Space-separated: -o <file>
+                cat "$_BODY_FILE" > "${args[$((i+1))]}"
+                break
+                ;;
+            -o=*)
+                # Equals-sign form: -o=<file>
+                cat "$_BODY_FILE" > "${args[$i]#-o=}"
+                break
+                ;;
+            --output=*)
+                # Long equals-sign form: --output=<file>
+                cat "$_BODY_FILE" > "${args[$i]#--output=}"
+                break
+                ;;
+        esac
+    done
+
+    echo -n "$http_code"
+    return "$exit_code"
+}
+
+# Override sleep so tests run instantly.
+sleep() { : ; }
+
+# ── Load api.sh ───────────────────────────────────────────────────────────────
+AGAMEMNON_URL="http://mock.test:9999"
+export AGAMEMNON_TIMEOUT=5
+source "${REPO_ROOT}/scripts/lib/api.sh"
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+echo "Running api retry tests..."
+echo ""
+
+# ── Test 1: Success on first attempt — no retries ─────────────────────────────
+setup_mock
+mock_single 0 200
+output="$(_agamemnon_curl_retry "http://mock.test:9999/v1/agents" 2>"$_STDERR_FILE")"
+rc=$?
+calls=$(<"$_CALL_FILE")
+assert_zero "success on first attempt: exit 0" "$rc"
+assert_eq "success on first attempt: response body" '{"ok":true}' "$output"
+assert_eq "success on first attempt: curl called once" "1" "$calls"
+teardown_mock
+
+# ── Test 2: Retry on exit 7 (connection refused), success on 2nd attempt ──────
+setup_mock
+mock_sequence "7,000" "0,200"
+output="$(_agamemnon_curl_retry "http://mock.test:9999/v1/agents" 2>"$_STDERR_FILE")"
+rc=$?
+calls=$(<"$_CALL_FILE")
+stderr_content="$(cat "$_STDERR_FILE")"
+assert_zero "retry on exit 7, success on 2nd: exit 0" "$rc"
+assert_eq "retry on exit 7, success on 2nd: curl called twice" "2" "$calls"
+assert_contains "retry on exit 7: WARN emitted" "WARN: Retry 1/3" "$stderr_content"
+teardown_mock
+
+# ── Test 3: Retry on exit 28 (timeout), success on 2nd attempt ────────────────
+setup_mock
+mock_sequence "28,000" "0,200"
+output="$(_agamemnon_curl_retry "http://mock.test:9999/v1/agents" 2>"$_STDERR_FILE")"
+rc=$?
+calls=$(<"$_CALL_FILE")
+stderr_content="$(cat "$_STDERR_FILE")"
+assert_zero "retry on exit 28, success on 2nd: exit 0" "$rc"
+assert_eq "retry on exit 28, success on 2nd: curl called twice" "2" "$calls"
+assert_contains "retry on exit 28: WARN emitted" "WARN: Retry 1/3" "$stderr_content"
+teardown_mock
+
+# ── Test 4: Retry on HTTP 503, success on 2nd attempt ─────────────────────────
+setup_mock
+mock_sequence "0,503" "0,200"
+output="$(_agamemnon_curl_retry "http://mock.test:9999/v1/agents" 2>"$_STDERR_FILE")"
+rc=$?
+calls=$(<"$_CALL_FILE")
+stderr_content="$(cat "$_STDERR_FILE")"
+assert_zero "retry on HTTP 503, success on 2nd: exit 0" "$rc"
+assert_eq "retry on HTTP 503, success on 2nd: curl called twice" "2" "$calls"
+assert_contains "retry on HTTP 503: WARN emitted" "WARN: Retry 1/3" "$stderr_content"
+teardown_mock
+
+# ── Test 5: No retry on HTTP 404 (permanent error) ────────────────────────────
+setup_mock
+mock_single 0 404
+rc=0
+output="$(_agamemnon_curl_retry "http://mock.test:9999/v1/agents/missing" 2>"$_STDERR_FILE")" && rc=0 || rc=$?
+calls=$(<"$_CALL_FILE")
+assert_nonzero "no retry on HTTP 404: non-zero exit" "$rc"
+assert_eq "no retry on HTTP 404: curl called exactly once" "1" "$calls"
+teardown_mock
+
+# ── Test 6: No retry on HTTP 401 (permanent error) ────────────────────────────
+setup_mock
+mock_single 0 401
+rc=0
+output="$(_agamemnon_curl_retry "http://mock.test:9999/v1/agents" 2>"$_STDERR_FILE")" && rc=0 || rc=$?
+calls=$(<"$_CALL_FILE")
+assert_nonzero "no retry on HTTP 401: non-zero exit" "$rc"
+assert_eq "no retry on HTTP 401: curl called exactly once" "1" "$calls"
+teardown_mock
+
+# ── Test 7: AGAMEMNON_TIMEOUT is passed to curl as --max-time ─────────────────
+setup_mock
+mock_single 0 200
+# Capture curl args by overriding curl once more
+CAPTURED_ARGS=""
+_CAPTURED_FILE="$(mktemp)"
+curl() {
+    echo "$*" > "$_CAPTURED_FILE"
+    local count
+    count=$(<"$_CALL_FILE")
+    echo $((count + 1)) > "$_CALL_FILE"
+    local args=("$@")
+    local i
+    for (( i=0; i<${#args[@]}; i++ )); do
+        if [[ "${args[$i]}" == "-o" ]]; then
+            cat "$_BODY_FILE" > "${args[$((i+1))]}"; break
+        fi
+    done
+    echo -n "200"
+    return 0
+}
+export AGAMEMNON_TIMEOUT=42
+_agamemnon_curl_retry "http://mock.test:9999/v1/agents" >/dev/null 2>/dev/null
+export AGAMEMNON_TIMEOUT=5
+CAPTURED_ARGS="$(cat "$_CAPTURED_FILE")"
+rm -f "$_CAPTURED_FILE"
+# Restore standard curl mock
+curl() {
+    local count
+    count=$(<"$_CALL_FILE")
+    echo $((count + 1)) > "$_CALL_FILE"
+    local seq entry rest exit_code http_code
+    seq=$(<"$_SEQ_FILE")
+    entry="${seq%%|*}"; rest="${seq#*|}"
+    exit_code="${entry%%,*}"; http_code="${entry#*,}"
+    [[ "$rest" != "$seq" ]] && echo "$rest" > "$_SEQ_FILE"
+    local args=("$@"); local i
+    for (( i=0; i<${#args[@]}; i++ )); do
+        case "${args[$i]}" in
+            -o) cat "$_BODY_FILE" > "${args[$((i+1))]}"; break ;;
+            -o=*) cat "$_BODY_FILE" > "${args[$i]#-o=}"; break ;;
+            --output=*) cat "$_BODY_FILE" > "${args[$i]#--output=}"; break ;;
+        esac
+    done
+    echo -n "$http_code"
+    return "$exit_code"
+}
+assert_contains "AGAMEMNON_TIMEOUT passed as --max-time 42" "--max-time 42" "$CAPTURED_ARGS"
+teardown_mock
+
+# ── Test 7b: mock curl handles --max-time=N (equals sign form, issue #265) ───────
+# Verify the mock curl body-writing loop works correctly when a caller passes
+# --max-time=30 instead of --max-time 30.  We simulate this by calling the
+# mock directly with the equals-sign form and confirming it writes the body.
+setup_mock
+mock_single 0 200
+_EQ_FILE="$(mktemp)"
+# Call the mock curl directly with --max-time=30 (equals sign) and -o <file>.
+# The mock returns the exit code from its sequence; here we only care that the
+# body was written, so capture rc explicitly instead of suppressing it.
+_curl_rc=0
+curl --max-time=30 -o "$_EQ_FILE" "http://mock.test:9999/v1/agents" >/dev/null 2>/dev/null || _curl_rc=$?
+: "captured curl exit rc=${_curl_rc} for equals-sign --max-time test"
+eq_body="$(cat "$_EQ_FILE")"
+rm -f "$_EQ_FILE"
+assert_eq "mock curl handles --max-time=N: body written via -o" '{"ok":true}' "$eq_body"
+teardown_mock
+
+# ── Test 8: All 3 attempts fail (exit 7 each), non-zero exit returned ──────────
+setup_mock
+mock_single 7 000
+rc=0
+output="$(_agamemnon_curl_retry "http://mock.test:9999/v1/agents" 2>"$_STDERR_FILE")" && rc=0 || rc=$?
+calls=$(<"$_CALL_FILE")
+stderr_content="$(cat "$_STDERR_FILE")"
+assert_nonzero "all 3 attempts fail: non-zero exit" "$rc"
+assert_eq "all 3 attempts fail: curl called 3 times" "3" "$calls"
+assert_contains "all 3 attempts fail: ERROR in stderr" "ERROR:" "$stderr_content"
+teardown_mock
+
+# ── Test 9: WARN retry messages count up correctly (1/3, 2/3) ─────────────────
+setup_mock
+mock_single 7 000
+# Capture rc explicitly — we only assert on stderr content, not on rc, but we
+# refuse to silently swallow the value (the previous form `... && true || true`
+# was a placeholder for `ignore rc`).
+_retry_rc=0
+output="$(_agamemnon_curl_retry "http://mock.test:9999/v1/agents" 2>"$_STDERR_FILE")" || _retry_rc=$?
+: "Test 9 retry rc=${_retry_rc} (intentionally not asserted)"
+stderr_content="$(cat "$_STDERR_FILE")"
+assert_contains "WARN messages: Retry 1/3 present" "Retry 1/3" "$stderr_content"
+assert_contains "WARN messages: Retry 2/3 present" "Retry 2/3" "$stderr_content"
+teardown_mock
+
+# ── Test 10: HTTP 500 also treated as transient ────────────────────────────────
+setup_mock
+mock_sequence "0,500" "0,200"
+output="$(_agamemnon_curl_retry "http://mock.test:9999/v1/agents" 2>"$_STDERR_FILE")"
+rc=$?
+calls=$(<"$_CALL_FILE")
+assert_zero "HTTP 500 is transient, retried: exit 0" "$rc"
+assert_eq "HTTP 500 retried: curl called twice" "2" "$calls"
+teardown_mock
+
+# ── Test 11: Call-count assertion — success on first try calls curl exactly once ──
+# Issue #210: verify that sleep mock is working AND that retry behaviour fires
+# the right number of times by asserting curl call counts precisely.
+setup_mock
+mock_single 0 200
+# Test asserts on curl call count, not on the function's rc. Capture rc
+# explicitly so a regression in the retry function's exit-code semantics is
+# still visible in the test transcript.
+_retry_rc=0
+_agamemnon_curl_retry "http://mock.test:9999/v1/agents" >/dev/null 2>/dev/null || _retry_rc=$?
+: "Test 11 retry rc=${_retry_rc} (intentionally not asserted)"
+calls=$(<"$_CALL_FILE")
+assert_eq "call-count: success on first try — curl called exactly 1 time" "1" "$calls"
+teardown_mock
+
+# ── Test 12: Call-count — 2 transient failures then success = 3 curl calls ────
+setup_mock
+mock_sequence "7,000" "7,000" "0,200"
+_retry_rc=0
+_agamemnon_curl_retry "http://mock.test:9999/v1/agents" >/dev/null 2>"$_STDERR_FILE" || _retry_rc=$?
+: "Test 12 retry rc=${_retry_rc} (intentionally not asserted)"
+calls=$(<"$_CALL_FILE")
+stderr_content="$(cat "$_STDERR_FILE")"
+assert_eq "call-count: 2 failures then success — curl called exactly 3 times" "3" "$calls"
+assert_contains "call-count: Retry 1/3 present in stderr" "Retry 1/3" "$stderr_content"
+assert_contains "call-count: Retry 2/3 present in stderr" "Retry 2/3" "$stderr_content"
+teardown_mock
+
+# ── Test 13: Call-count — permanent HTTP 404 aborts immediately, 1 curl call ──
+setup_mock
+mock_single 0 404
+rc=0
+_agamemnon_curl_retry "http://mock.test:9999/v1/agents/x" >/dev/null 2>/dev/null && rc=0 || rc=$?
+calls=$(<"$_CALL_FILE")
+assert_eq "call-count: permanent 404 — curl called exactly 1 time (no retries)" "1" "$calls"
+assert_nonzero "call-count: permanent 404 returns non-zero" "$rc"
+teardown_mock
+
+# ── Test 14: Call-count — HTTP 503 x3 exhausts retries, curl called 3 times ──
+setup_mock
+mock_single 0 503
+rc=0
+_agamemnon_curl_retry "http://mock.test:9999/v1/agents" >/dev/null 2>/dev/null && rc=0 || rc=$?
+calls=$(<"$_CALL_FILE")
+assert_eq "call-count: 503 x3 exhausted — curl called exactly 3 times" "3" "$calls"
+assert_nonzero "call-count: 503 exhausted returns non-zero" "$rc"
+teardown_mock
+
+# ── Test 15: sleep mock verifies tests run without real delays ─────────────────
+# The sleep function is overridden to a no-op at the top of this file.
+# We verify this is working by timing a full 3-attempt retry sequence:
+# with real sleep (1s + 2s = 3s), this would take >3 seconds;
+# with the mock sleep it should complete in well under 1 second.
+setup_mock
+mock_single 7 000  # all 3 attempts fail
+_SLEEP_COUNT_FILE="$(mktemp)"
+echo 0 > "$_SLEEP_COUNT_FILE"
+
+# Override sleep to count calls in addition to being a no-op
+sleep() {
+    local n
+    n=$(<"$_SLEEP_COUNT_FILE")
+    echo $((n + 1)) > "$_SLEEP_COUNT_FILE"
+    :  # no-op — do not actually sleep
+}
+
+rc=0
+_agamemnon_curl_retry "http://mock.test:9999/v1/agents" >/dev/null 2>/dev/null && rc=0 || rc=$?
+calls=$(<"$_CALL_FILE")
+sleep_calls=$(<"$_SLEEP_COUNT_FILE")
+rm -f "$_SLEEP_COUNT_FILE"
+
+# Restore the original sleep override (no-op)
+sleep() { : ; }
+
+assert_eq "sleep-mock: curl called 3 times with mocked sleep" "3" "$calls"
+# _agamemnon_curl_retry calls sleep between attempt 1→2 and 2→3 (max_attempts-1 = 2 times)
+assert_eq "sleep-mock: sleep called exactly 2 times (between retries)" "2" "$sleep_calls"
+teardown_mock
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+
+echo ""
+echo "================================================"
+echo "Results: ${PASS} passed, ${FAIL} failed"
+
+if [[ $FAIL -gt 0 ]]; then
+    exit 1
+fi
+exit 0

--- a/tools/reconciler/tests/test-api-xtrace-init.sh
+++ b/tools/reconciler/tests/test-api-xtrace-init.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# tests/test-api-xtrace-init.sh — Verify AGAMEMNON_API_KEY init in api.sh does not leak under xtrace
+#
+# Issue #429: the source-time assignment `AGAMEMNON_API_KEY="${AGAMEMNON_API_KEY:-}"` at the top
+# of scripts/lib/api.sh was a secondary xtrace leak path. A set +x guard was added around it.
+# These tests verify that guard works correctly.
+#
+# Tests:
+#   1. Token value does not appear in xtrace when api.sh is sourced under bash -x
+#   2. AGAMEMNON_API_KEY is correctly set after the guard (functional check)
+#   3. Xtrace is restored after sourcing (a statement after source still traces)
+#   4. Guard does not enable xtrace when it was off before sourcing
+#
+# Usage:
+#   ./tests/test-api-xtrace-init.sh
+#
+# Exit codes:
+#   0 = all tests passed
+#   1 = one or more tests failed
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+PASS=0
+FAIL=0
+
+_pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+_fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+assert_not_contains() {
+    local desc="$1" needle="$2" haystack="$3"
+    if [[ "$haystack" != *"$needle"* ]]; then
+        _pass "$desc"
+    else
+        _fail "$desc — found '${needle}' in output (should be hidden)"
+    fi
+}
+
+assert_contains() {
+    local desc="$1" needle="$2" haystack="$3"
+    if [[ "$haystack" == *"$needle"* ]]; then
+        _pass "$desc"
+    else
+        _fail "$desc — expected '${needle}' not found in output"
+    fi
+}
+
+echo "Running api source-time xtrace init tests..."
+echo ""
+
+# ── Test 1: Token value does not appear in xtrace when api.sh is sourced ─────
+# The key is passed via the environment so the caller's own assignment does not
+# appear in the xtrace — we only want to verify that api.sh's internal re-init
+# `AGAMEMNON_API_KEY="${AGAMEMNON_API_KEY:-}"` does not re-echo the token.
+_XTRACE_OUT="$(AGAMEMNON_API_KEY=init-secret-token-1 bash -x -c "
+    AGAMEMNON_URL=http://localhost:9999
+    source '${REPO_ROOT}/scripts/lib/api.sh'
+" 2>&1 >/dev/null)"
+assert_not_contains "source-time init: token not in xtrace" \
+    "init-secret-token-1" "$_XTRACE_OUT"
+
+# ── Test 2: AGAMEMNON_API_KEY is correctly set after source ───────────────────
+_VALUE_CHECK="$(bash -c "
+    AGAMEMNON_URL=http://localhost:9999
+    AGAMEMNON_API_KEY=init-secret-token-2
+    source '${REPO_ROOT}/scripts/lib/api.sh'
+    echo \"\${AGAMEMNON_API_KEY}\"
+" 2>/dev/null)"
+assert_contains "source-time init: AGAMEMNON_API_KEY correctly set" \
+    "init-secret-token-2" "$_VALUE_CHECK"
+
+# ── Test 3: Xtrace is restored after sourcing api.sh ─────────────────────────
+_RESTORE_CHECK="$(bash -x -c "
+    AGAMEMNON_URL=http://localhost:9999
+    AGAMEMNON_API_KEY=init-canary-restore
+    source '${REPO_ROOT}/scripts/lib/api.sh'
+    echo XTRACE_STILL_ON
+" 2>&1)"
+assert_contains "xtrace restored after source: echo command traced" \
+    "+ echo XTRACE_STILL_ON" "$_RESTORE_CHECK"
+
+# ── Test 4: Guard does not enable xtrace when it was off ─────────────────────
+_NO_XTRACE_CHECK="$(bash +x -c "
+    AGAMEMNON_URL=http://localhost:9999
+    AGAMEMNON_API_KEY=init-secret-token-4
+    source '${REPO_ROOT}/scripts/lib/api.sh'
+    echo AFTER_SOURCE
+" 2>&1)"
+assert_contains "xtrace-off path: echo still works after source" \
+    "AFTER_SOURCE" "$_NO_XTRACE_CHECK"
+assert_not_contains "xtrace-off path: no xtrace lines introduced by source" \
+    "+ source" "$_NO_XTRACE_CHECK"
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+
+echo ""
+echo "================================================"
+echo "Results: ${PASS} passed, ${FAIL} failed"
+
+if [[ $FAIL -gt 0 ]]; then
+    exit 1
+fi
+exit 0

--- a/tools/reconciler/tests/test-api-xtrace.sh
+++ b/tools/reconciler/tests/test-api-xtrace.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# tests/test-api-xtrace.sh — Verify AGAMEMNON_API_KEY does not leak in xtrace output
+#
+# The issue: curl invocations expand "-H Authorization: Bearer ${AGAMEMNON_API_KEY}"
+# under bash -x / set -x, printing the token to the trace log. Guards in api.sh
+# suppress xtrace during header construction and curl calls. These tests verify:
+#   1. The Authorization/X-API-Key header values do not appear in xtrace output.
+#   2. The _AUTH_HEADERS array is still correctly populated (guard doesn't break function).
+#   3. Xtrace is restored to its prior state after the guarded section.
+#   4. No headers are built when AGAMEMNON_API_KEY is unset.
+#
+# What is NOT tested (and is intentionally out of scope):
+#   - "export AGAMEMNON_API_KEY=..." in caller scripts — that is caller responsibility.
+#
+# Source-time variable init (issue #429) is covered by tests/test-api-xtrace-init.sh.
+#
+# Usage:
+#   ./tests/test-api-xtrace.sh
+#
+# Exit codes:
+#   0 = all tests passed
+#   1 = one or more tests failed
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+PASS=0
+FAIL=0
+
+_pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+_fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+assert_not_contains() {
+    local desc="$1" needle="$2" haystack="$3"
+    if [[ "$haystack" != *"$needle"* ]]; then
+        _pass "$desc"
+    else
+        _fail "$desc — found '${needle}' in output (should be hidden)"
+    fi
+}
+
+assert_contains() {
+    local desc="$1" needle="$2" haystack="$3"
+    if [[ "$haystack" == *"$needle"* ]]; then
+        _pass "$desc"
+    else
+        _fail "$desc — expected '${needle}' not found in output"
+    fi
+}
+
+echo "Running api xtrace leak tests..."
+echo ""
+
+# ── Test 1: Authorization header value does not appear in xtrace ──────────────
+# Run a subshell with bash -x and capture stderr (where xtrace goes).
+# The "Authorization: Bearer <token>" string must not appear in the trace.
+# Note: "export AGAMEMNON_API_KEY=<token>" from the caller IS expected in trace;
+# we check specifically that the header string is not traced.
+_XTRACE_OUT="$(bash -x -c "
+    AGAMEMNON_URL=http://localhost:9999
+    AGAMEMNON_API_KEY=supersecret-token-1
+    source '${REPO_ROOT}/scripts/lib/api.sh'
+    _agamemnon_auth_headers
+" 2>&1 >/dev/null)"
+assert_not_contains "_agamemnon_auth_headers: Authorization Bearer not in xtrace" \
+    "Authorization: Bearer supersecret-token-1" "$_XTRACE_OUT"
+assert_not_contains "_agamemnon_auth_headers: X-API-Key not in xtrace" \
+    "X-API-Key: supersecret-token-1" "$_XTRACE_OUT"
+
+# ── Test 2: _AUTH_HEADERS array is still populated correctly ──────────────────
+# Functional check: the guard must not break header population.
+_HEADERS_CHECK="$(bash -c "
+    AGAMEMNON_URL=http://localhost:9999
+    AGAMEMNON_API_KEY=supersecret-token-2
+    source '${REPO_ROOT}/scripts/lib/api.sh'
+    _agamemnon_auth_headers
+    echo \"\${_AUTH_HEADERS[*]}\"
+" 2>/dev/null)"
+assert_contains "_agamemnon_auth_headers: Authorization header populated" \
+    "Authorization: Bearer supersecret-token-2" "$_HEADERS_CHECK"
+assert_contains "_agamemnon_auth_headers: X-API-Key header populated" \
+    "X-API-Key: supersecret-token-2" "$_HEADERS_CHECK"
+
+# ── Test 3: Authorization header value does not leak from _agamemnon_curl_retry ─
+# Override curl in the subshell to avoid network calls, then check xtrace output.
+_RETRY_XTRACE="$(bash -x -c "
+    AGAMEMNON_URL=http://localhost:9999
+    AGAMEMNON_API_KEY=supersecret-token-3
+    # Stub curl: write an empty body and return HTTP 200
+    curl() {
+        local args=(\"\$@\")
+        local i
+        for (( i=0; i<\${#args[@]}; i++ )); do
+            if [[ \"\${args[\$i]}\" == \"-o\" ]]; then
+                echo '{}' > \"\${args[\$((i+1))]}\"; break
+            fi
+        done
+        echo -n '200'
+        return 0
+    }
+    source '${REPO_ROOT}/scripts/lib/api.sh'
+    _agamemnon_curl_retry 'http://localhost:9999/v1/agents' >/dev/null
+" 2>&1 >/dev/null)"
+assert_not_contains "_agamemnon_curl_retry: Authorization Bearer not in xtrace" \
+    "Authorization: Bearer supersecret-token-3" "$_RETRY_XTRACE"
+assert_not_contains "_agamemnon_curl_retry: X-API-Key not in xtrace" \
+    "X-API-Key: supersecret-token-3" "$_RETRY_XTRACE"
+
+# ── Test 4: xtrace is restored after _agamemnon_auth_headers ──────────────────
+# If xtrace was on before the call, it must be on after. We verify by checking
+# that a statement AFTER the call still appears in the xtrace output.
+_RESTORE_CHECK="$(bash -x -c "
+    AGAMEMNON_URL=http://localhost:9999
+    AGAMEMNON_API_KEY=canary-restore-token
+    source '${REPO_ROOT}/scripts/lib/api.sh'
+    _agamemnon_auth_headers
+    echo XTRACE_STILL_ON
+" 2>&1)"
+assert_contains "xtrace restored after _agamemnon_auth_headers" \
+    "XTRACE_STILL_ON" "$_RESTORE_CHECK"
+assert_contains "xtrace re-enabled: echo command traced" \
+    "+ echo XTRACE_STILL_ON" "$_RESTORE_CHECK"
+
+# ── Test 5: no-auth path unchanged — empty key produces no headers ────────────
+_NO_KEY_CHECK="$(bash -c "
+    AGAMEMNON_URL=http://localhost:9999
+    unset AGAMEMNON_API_KEY
+    source '${REPO_ROOT}/scripts/lib/api.sh'
+    _agamemnon_auth_headers
+    echo \"\${#_AUTH_HEADERS[@]}\"
+" 2>/dev/null)"
+if [[ "$_NO_KEY_CHECK" == "0" ]]; then
+    _pass "no-auth path: empty key yields empty _AUTH_HEADERS"
+else
+    _fail "no-auth path: expected 0 headers, got ${_NO_KEY_CHECK}"
+fi
+
+# ── Test 6: xtrace guard does not enable xtrace when it was off ───────────────
+# If xtrace is OFF before the call, it must remain OFF after.
+_NO_XTRACE_CHECK="$(bash +x -c "
+    AGAMEMNON_URL=http://localhost:9999
+    AGAMEMNON_API_KEY=supersecret-token-6
+    source '${REPO_ROOT}/scripts/lib/api.sh'
+    _agamemnon_auth_headers
+    echo AFTER_CALL
+" 2>&1)"
+# In non-xtrace mode, the output should contain AFTER_CALL (from echo) but no +/-x traces
+assert_contains "xtrace-off path: echo still works" "AFTER_CALL" "$_NO_XTRACE_CHECK"
+assert_not_contains "xtrace-off path: no xtrace lines introduced" \
+    "+ _agamemnon_auth_headers" "$_NO_XTRACE_CHECK"
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+
+echo ""
+echo "================================================"
+echo "Results: ${PASS} passed, ${FAIL} failed"
+
+if [[ $FAIL -gt 0 ]]; then
+    exit 1
+fi
+exit 0

--- a/tools/reconciler/tests/test-apply-cache.sh
+++ b/tools/reconciler/tests/test-apply-cache.sh
@@ -1,0 +1,362 @@
+#!/usr/bin/env bash
+# tests/test-apply-cache.sh — Verify apply.sh makes O(1) agamemnon_list_agents calls
+#
+# These tests mock the Agamemnon API functions and source apply.sh internals
+# to assert that the reconciliation loop does not re-fetch the agent list after
+# every operation. See issue #6.
+#
+# Usage:
+#   bash tests/test-apply-cache.sh
+#   # Exit code 0 = all tests passed, non-zero = failure
+
+set -euo pipefail
+
+# Skip entire file on bash < 4 ([[ ]], arrays with [@], and other features require bash 4+)
+if (( BASH_VERSINFO[0] < 4 )); then
+    echo "SKIP: bash 4+ required (got ${BASH_VERSION})" >&2
+    exit 0
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+PASS=0
+FAIL=0
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+_assert_eq() {
+    local desc="$1" expected="$2" actual="$3"
+    if [[ "$expected" == "$actual" ]]; then
+        echo "  PASS: ${desc}"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: ${desc}"
+        echo "        expected: ${expected}"
+        echo "        actual:   ${actual}"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Create a temporary YAML agent fixture and print its path.
+_make_agent_yaml() {
+    local name="$1"
+    local desired_state="${2:-active}"
+    local tmpfile
+    tmpfile="$(mktemp /tmp/test-agent-XXXXXX.yaml)"
+    cat > "$tmpfile" <<YAML
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: ${name}
+  host: hermes
+spec:
+  label: ${name}
+  program: claude-code
+  model: null
+  workingDirectory: /tmp
+  programArgs: ""
+  taskDescription: "test agent"
+  tags: []
+  owner: testuser
+  role: member
+  deployment:
+    type: local
+  desiredState: ${desired_state}
+YAML
+    echo "$tmpfile"
+}
+
+# ── test scaffolding ──────────────────────────────────────────────────────────
+#
+# We source reconcile.sh and api.sh, then override the API functions with mocks
+# before sourcing the apply.sh function definitions. apply.sh calls `main "$@"`
+# at the bottom, so we prevent that by defining a guard variable.
+
+_setup_env() {
+    export AGAMEMNON_URL="http://mock-agamemnon"
+    # Use a temp file to count calls across subshell boundaries.
+    export _LIST_CALL_COUNT_FILE
+    _LIST_CALL_COUNT_FILE="$(mktemp)"
+    echo "0" > "$_LIST_CALL_COUNT_FILE"
+
+    # Override check_deps so we don't need yq/jq/curl on PATH to be Agamemnon-aware
+    check_deps() { return 0; }
+    agamemnon_check_connection() { return 0; }
+}
+
+_get_list_call_count() {
+    cat "$_LIST_CALL_COUNT_FILE"
+}
+
+# ── mock factories ────────────────────────────────────────────────────────────
+
+# Mock agamemnon_list_agents: increments counter file, returns provided JSON.
+_mock_list_agents() {
+    local fixture_json="$1"
+    # Export fixture so subshells can access it
+    export _LIST_AGENTS_FIXTURE="$fixture_json"
+    agamemnon_list_agents() {
+        local c
+        c="$(cat "$_LIST_CALL_COUNT_FILE")"
+        echo "$((c + 1))" > "$_LIST_CALL_COUNT_FILE"
+        echo "$_LIST_AGENTS_FIXTURE"
+    }
+}
+
+# Mock agamemnon_create_agent: returns a new agent JSON with a generated id.
+_mock_create_agent() {
+    local new_agent_json="$1"
+    eval "agamemnon_create_agent() { echo '${new_agent_json}'; }"
+}
+
+# Mock other mutating calls to no-ops.
+_mock_mutating_calls() {
+    agamemnon_wake_agent()      { return 0; }
+    agamemnon_hibernate_agent() { return 0; }
+    agamemnon_update_agent()    { return 0; }
+    agamemnon_delete_agent()    { return 0; }
+}
+
+# ── source apply.sh without running main() ───────────────────────────────────
+#
+# apply.sh ends with `main "$@"`. We prevent that by overriding main before
+# sourcing, then restoring after.
+
+_source_apply_functions() {
+    local apply_sh="${REPO_ROOT}/scripts/apply.sh"
+
+    # Source the lib dependencies directly with their real paths.
+    # shellcheck source=scripts/lib/config.sh
+    source "${REPO_ROOT}/scripts/lib/config.sh"
+    # shellcheck source=scripts/lib/api.sh
+    source "${REPO_ROOT}/scripts/lib/api.sh"
+    # shellcheck source=scripts/lib/reconcile.sh
+    source "${REPO_ROOT}/scripts/lib/reconcile.sh"
+    # shellcheck source=scripts/lib/report.sh
+    source "${REPO_ROOT}/scripts/lib/report.sh"
+
+    # Eval apply.sh stripping lines that would re-source libs or run main.
+    # Also strip SCRIPT_DIR/REPO_ROOT setup (already set) and shebang/set lines.
+    local stripped
+    stripped="$(grep -v \
+        -e '^#!/' \
+        -e '^set -' \
+        -e 'SCRIPT_DIR=' \
+        -e 'REPO_ROOT=' \
+        -e '# shellcheck' \
+        -e '^source ' \
+        -e '^main "\$@"$' \
+        "$apply_sh")"
+    eval "$stripped"
+}
+
+# ── test cases ────────────────────────────────────────────────────────────────
+
+test_no_creates_one_list_call() {
+    echo ""
+    echo "Test: all-unchanged run makes exactly 1 agamemnon_list_agents call"
+
+    _setup_env
+
+    # Fixture: two existing agents
+    local fixture
+    fixture='[{"id":"id-alpha","name":"alpha","status":"online","label":"alpha","program":"claude-code","workingDirectory":"/tmp","programArgs":"","taskDescription":"test agent","tags":""},{"id":"id-beta","name":"beta","status":"online","label":"beta","program":"claude-code","workingDirectory":"/tmp","programArgs":"","taskDescription":"test agent","tags":""}]'
+
+    _mock_list_agents "$fixture"
+    _mock_mutating_calls
+
+    # Two YAML files that match the existing agents exactly (will be UNCHANGED)
+    local yaml_alpha yaml_beta
+    yaml_alpha="$(_make_agent_yaml alpha active)"
+    yaml_beta="$(_make_agent_yaml beta active)"
+
+    # Run the reconciliation loop directly (bypass main's arg parsing / dep check)
+    local agents_json
+    agents_json="$(agamemnon_list_agents)"
+    local yaml_files=("$yaml_alpha" "$yaml_beta")
+
+    for yaml_file in "${yaml_files[@]}"; do
+        _LAST_CREATED_AGENT_JSON=""
+        # The test asserts on list-call count, not on apply_agent's rc. Capture
+        # rc explicitly so a regression in apply_agent's exit semantics is
+        # still visible in the test transcript (rather than silently masked).
+        _apply_rc=0
+        apply_agent "$yaml_file" "$agents_json" > /dev/null 2>&1 || _apply_rc=$?
+        if [[ "$_apply_rc" -ne 0 ]]; then
+            echo "  (apply_agent rc=${_apply_rc} — not asserted)" >&2
+        fi
+        if [[ -n "$_LAST_CREATED_AGENT_JSON" ]]; then
+            agents_json="$(echo "$agents_json" | jq --argjson new "$_LAST_CREATED_AGENT_JSON" '. + [$new]')"
+        fi
+    done
+
+    rm -f "$yaml_alpha" "$yaml_beta"
+
+    # Initial fetch counts as 1; loop should add 0 more.
+    _assert_eq "list call count == 1 (no creates)" "1" "$(_get_list_call_count)"
+}
+
+test_creates_update_cache_without_refetch() {
+    echo ""
+    echo "Test: k creates cause 1 list call total (cache updated in-memory)"
+
+    _setup_env
+
+    # Fixture: no existing agents
+    local fixture='[]'
+    _mock_list_agents "$fixture"
+    _mock_mutating_calls
+
+    # Mock create to return a new agent JSON
+    local new_agent='{"id":"new-id-1","name":"gamma","status":"offline","label":"gamma","program":"claude-code","workingDirectory":"/tmp","programArgs":"","taskDescription":"test agent","tags":""}'
+    _mock_create_agent "$new_agent"
+
+    local yaml_gamma
+    yaml_gamma="$(_make_agent_yaml gamma active)"
+
+    local agents_json
+    agents_json="$(agamemnon_list_agents)"
+    local yaml_files=("$yaml_gamma")
+
+    for yaml_file in "${yaml_files[@]}"; do
+        _LAST_CREATED_AGENT_JSON=""
+        # The test asserts on list-call count, not on apply_agent's rc. Capture
+        # rc explicitly so a regression in apply_agent's exit semantics is
+        # still visible in the test transcript (rather than silently masked).
+        _apply_rc=0
+        apply_agent "$yaml_file" "$agents_json" > /dev/null 2>&1 || _apply_rc=$?
+        if [[ "$_apply_rc" -ne 0 ]]; then
+            echo "  (apply_agent rc=${_apply_rc} — not asserted)" >&2
+        fi
+        if [[ -n "$_LAST_CREATED_AGENT_JSON" ]]; then
+            agents_json="$(echo "$agents_json" | jq --argjson new "$_LAST_CREATED_AGENT_JSON" '. + [$new]')"
+        fi
+    done
+
+    rm -f "$yaml_gamma"
+
+    # 1 initial fetch; create should NOT trigger another list call.
+    _assert_eq "list call count == 1 after 1 create" "1" "$(_get_list_call_count)"
+}
+
+test_cache_contains_new_agent_after_create() {
+    echo ""
+    echo "Test: agents_json cache contains new agent entry after create"
+
+    _setup_env
+
+    local fixture='[]'
+    _mock_list_agents "$fixture"
+    _mock_mutating_calls
+
+    local new_agent='{"id":"new-id-2","name":"delta","status":"offline","label":"delta","program":"claude-code","workingDirectory":"/tmp","programArgs":"","taskDescription":"test agent","tags":""}'
+    _mock_create_agent "$new_agent"
+
+    local yaml_delta
+    yaml_delta="$(_make_agent_yaml delta active)"
+
+    local agents_json
+    agents_json="$(agamemnon_list_agents)"
+    local yaml_files=("$yaml_delta")
+
+    for yaml_file in "${yaml_files[@]}"; do
+        _LAST_CREATED_AGENT_JSON=""
+        # The test asserts on list-call count, not on apply_agent's rc. Capture
+        # rc explicitly so a regression in apply_agent's exit semantics is
+        # still visible in the test transcript (rather than silently masked).
+        _apply_rc=0
+        apply_agent "$yaml_file" "$agents_json" > /dev/null 2>&1 || _apply_rc=$?
+        if [[ "$_apply_rc" -ne 0 ]]; then
+            echo "  (apply_agent rc=${_apply_rc} — not asserted)" >&2
+        fi
+        if [[ -n "$_LAST_CREATED_AGENT_JSON" ]]; then
+            agents_json="$(echo "$agents_json" | jq --argjson new "$_LAST_CREATED_AGENT_JSON" '. + [$new]')"
+        fi
+    done
+
+    rm -f "$yaml_delta"
+
+    # The cache should now contain the new agent
+    local found_id
+    found_id="$(echo "$agents_json" | jq -r '.[] | select(.name == "delta") | .id')"
+    _assert_eq "new agent id in cache after create" "new-id-2" "$found_id"
+}
+
+test_multiple_creates_single_list_call() {
+    echo ""
+    echo "Test: 3 creates still produce only 1 agamemnon_list_agents call"
+
+    _setup_env
+
+    local fixture='[]'
+    _mock_list_agents "$fixture"
+    _mock_mutating_calls
+
+    # Each create returns a different agent; use a file counter to survive subshells.
+    local _create_count_file
+    _create_count_file="$(mktemp)"
+    echo "0" > "$_create_count_file"
+    export _create_count_file
+    agamemnon_create_agent() {
+        local c
+        c="$(cat "$_create_count_file")"
+        c=$((c + 1))
+        echo "$c" > "$_create_count_file"
+        echo "{\"id\":\"new-id-${c}\",\"name\":\"agent${c}\",\"status\":\"offline\",\"label\":\"agent${c}\",\"program\":\"claude-code\",\"workingDirectory\":\"/tmp\",\"programArgs\":\"\",\"taskDescription\":\"test agent\",\"tags\":\"\"}"
+    }
+
+    local y1 y2 y3
+    y1="$(_make_agent_yaml agent1 active)"
+    y2="$(_make_agent_yaml agent2 active)"
+    y3="$(_make_agent_yaml agent3 active)"
+
+    local agents_json
+    agents_json="$(agamemnon_list_agents)"
+    local yaml_files=("$y1" "$y2" "$y3")
+
+    for yaml_file in "${yaml_files[@]}"; do
+        _LAST_CREATED_AGENT_JSON=""
+        # The test asserts on list-call count, not on apply_agent's rc. Capture
+        # rc explicitly so a regression in apply_agent's exit semantics is
+        # still visible in the test transcript (rather than silently masked).
+        _apply_rc=0
+        apply_agent "$yaml_file" "$agents_json" > /dev/null 2>&1 || _apply_rc=$?
+        if [[ "$_apply_rc" -ne 0 ]]; then
+            echo "  (apply_agent rc=${_apply_rc} — not asserted)" >&2
+        fi
+        if [[ -n "$_LAST_CREATED_AGENT_JSON" ]]; then
+            agents_json="$(echo "$agents_json" | jq --argjson new "$_LAST_CREATED_AGENT_JSON" '. + [$new]')"
+        fi
+    done
+
+    rm -f "$y1" "$y2" "$y3" "$_create_count_file"
+
+    _assert_eq "list call count == 1 after 3 creates" "1" "$(_get_list_call_count)"
+
+    # All 3 created agents should be in the cache
+    local cache_count
+    cache_count="$(echo "$agents_json" | jq 'length')"
+    _assert_eq "cache contains all 3 created agents" "3" "$cache_count"
+}
+
+# ── run ───────────────────────────────────────────────────────────────────────
+
+echo "================================================"
+echo "apply.sh cache optimization tests (issue #6)"
+echo "================================================"
+
+# Source apply.sh function definitions (without running main)
+_source_apply_functions
+
+test_no_creates_one_list_call
+test_creates_update_cache_without_refetch
+test_cache_contains_new_agent_after_create
+test_multiple_creates_single_list_call
+
+echo ""
+echo "================================================"
+echo "Results: ${PASS} passed, ${FAIL} failed"
+echo "================================================"
+
+[[ $FAIL -eq 0 ]]

--- a/tools/reconciler/tests/test-compute-drift.sh
+++ b/tools/reconciler/tests/test-compute-drift.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# tests/test-compute-drift.sh — Unit tests for compute_drift() in scripts/lib/reconcile.sh
+#
+# Tests that model, owner, role, and deployment.type drift is detected correctly,
+# and that existing fields still work (regression).
+#
+# Usage:
+#   ./tests/test-compute-drift.sh
+#
+# Exit codes:
+#   0 = all tests passed
+#   1 = one or more tests failed
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# shellcheck source=scripts/lib/reconcile.sh
+source "${REPO_ROOT}/scripts/lib/reconcile.sh"
+
+PASS=0
+FAIL=0
+
+# assert_eq DESCRIPTION EXPECTED ACTUAL
+assert_eq() {
+    local desc="$1" expected="$2" actual="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        echo "  PASS: $desc"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $desc"
+        echo "        expected: $expected"
+        echo "        actual:   $actual"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Base JSON that matches desired state — used as a starting point; override fields per test
+BASE_JSON='{"status":"online","label":"MyAgent","program":"claude-code","workingDirectory":"/home/user/project","programArgs":"","taskDescription":"Does stuff","tags":[],"model":"claude-sonnet-4-6","owner":"mvillmow","role":"member","deployment":{"type":"local"}}'
+
+echo "=== compute_drift() unit tests ==="
+echo ""
+
+echo "--- UNCHANGED / baseline ---"
+
+result="$(compute_drift "test" "active" "$BASE_JSON" \
+    "MyAgent" "claude-code" "/home/user/project" "" "Does stuff" "" \
+    "claude-sonnet-4-6" "mvillmow" "member" "local")"
+assert_eq "all fields match → UNCHANGED" "UNCHANGED" "$result"
+
+echo ""
+echo "--- model drift ---"
+
+result="$(compute_drift "test" "active" "$BASE_JSON" \
+    "MyAgent" "claude-code" "/home/user/project" "" "Does stuff" "" \
+    "claude-opus-4-6" "mvillmow" "member" "local")"
+assert_eq "model changed → UPDATE:model" "UPDATE:model" "$result"
+
+# API returns null model — desired is empty string (null YAML)
+NULL_MODEL_JSON='{"status":"online","label":"MyAgent","program":"claude-code","workingDirectory":"/home/user/project","programArgs":"","taskDescription":"Does stuff","tags":[],"model":null,"owner":"mvillmow","role":"member","deployment":{"type":"local"}}'
+result="$(compute_drift "test" "active" "$NULL_MODEL_JSON" \
+    "MyAgent" "claude-code" "/home/user/project" "" "Does stuff" "" \
+    "" "mvillmow" "member" "local")"
+assert_eq "null model vs empty desired → UNCHANGED (null normalization)" "UNCHANGED" "$result"
+
+echo ""
+echo "--- owner drift ---"
+
+result="$(compute_drift "test" "active" "$BASE_JSON" \
+    "MyAgent" "claude-code" "/home/user/project" "" "Does stuff" "" \
+    "claude-sonnet-4-6" "other-user" "member" "local")"
+assert_eq "owner changed → UPDATE:owner" "UPDATE:owner" "$result"
+
+echo ""
+echo "--- role drift ---"
+
+result="$(compute_drift "test" "active" "$BASE_JSON" \
+    "MyAgent" "claude-code" "/home/user/project" "" "Does stuff" "" \
+    "claude-sonnet-4-6" "mvillmow" "admin" "local")"
+assert_eq "role changed → UPDATE:role" "UPDATE:role" "$result"
+
+echo ""
+echo "--- deployment.type drift ---"
+
+result="$(compute_drift "test" "active" "$BASE_JSON" \
+    "MyAgent" "claude-code" "/home/user/project" "" "Does stuff" "" \
+    "claude-sonnet-4-6" "mvillmow" "member" "docker")"
+assert_eq "deploymentType changed → UPDATE:deploymentType" "UPDATE:deploymentType" "$result"
+
+echo ""
+echo "--- multiple new fields drift ---"
+
+result="$(compute_drift "test" "active" "$BASE_JSON" \
+    "MyAgent" "claude-code" "/home/user/project" "" "Does stuff" "" \
+    "claude-opus-4-6" "other-user" "admin" "docker")"
+assert_eq "model+owner+role+deploymentType changed → UPDATE contains all 4" \
+    "UPDATE:model,owner,role,deploymentType" "$result"
+
+echo ""
+echo "--- regression: existing fields still detected ---"
+
+result="$(compute_drift "test" "active" "$BASE_JSON" \
+    "NewLabel" "claude-code" "/home/user/project" "" "Does stuff" "" \
+    "claude-sonnet-4-6" "mvillmow" "member" "local")"
+assert_eq "label changed → UPDATE:label" "UPDATE:label" "$result"
+
+result="$(compute_drift "test" "active" "$BASE_JSON" \
+    "MyAgent" "aider" "/home/user/project" "" "Does stuff" "" \
+    "claude-sonnet-4-6" "mvillmow" "member" "local")"
+assert_eq "program changed → UPDATE:program" "UPDATE:program" "$result"
+
+result="$(compute_drift "test" "active" "$BASE_JSON" \
+    "MyAgent" "claude-code" "/home/user/other" "" "Does stuff" "" \
+    "claude-sonnet-4-6" "mvillmow" "member" "local")"
+assert_eq "workingDirectory changed → UPDATE:workingDirectory" "UPDATE:workingDirectory" "$result"
+
+result="$(compute_drift "test" "active" "$BASE_JSON" \
+    "MyAgent" "claude-code" "/home/user/project" "--verbose" "Does stuff" "" \
+    "claude-sonnet-4-6" "mvillmow" "member" "local")"
+assert_eq "programArgs changed → UPDATE:programArgs" "UPDATE:programArgs" "$result"
+
+result="$(compute_drift "test" "active" "$BASE_JSON" \
+    "MyAgent" "claude-code" "/home/user/project" "" "Different desc" "" \
+    "claude-sonnet-4-6" "mvillmow" "member" "local")"
+assert_eq "taskDescription changed → UPDATE:taskDescription" "UPDATE:taskDescription" "$result"
+
+echo ""
+echo "--- regression: WAKE / HIBERNATE still work ---"
+
+OFFLINE_JSON='{"status":"offline","label":"MyAgent","program":"claude-code","workingDirectory":"/home/user/project","programArgs":"","taskDescription":"Does stuff","tags":[],"model":"claude-sonnet-4-6","owner":"mvillmow","role":"member","deployment":{"type":"local"}}'
+result="$(compute_drift "test" "active" "$OFFLINE_JSON" \
+    "MyAgent" "claude-code" "/home/user/project" "" "Does stuff" "" \
+    "claude-sonnet-4-6" "mvillmow" "member" "local")"
+assert_eq "desired=active, actual=offline → WAKE" "WAKE" "$result"
+
+ONLINE_JSON='{"status":"online","label":"MyAgent","program":"claude-code","workingDirectory":"/home/user/project","programArgs":"","taskDescription":"Does stuff","tags":[],"model":"claude-sonnet-4-6","owner":"mvillmow","role":"member","deployment":{"type":"local"}}'
+result="$(compute_drift "test" "hibernated" "$ONLINE_JSON" \
+    "MyAgent" "claude-code" "/home/user/project" "" "Does stuff" "" \
+    "claude-sonnet-4-6" "mvillmow" "member" "local")"
+assert_eq "desired=hibernated, actual=online → HIBERNATE" "HIBERNATE" "$result"
+
+echo ""
+echo "==================================="
+echo "Results: ${PASS} passed, ${FAIL} failed"
+echo ""
+
+if [[ $FAIL -gt 0 ]]; then
+    exit 1
+fi
+exit 0

--- a/tools/reconciler/tests/test-doctor-xtrace.sh
+++ b/tools/reconciler/tests/test-doctor-xtrace.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# tests/test-doctor-xtrace.sh — Verify AGAMEMNON_API_KEY does not leak from doctor.sh
+#
+# doctor.sh's check_connectivity() makes two curl calls to /v1/health and /v1/agents.
+# After the fix in issue #430, these calls are guarded with the standard xtrace pattern
+# so that AGAMEMNON_API_KEY does not appear in bash -x trace output.
+#
+# Usage:
+#   ./tests/test-doctor-xtrace.sh
+#
+# Exit codes:
+#   0 = all tests passed
+#   1 = one or more tests failed
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+PASS=0
+FAIL=0
+
+_pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+_fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+assert_not_contains() {
+    local desc="$1" needle="$2" haystack="$3"
+    if [[ "$haystack" != *"$needle"* ]]; then
+        _pass "$desc"
+    else
+        _fail "$desc — found '${needle}' in output (should be hidden)"
+    fi
+}
+
+assert_contains() {
+    local desc="$1" needle="$2" haystack="$3"
+    if [[ "$haystack" == *"$needle"* ]]; then
+        _pass "$desc"
+    else
+        _fail "$desc — expected '${needle}' not found in output"
+    fi
+}
+
+echo "Running doctor.sh xtrace leak tests..."
+echo ""
+
+# ── Test 1: AGAMEMNON_API_KEY does not appear in xtrace for health check ────────
+# Uses a function to allow `local` declarations; stubs curl to avoid network calls.
+_XTRACE_OUT="$(bash -x -c "
+    _run_connectivity_check() {
+        AGAMEMNON_URL=http://localhost:9999
+        AGAMEMNON_API_KEY=super-secret-doctor-key
+        curl() { echo -n '200'; return 0; }
+        export -f curl
+        source '${REPO_ROOT}/scripts/lib/api.sh'
+        _agamemnon_auth_headers
+        local _had_xtrace=0
+        if [[ \"\$-\" == *x* ]]; then _had_xtrace=1; fi
+        { set +x; } 2>/dev/null
+        local http_code
+        http_code=\"\$(curl -s --max-time 5 -o /dev/null -w '%{http_code}' \
+            \"\${_AUTH_HEADERS[@]+\"\${_AUTH_HEADERS[@]}\"}\" \
+            'http://localhost:9999/v1/health' 2>/dev/null)\" || http_code='000'
+        if [[ \$_had_xtrace -eq 1 ]]; then set -x; fi
+        echo \"health:\$http_code\"
+    }
+    _run_connectivity_check
+" 2>&1 >/dev/null)"
+assert_not_contains "doctor health check: Authorization Bearer not in xtrace" \
+    "Authorization: Bearer super-secret-doctor-key" "$_XTRACE_OUT"
+assert_not_contains "doctor health check: X-API-Key not in xtrace" \
+    "X-API-Key: super-secret-doctor-key" "$_XTRACE_OUT"
+
+# ── Test 2: xtrace is restored after the health check guard ─────────────────────
+_RESTORE_OUT="$(bash -x -c "
+    _run_restore_check() {
+        AGAMEMNON_URL=http://localhost:9999
+        AGAMEMNON_API_KEY=canary-restore-key
+        curl() { echo -n '200'; return 0; }
+        export -f curl
+        source '${REPO_ROOT}/scripts/lib/api.sh'
+        _agamemnon_auth_headers
+        local _had_xtrace=0
+        if [[ \"\$-\" == *x* ]]; then _had_xtrace=1; fi
+        { set +x; } 2>/dev/null
+        local http_code
+        http_code=\"\$(curl -s --max-time 5 -o /dev/null -w '%{http_code}' \
+            \"\${_AUTH_HEADERS[@]+\"\${_AUTH_HEADERS[@]}\"}\" \
+            'http://localhost:9999/v1/health' 2>/dev/null)\" || http_code='000'
+        if [[ \$_had_xtrace -eq 1 ]]; then set -x; fi
+        echo XTRACE_RESTORED
+    }
+    _run_restore_check
+" 2>&1)"
+assert_contains "xtrace restored after health check guard" \
+    "XTRACE_RESTORED" "$_RESTORE_OUT"
+assert_contains "xtrace re-enabled: echo traced after guard" \
+    "+ echo XTRACE_RESTORED" "$_RESTORE_OUT"
+
+# ── Test 3: no-auth path — no headers built, guard still safe ───────────────────
+_NO_KEY_OUT="$(bash -c "
+    unset AGAMEMNON_API_KEY
+    AGAMEMNON_URL=http://localhost:9999
+    source '${REPO_ROOT}/scripts/lib/api.sh'
+    _agamemnon_auth_headers
+    echo \"header_count:\${#_AUTH_HEADERS[@]}\"
+" 2>/dev/null)"
+if [[ "$_NO_KEY_OUT" == *"header_count:0"* ]]; then
+    _pass "doctor no-auth path: empty key yields no headers"
+else
+    _fail "doctor no-auth path: expected header_count:0, got: ${_NO_KEY_OUT}"
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+
+echo ""
+echo "================================================"
+echo "Results: ${PASS} passed, ${FAIL} failed"
+
+if [[ $FAIL -gt 0 ]]; then
+    exit 1
+fi
+exit 0

--- a/tools/reconciler/tests/test-export-default-owner.sh
+++ b/tools/reconciler/tests/test-export-default-owner.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# tests/test-export-default-owner.sh — Unit tests for MYRMIDONS_DEFAULT_OWNER fallback
+#
+# Verifies that export.sh uses MYRMIDONS_DEFAULT_OWNER when set, falls back to
+# $(whoami) when unset, and never contains the hardcoded literal "mvillmow" in
+# any jq expression.
+#
+# Usage:
+#   ./tests/test-export-default-owner.sh
+#
+# Exit codes:
+#   0 = all tests passed
+#   1 = one or more tests failed
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+EXPORT_SH="${REPO_ROOT}/scripts/export.sh"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+    local desc="$1" expected="$2" actual="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        echo "  PASS: ${desc}"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: ${desc}"
+        echo "        expected: ${expected}"
+        echo "        actual:   ${actual}"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_no_match() {
+    local desc="$1" pattern="$2" file="$3"
+    if ! grep -qE "$pattern" "$file"; then
+        echo "  PASS: ${desc}"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: ${desc} — pattern '${pattern}' still found in ${file}"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Helper: extract the resolved owner from the jq expression in export.sh.
+# Simulates the export_agent owner line by evaluating it in a subshell with
+# the given env, passing a synthetic agent JSON with no owner field.
+# ---------------------------------------------------------------------------
+resolve_owner() {
+    local env_var="${1:-}"
+    local agent_json='{"name":"test","label":"Test","program":"claude-code"}'
+
+    if [[ -n "$env_var" ]]; then
+        MYRMIDONS_DEFAULT_OWNER="$env_var" \
+            bash -c "echo '$agent_json' | jq -r --arg default_owner \"\${MYRMIDONS_DEFAULT_OWNER:-\$(whoami)}\" '.owner // \$default_owner'"
+    else
+        # `unset` only fails if the name is read-only or invalid; both would
+        # be bugs we want to know about, so don't suppress the rc.
+        unset MYRMIDONS_DEFAULT_OWNER
+        bash -c "echo '$agent_json' | jq -r --arg default_owner \"\${MYRMIDONS_DEFAULT_OWNER:-\$(whoami)}\" '.owner // \$default_owner'"
+    fi
+}
+
+echo "Testing MYRMIDONS_DEFAULT_OWNER fallback logic..."
+echo ""
+
+echo "=== Env var set ==="
+result="$(resolve_owner "custom-user")"
+assert_eq "MYRMIDONS_DEFAULT_OWNER=custom-user → owner is custom-user" "custom-user" "$result"
+
+echo ""
+echo "=== Env var unset (falls back to whoami) ==="
+expected_whoami="$(whoami)"
+result="$(resolve_owner "")"
+assert_eq "Unset MYRMIDONS_DEFAULT_OWNER → owner matches whoami (${expected_whoami})" "$expected_whoami" "$result"
+
+echo ""
+echo "=== Owner present in API response (env var not used) ==="
+result="$(bash -c "
+    agent_json='{\"name\":\"a\",\"label\":\"A\",\"owner\":\"api-owner\"}'
+    MYRMIDONS_DEFAULT_OWNER=env-user
+    echo \"\$agent_json\" | jq -r --arg default_owner \"\${MYRMIDONS_DEFAULT_OWNER:-\$(whoami)}\" '.owner // \$default_owner'
+")"
+assert_eq "API-supplied owner takes precedence over env var" "api-owner" "$result"
+
+echo ""
+echo "=== Source code does not contain hardcoded 'mvillmow' in a jq expression ==="
+assert_no_match \
+    "No 'mvillmow' literal in a jq fallback expression in export.sh" \
+    'jq.*mvillmow' \
+    "$EXPORT_SH"
+
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+
+if [[ $FAIL -gt 0 ]]; then
+    exit 1
+fi
+exit 0

--- a/tools/reconciler/tests/test-prune-settle.sh
+++ b/tools/reconciler/tests/test-prune-settle.sh
@@ -1,0 +1,268 @@
+#!/usr/bin/env bash
+# tests/test-prune-settle.sh — Verify HIBERNATE_SETTLE_SECONDS replaces magic sleep 2
+#
+# Tests that:
+#   1. apply.sh uses sleep "$HIBERNATE_SETTLE_SECONDS" (not a hardcoded number)
+#   2. The value defaults to 2 when the env var is unset
+#   3. Setting HIBERNATE_SETTLE_SECONDS=0 causes sleep to be called with "0"
+#
+# Usage:
+#   bash tests/test-prune-settle.sh
+#   # Exit code 0 = all tests passed, non-zero = failure
+
+set -euo pipefail
+
+if (( BASH_VERSINFO[0] < 4 )); then
+    echo "SKIP: bash 4+ required (got ${BASH_VERSION})" >&2
+    exit 0
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+APPLY_SH="${REPO_ROOT}/scripts/apply.sh"
+
+PASS=0
+FAIL=0
+
+_assert_eq() {
+    local desc="$1" expected="$2" actual="$3"
+    if [[ "$expected" == "$actual" ]]; then
+        echo "  PASS: ${desc}"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: ${desc}"
+        echo "        expected: ${expected}"
+        echo "        actual:   ${actual}"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# ── test: --help output documents HIBERNATE_SETTLE_SECONDS ───────────────────
+
+test_help_documents_hibernate_settle_seconds() {
+    echo ""
+    echo "Test: --help output mentions HIBERNATE_SETTLE_SECONDS"
+
+    local found
+    found="$(grep -c 'HIBERNATE_SETTLE_SECONDS' "$APPLY_SH" || true)"
+    _assert_eq "HIBERNATE_SETTLE_SECONDS appears in apply.sh" "1" "$([ "$found" -ge 1 ] && echo 1 || echo 0)"
+
+    # Verify it appears specifically in the usage() function body
+    local in_usage
+    in_usage="$(awk '/^usage\(\)/{found=1} found && /HIBERNATE_SETTLE_SECONDS/{print; exit}' "$APPLY_SH")"
+    _assert_eq "HIBERNATE_SETTLE_SECONDS documented in usage()" "1" "$([ -n "$in_usage" ] && echo 1 || echo 0)"
+}
+
+# ── test: static grep — confirm sleep uses the variable, not a literal ────────
+
+test_no_hardcoded_sleep_2() {
+    echo ""
+    echo "Test: apply.sh does not contain hardcoded 'sleep 2'"
+
+    # Allow 'sleep 2' only in comments; the actual call must use the variable.
+    local hardcoded_count
+    hardcoded_count="$(grep -cE '^\s+sleep 2\s*$' "$APPLY_SH" || true)"
+    _assert_eq "no bare 'sleep 2' lines in apply.sh" "0" "$hardcoded_count"
+}
+
+test_sleep_uses_variable() {
+    echo ""
+    echo "Test: apply.sh contains sleep \"\$HIBERNATE_SETTLE_SECONDS\""
+
+    local found
+    found="$(grep -cE 'sleep "\$HIBERNATE_SETTLE_SECONDS"' "$APPLY_SH" || true)"
+    _assert_eq "sleep variable call exists in apply.sh" "1" "$found"
+}
+
+test_default_value_is_2() {
+    echo ""
+    echo "Test: HIBERNATE_SETTLE_SECONDS defaults to 2 when unset"
+
+    local default_line
+    default_line="$(grep 'HIBERNATE_SETTLE_SECONDS=' "$APPLY_SH" | grep ':-2')"
+    _assert_eq "default value is 2" "0" "$( [[ -n "$default_line" ]] && echo 0 || echo 1 )"
+}
+
+# ── test: runtime — mock sleep and confirm it is called with the right value ──
+
+_source_apply_functions() {
+    # shellcheck source=scripts/lib/config.sh
+    source "${REPO_ROOT}/scripts/lib/config.sh"
+    # shellcheck source=scripts/lib/api.sh
+    source "${REPO_ROOT}/scripts/lib/api.sh"
+    # shellcheck source=scripts/lib/reconcile.sh
+    source "${REPO_ROOT}/scripts/lib/reconcile.sh"
+    # shellcheck source=scripts/lib/report.sh
+    source "${REPO_ROOT}/scripts/lib/report.sh"
+
+    local stripped
+    stripped="$(grep -v \
+        -e '^#!/' \
+        -e '^set -' \
+        -e 'SCRIPT_DIR=' \
+        -e 'REPO_ROOT=' \
+        -e '# shellcheck' \
+        -e '^source ' \
+        -e '^main "\$@"$' \
+        "$APPLY_SH")"
+    eval "$stripped"
+}
+
+_make_agent_yaml() {
+    local name="$1"
+    local tmpfile
+    tmpfile="$(mktemp /tmp/test-agent-XXXXXX.yaml)"
+    cat > "$tmpfile" <<YAML
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: ${name}
+  host: hermes
+spec:
+  label: ${name}
+  program: claude-code
+  model: null
+  workingDirectory: /tmp
+  programArgs: ""
+  taskDescription: "test agent"
+  tags: []
+  owner: testuser
+  role: member
+  deployment:
+    type: local
+  desiredState: active
+YAML
+    echo "$tmpfile"
+}
+
+test_prune_calls_sleep_with_env_value() {
+    echo ""
+    echo "Test: handle_unmanaged calls sleep with HIBERNATE_SETTLE_SECONDS value"
+
+    export AGAMEMNON_URL="http://mock-agamemnon"
+
+    # Track what sleep was called with via a temp file (survives subshells)
+    local sleep_arg_file
+    sleep_arg_file="$(mktemp)"
+
+    # Capture sleep argument; override in current shell via function
+    sleep() { echo "$1" > "$sleep_arg_file"; }
+
+    check_deps()                { return 0; }
+    agamemnon_check_connection(){ return 0; }
+    agamemnon_hibernate_agent() { return 0; }
+    agamemnon_delete_agent()    { return 0; }
+    snapshot_agent()            { return 0; }
+    record_failure()            { return 0; }
+    report_add_agent()          { return 0; }
+
+    _source_apply_functions
+
+    # Override sleep again after sourcing (source may have reset environment)
+    sleep() { echo "$1" > "$sleep_arg_file"; }
+
+    # One managed YAML, one unmanaged agent in Agamemnon
+    local yaml_managed
+    yaml_managed="$(_make_agent_yaml managed-agent)"
+
+    local agents_json
+    agents_json='[{"id":"id-unmanaged","name":"unmanaged-agent","status":"online","label":"unmanaged-agent","program":"claude-code","workingDirectory":"/tmp","programArgs":"","taskDescription":"test","tags":""}]'
+
+    # shellcheck disable=SC2034
+    PRUNE=1
+    # shellcheck disable=SC2034
+    OUTPUT_FORMAT="text"
+    # shellcheck disable=SC2034
+    HIBERNATE_SETTLE_SECONDS=7
+
+    # We assert on the captured sleep argument, not on handle_unmanaged's rc;
+    # capture rc explicitly rather than silently swallowing it.
+    _hu_rc=0
+    handle_unmanaged "$agents_json" "$yaml_managed" > /dev/null 2>&1 || _hu_rc=$?
+    if [[ "$_hu_rc" -ne 0 ]]; then
+        echo "  (handle_unmanaged rc=${_hu_rc} — not asserted)" >&2
+    fi
+
+    rm -f "$yaml_managed"
+
+    local actual_sleep_arg
+    actual_sleep_arg="$(cat "$sleep_arg_file" 2>/dev/null || echo "")"
+    rm -f "$sleep_arg_file"
+
+    _assert_eq "sleep called with HIBERNATE_SETTLE_SECONDS value (7)" "7" "$actual_sleep_arg"
+}
+
+test_prune_zero_settle_no_wait() {
+    echo ""
+    echo "Test: HIBERNATE_SETTLE_SECONDS=0 calls sleep with 0 (fast CI path)"
+
+    export AGAMEMNON_URL="http://mock-agamemnon"
+
+    local sleep_arg_file
+    sleep_arg_file="$(mktemp)"
+
+    sleep() { echo "$1" > "$sleep_arg_file"; }
+
+    check_deps()                { return 0; }
+    agamemnon_check_connection(){ return 0; }
+    agamemnon_hibernate_agent() { return 0; }
+    agamemnon_delete_agent()    { return 0; }
+    snapshot_agent()            { return 0; }
+    record_failure()            { return 0; }
+    report_add_agent()          { return 0; }
+
+    _source_apply_functions
+
+    sleep() { echo "$1" > "$sleep_arg_file"; }
+
+    local yaml_managed
+    yaml_managed="$(_make_agent_yaml managed-agent)"
+
+    local agents_json
+    agents_json='[{"id":"id-unmanaged","name":"unmanaged-agent","status":"online","label":"unmanaged-agent","program":"claude-code","workingDirectory":"/tmp","programArgs":"","taskDescription":"test","tags":""}]'
+
+    # shellcheck disable=SC2034
+    PRUNE=1
+    # shellcheck disable=SC2034
+    OUTPUT_FORMAT="text"
+    # shellcheck disable=SC2034
+    HIBERNATE_SETTLE_SECONDS=0
+
+    # We assert on the captured sleep argument, not on handle_unmanaged's rc;
+    # capture rc explicitly rather than silently swallowing it.
+    _hu_rc=0
+    handle_unmanaged "$agents_json" "$yaml_managed" > /dev/null 2>&1 || _hu_rc=$?
+    if [[ "$_hu_rc" -ne 0 ]]; then
+        echo "  (handle_unmanaged rc=${_hu_rc} — not asserted)" >&2
+    fi
+
+    rm -f "$yaml_managed"
+
+    local actual_sleep_arg
+    actual_sleep_arg="$(cat "$sleep_arg_file" 2>/dev/null || echo "")"
+    rm -f "$sleep_arg_file"
+
+    _assert_eq "sleep called with 0 when HIBERNATE_SETTLE_SECONDS=0" "0" "$actual_sleep_arg"
+}
+
+# ── run ───────────────────────────────────────────────────────────────────────
+
+echo "================================================"
+echo "HIBERNATE_SETTLE_SECONDS tests (issue #373)"
+echo "================================================"
+
+test_help_documents_hibernate_settle_seconds
+test_no_hardcoded_sleep_2
+test_sleep_uses_variable
+test_default_value_is_2
+test_prune_calls_sleep_with_env_value
+test_prune_zero_settle_no_wait
+
+echo ""
+echo "================================================"
+echo "Results: ${PASS} passed, ${FAIL} failed"
+echo "================================================"
+
+if [[ $FAIL -gt 0 ]]; then
+    exit 1
+fi

--- a/tools/reconciler/tests/test-report.sh
+++ b/tools/reconciler/tests/test-report.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# tests/test-report.sh — Unit tests for scripts/lib/report.sh
+#
+# Tests the JSON report builder functions in isolation (no live Agamemnon needed).
+#
+# Usage:
+#   ./tests/test-report.sh
+#
+# Exit codes:
+#   0 = all tests passed
+#   1 = one or more tests failed
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Source libs under test (api.sh defines AGAMEMNON_URL; reconcile.sh defines normalize_path)
+AGAMEMNON_URL="${AGAMEMNON_URL:-http://localhost:8080}"
+# shellcheck source=scripts/lib/reconcile.sh
+source "${REPO_ROOT}/scripts/lib/reconcile.sh"
+# shellcheck source=scripts/lib/report.sh
+source "${REPO_ROOT}/scripts/lib/report.sh"
+
+PASS=0
+FAIL=0
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+assert_eq() {
+    local desc="$1" expected="$2" actual="$3"
+    if [[ "$expected" == "$actual" ]]; then
+        pass "$desc"
+    else
+        fail "$desc (expected '${expected}', got '${actual}')"
+    fi
+}
+
+assert_json_field() {
+    local desc="$1" json="$2" jq_expr="$3" expected="$4"
+    local actual
+    actual="$(echo "$json" | jq -r "$jq_expr")"
+    assert_eq "$desc" "$expected" "$actual"
+}
+
+assert_json_valid() {
+    local desc="$1" json="$2"
+    if echo "$json" | jq -e . > /dev/null 2>&1; then
+        pass "$desc"
+    else
+        fail "$desc (invalid JSON: ${json:0:80})"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Tests: report_init / report_emit (empty run)
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== report_init / report_emit ==="
+
+report_init "hermes"
+trap report_cleanup EXIT
+
+result="$(report_emit 0 0 0 0 0 0 0)"
+assert_json_valid "report_emit produces valid JSON" "$result"
+assert_json_field "timestamp is non-empty" "$result" '.timestamp' "$(echo "$result" | jq -r '.timestamp')"
+assert_json_field "host is hermes" "$result" '.host' "hermes"
+assert_json_field "summary.created=0" "$result" '.summary.created' "0"
+assert_json_field "summary.errors=0" "$result" '.summary.errors' "0"
+assert_json_field "agents is empty array" "$result" '.agents | length' "0"
+assert_json_field "unmanaged is empty array" "$result" '.unmanaged | length' "0"
+
+# ---------------------------------------------------------------------------
+# Tests: report_add_agent accumulates entries
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== report_add_agent ==="
+
+report_init "hermes"
+
+report_add_agent "alpha" "hermes" "UNCHANGED" "active" "online" "[]" ""
+report_add_agent "beta"  "hermes" "CREATE"    "active" "MISSING" "[]" ""
+report_add_agent "gamma" "hermes" "ERROR"     "active" "unknown" "[]" "create failed"
+
+result="$(report_emit 0 1 0 0 1 0 1)"
+assert_json_valid "report_emit with agents is valid JSON" "$result"
+assert_json_field "agents length = 3" "$result" '.agents | length' "3"
+assert_json_field "first agent name" "$result" '.agents[0].name' "alpha"
+assert_json_field "first agent action" "$result" '.agents[0].action' "UNCHANGED"
+assert_json_field "second agent action" "$result" '.agents[1].action' "CREATE"
+assert_json_field "third agent error is non-null" "$result" '.agents[2].error' "create failed"
+assert_json_field "summary.created=0" "$result" '.summary.created' "0"
+assert_json_field "summary.updated=1" "$result" '.summary.updated' "1"
+assert_json_field "summary.unchanged=1" "$result" '.summary.unchanged' "1"
+assert_json_field "summary.errors=1" "$result" '.summary.errors' "1"
+
+# ---------------------------------------------------------------------------
+# Tests: report_add_unmanaged
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== report_add_unmanaged ==="
+
+report_init "all"
+report_add_unmanaged "orphan-1"
+report_add_unmanaged "orphan-2"
+result="$(report_emit 0 0 0 0 0 0 0)"
+assert_json_field "unmanaged length = 2" "$result" '.unmanaged | length' "2"
+assert_json_field "unmanaged[0] = orphan-1" "$result" '.unmanaged[0]' "orphan-1"
+assert_json_field "unmanaged[1] = orphan-2" "$result" '.unmanaged[1]' "orphan-2"
+
+# ---------------------------------------------------------------------------
+# Tests: build_drift_json
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== build_drift_json ==="
+
+actual_json='{"label":"Old Label","program":"claude-code","workingDirectory":"/old","programArgs":"","taskDescription":"Old desc","tags":["a","b"]}'
+
+# UPDATE on label and workingDirectory
+drift="$(build_drift_json "UPDATE:label,workingDirectory" "$actual_json" \
+    "New Label" "claude-code" "/new" "" "Old desc" "a,b")"
+
+assert_json_valid "build_drift_json produces valid JSON" "$drift"
+assert_json_field "drift length = 2" "$drift" 'length' "2"
+assert_json_field "drift[0].field = label" "$drift" '.[0].field' "label"
+assert_json_field "drift[0].old = Old Label" "$drift" '.[0].old' "Old Label"
+assert_json_field "drift[0].new = New Label" "$drift" '.[0].new' "New Label"
+assert_json_field "drift[1].field = workingDirectory" "$drift" '.[1].field' "workingDirectory"
+assert_json_field "drift[1].old = /old" "$drift" '.[1].old' "/old"
+assert_json_field "drift[1].new = /new" "$drift" '.[1].new' "/new"
+
+# Non-UPDATE action → empty drift array
+drift_none="$(build_drift_json "UNCHANGED" "$actual_json" "lbl" "prg" "/dir" "" "" "")"
+assert_json_field "non-UPDATE action → empty array" "$drift_none" 'length' "0"
+
+# ---------------------------------------------------------------------------
+# Tests: report_save creates file
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== report_save ==="
+
+report_init "hermes"
+json="$(report_emit 1 0 0 0 0 0 0)"
+tmpdir="$(mktemp -d)"
+report_save "$json" "$tmpdir"
+
+if [[ -f "${tmpdir}/last-reconciliation.json" ]]; then
+    pass "report_save creates last-reconciliation.json"
+    saved_json="$(cat "${tmpdir}/last-reconciliation.json")"
+    assert_json_valid "saved JSON is valid" "$saved_json"
+    assert_json_field "saved summary.created=1" "$saved_json" '.summary.created' "1"
+else
+    fail "report_save did not create file"
+fi
+rm -rf "$tmpdir"
+
+# ---------------------------------------------------------------------------
+# Tests: report_emit agamemnon_url field
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== report_emit agamemnon_url ==="
+
+AGAMEMNON_URL="http://test-host:9090"
+report_init "all"
+result="$(report_emit 0 0 0 0 0 0 0)"
+assert_json_field "agamemnon_url reflects AGAMEMNON_URL" "$result" '.agamemnon_url' "http://test-host:9090"
+
+# ---------------------------------------------------------------------------
+# Tests: drift JSON with tags
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== build_drift_json tags ==="
+
+actual_with_tags='{"label":"L","program":"P","workingDirectory":"/w","programArgs":"","taskDescription":"D","tags":["x","y"]}'
+drift_tags="$(build_drift_json "UPDATE:tags" "$actual_with_tags" \
+    "L" "P" "/w" "" "D" "a,b,c")"
+assert_json_valid "drift tags is valid JSON" "$drift_tags"
+assert_json_field "drift tags field name" "$drift_tags" '.[0].field' "tags"
+assert_json_field "drift tags old value" "$drift_tags" '.[0].old' "x,y"
+assert_json_field "drift tags new value (csv)" "$drift_tags" '.[0].new' "a,b,c"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "================================================"
+echo "Results: ${PASS} passed, ${FAIL} failed"
+
+if [[ $FAIL -gt 0 ]]; then
+    exit 1
+fi
+exit 0

--- a/tools/reconciler/tests/test-rollback.sh
+++ b/tools/reconciler/tests/test-rollback.sh
@@ -1,0 +1,439 @@
+#!/usr/bin/env bash
+# tests/test-rollback.sh — Unit tests for rollback/snapshot functionality
+#
+# Tests the snapshot saving logic in apply.sh and the rollback.sh script
+# using a mock Agamemnon server via a stub HTTP server.
+#
+# Usage:
+#   ./tests/test-rollback.sh
+#
+# Exit codes:
+#   0 = all tests passed
+#   1 = test failures found
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+PASS=0
+FAIL=0
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+ok() {
+    local desc="$1"
+    echo "  PASS: ${desc}"
+    PASS=$((PASS + 1))
+}
+
+fail() {
+    local desc="$1"
+    local detail="${2:-}"
+    echo "  FAIL: ${desc}"
+    [[ -n "$detail" ]] && echo "        ${detail}"
+    FAIL=$((FAIL + 1))
+}
+
+assert_eq() {
+    local desc="$1" expected="$2" actual="$3"
+    if [[ "$expected" == "$actual" ]]; then
+        ok "$desc"
+    else
+        fail "$desc" "expected='${expected}' actual='${actual}'"
+    fi
+}
+
+assert_file_exists() {
+    local desc="$1" file="$2"
+    if [[ -f "$file" ]]; then
+        ok "$desc"
+    else
+        fail "$desc" "file not found: ${file}"
+    fi
+}
+
+assert_dir_exists() {
+    local desc="$1" dir="$2"
+    if [[ -d "$dir" ]]; then
+        ok "$desc"
+    else
+        fail "$desc" "directory not found: ${dir}"
+    fi
+}
+
+assert_contains() {
+    local desc="$1" needle="$2" haystack="$3"
+    if echo "$haystack" | grep -qF "$needle"; then
+        ok "$desc"
+    else
+        fail "$desc" "expected to find '${needle}' in output"
+    fi
+}
+
+assert_not_contains() {
+    local desc="$1" needle="$2" haystack="$3"
+    if ! echo "$haystack" | grep -qF "$needle"; then
+        ok "$desc"
+    else
+        fail "$desc" "did not expect to find '${needle}' in output"
+    fi
+}
+
+# ── Test Fixtures ─────────────────────────────────────────────────────────────
+
+TMPDIR_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_ROOT"' EXIT
+
+make_snapshot_dir() {
+    local dir
+    dir="${TMPDIR_ROOT}/snapshots_$(date +%s%N)"
+    mkdir -p "$dir"
+    echo "$dir"
+}
+
+make_agent_json() {
+    local name="${1:-test-agent}"
+    local status="${2:-offline}"
+    jq -n \
+        --arg name "$name" \
+        --arg status "$status" \
+        '{
+            id: "abc-123",
+            name: $name,
+            label: "Test Agent",
+            program: "claude-code",
+            workingDirectory: "/home/user/project",
+            programArgs: "--flag",
+            taskDescription: "Does things",
+            tags: ["test"],
+            status: $status
+        }'
+}
+
+make_snapshot_file() {
+    local dir="$1"
+    local timestamp="${2:-2024-01-15T10:30:00Z}"
+    local content="${3:-[]}"
+    local file="${dir}/${timestamp}.json"
+    echo "$content" > "$file"
+    echo "$file"
+}
+
+# ── Test: save_snapshot function (sourced from apply.sh context) ───────────────
+
+test_save_snapshot_creates_dir_and_file() {
+    echo ""
+    echo "=== save_snapshot: creates directory and file ==="
+
+    local snap_dir="${TMPDIR_ROOT}/test_snap_$$"
+    local fake_agents='[{"id":"1","name":"foo","status":"active"}]'
+
+    # Source just the save_snapshot function by extracting and running it
+    (
+        SNAPSHOT_DIR="$snap_dir"
+        SNAPSHOT_KEEP=10
+        REPO_ROOT="$TMPDIR_ROOT"
+
+        # Inline the save_snapshot logic for unit testing
+        save_snapshot() {
+            local agents_json="$1"
+            local timestamp
+            timestamp="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            mkdir -p "$SNAPSHOT_DIR"
+            local snapshot_file="${SNAPSHOT_DIR}/${timestamp}.json"
+            echo "$agents_json" > "$snapshot_file"
+
+            local count
+            count="$(find "$SNAPSHOT_DIR" -name "*.json" | wc -l)"
+            if [[ $count -gt $SNAPSHOT_KEEP ]]; then
+                local excess=$(( count - SNAPSHOT_KEEP ))
+                find "$SNAPSHOT_DIR" -name "*.json" | sort | head -n "$excess" | xargs rm -f
+            fi
+        }
+
+        save_snapshot "$fake_agents"
+    )
+
+    assert_dir_exists "snapshot directory is created" "$snap_dir"
+
+    local file_count
+    file_count="$(find "$snap_dir" -name "*.json" | wc -l)"
+    assert_eq "one snapshot file is written" "1" "$file_count"
+
+    # Verify the content is the agent JSON
+    local content
+    content="$(cat "${snap_dir}"/*.json)"
+    assert_contains "snapshot contains agent data" '"name":"foo"' "$content"
+}
+
+test_save_snapshot_prunes_old_files() {
+    echo ""
+    echo "=== save_snapshot: prunes old snapshots beyond SNAPSHOT_KEEP ==="
+
+    local snap_dir="${TMPDIR_ROOT}/test_prune_$$"
+    mkdir -p "$snap_dir"
+
+    # Create 12 existing snapshots
+    for i in $(seq -w 1 12); do
+        echo '[]' > "${snap_dir}/2024-01-0${i}T00:00:00Z.json"
+    done
+
+    (
+        SNAPSHOT_DIR="$snap_dir"
+        SNAPSHOT_KEEP=10
+
+        save_snapshot() {
+            local agents_json="$1"
+            local timestamp
+            timestamp="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            mkdir -p "$SNAPSHOT_DIR"
+            local snapshot_file="${SNAPSHOT_DIR}/${timestamp}.json"
+            echo "$agents_json" > "$snapshot_file"
+
+            local count
+            count="$(find "$SNAPSHOT_DIR" -name "*.json" | wc -l)"
+            if [[ $count -gt $SNAPSHOT_KEEP ]]; then
+                local excess=$(( count - SNAPSHOT_KEEP ))
+                find "$SNAPSHOT_DIR" -name "*.json" | sort | head -n "$excess" | xargs rm -f
+            fi
+        }
+
+        save_snapshot '[]'
+    )
+
+    local remaining
+    remaining="$(find "$snap_dir" -name "*.json" | wc -l)"
+    assert_eq "snapshot count does not exceed SNAPSHOT_KEEP=10" "10" "$remaining"
+}
+
+# ── Test: rollback.sh --list ──────────────────────────────────────────────────
+
+test_rollback_list_empty() {
+    echo ""
+    echo "=== rollback.sh --list: no snapshots ==="
+
+    local snap_dir="${TMPDIR_ROOT}/test_list_empty_$$"
+    mkdir -p "$snap_dir"
+
+    local output
+    output="$(bash "${REPO_ROOT}/scripts/rollback.sh" \
+        --snapshot-dir "$snap_dir" --list 2>&1)"
+
+    assert_contains "reports no snapshots found" "No snapshots found" "$output"
+}
+
+test_rollback_list_shows_files() {
+    echo ""
+    echo "=== rollback.sh --list: shows available snapshots ==="
+
+    local snap_dir
+    snap_dir="$(make_snapshot_dir)"
+
+    make_snapshot_file "$snap_dir" "2024-01-15T10:00:00Z" \
+        '[{"id":"1","name":"agent-a","status":"active"}]' > /dev/null
+    make_snapshot_file "$snap_dir" "2024-01-15T11:00:00Z" \
+        '[{"id":"1","name":"agent-a","status":"active"},{"id":"2","name":"agent-b","status":"offline"}]' > /dev/null
+
+    local output
+    output="$(bash "${REPO_ROOT}/scripts/rollback.sh" \
+        --snapshot-dir "$snap_dir" --list 2>&1)"
+
+    assert_contains "lists snapshot filenames" "2024-01-15T" "$output"
+    assert_contains "marks most recent snapshot" "most recent" "$output"
+    assert_contains "shows agent counts" "agents" "$output"
+}
+
+test_rollback_list_newest_first() {
+    echo ""
+    echo "=== rollback.sh --list: most recent snapshot marked correctly ==="
+
+    local snap_dir
+    snap_dir="$(make_snapshot_dir)"
+
+    make_snapshot_file "$snap_dir" "2024-01-10T00:00:00Z" '[]' > /dev/null
+    make_snapshot_file "$snap_dir" "2024-01-20T00:00:00Z" '[]' > /dev/null
+
+    local output
+    output="$(bash "${REPO_ROOT}/scripts/rollback.sh" \
+        --snapshot-dir "$snap_dir" --list 2>&1)"
+
+    # The newest file should appear with the marker
+    local most_recent_line
+    most_recent_line="$(echo "$output" | grep "most recent" || true)"
+    assert_contains "newest file is marked most recent" "2024-01-20T" "$most_recent_line"
+}
+
+# ── Test: rollback.sh --dry-run ───────────────────────────────────────────────
+
+test_rollback_dry_run_no_api_calls() {
+    echo ""
+    echo "=== rollback.sh --dry-run: shows plan without calling API ==="
+
+    local snap_dir
+    snap_dir="$(make_snapshot_dir)"
+
+    local agent_json
+    agent_json="$(make_agent_json "my-agent" "active")"
+    make_snapshot_file "$snap_dir" "2024-01-15T10:00:00Z" \
+        "[${agent_json}]" > /dev/null
+
+    # Point at a non-existent Agamemnon so any real API call would fail
+    local output
+    output="$(AGAMEMNON_URL="http://localhost:19999" \
+        bash "${REPO_ROOT}/scripts/rollback.sh" \
+        --snapshot-dir "$snap_dir" --dry-run 2>&1)"
+
+    assert_contains "shows DRY-RUN label" "DRY-RUN" "$output"
+    assert_contains "names agent to restore" "my-agent" "$output"
+    assert_not_contains "does not call API (no HTTP error)" "HTTP" "$output"
+}
+
+test_rollback_dry_run_shows_agent_count() {
+    echo ""
+    echo "=== rollback.sh --dry-run: reports agent count from snapshot ==="
+
+    local snap_dir
+    snap_dir="$(make_snapshot_dir)"
+
+    local a b
+    a="$(make_agent_json "agent-1" "active")"
+    b="$(make_agent_json "agent-2" "offline")"
+    make_snapshot_file "$snap_dir" "2024-01-15T10:00:00Z" \
+        "[${a}, ${b}]" > /dev/null
+
+    local output
+    output="$(AGAMEMNON_URL="http://localhost:19999" \
+        bash "${REPO_ROOT}/scripts/rollback.sh" \
+        --snapshot-dir "$snap_dir" --dry-run 2>&1)"
+
+    assert_contains "shows snapshot contains 2 agents" "2 agents" "$output"
+}
+
+# ── Test: rollback.sh validation ─────────────────────────────────────────────
+
+test_rollback_missing_snapshot_dir() {
+    echo ""
+    echo "=== rollback.sh: fails gracefully when snapshot dir missing ==="
+
+    local output exit_code
+    set +e
+    output="$(bash "${REPO_ROOT}/scripts/rollback.sh" \
+        --snapshot-dir "/nonexistent/path/$$" 2>&1)"
+    exit_code=$?
+    set -e
+
+    assert_eq "exits with non-zero code" "1" "$exit_code"
+    assert_contains "reports missing directory" "No snapshots directory" "$output"
+}
+
+test_rollback_invalid_json_snapshot() {
+    echo ""
+    echo "=== rollback.sh: fails when snapshot is invalid JSON ==="
+
+    local snap_dir
+    snap_dir="$(make_snapshot_dir)"
+    echo "not valid json {{{" > "${snap_dir}/2024-01-15T10:00:00Z.json"
+
+    local output exit_code
+    set +e
+    output="$(AGAMEMNON_URL="http://localhost:19999" \
+        bash "${REPO_ROOT}/scripts/rollback.sh" \
+        --snapshot-dir "$snap_dir" 2>&1)"
+    exit_code=$?
+    set -e
+
+    assert_eq "exits with non-zero code" "1" "$exit_code"
+    assert_contains "reports invalid snapshot" "not a valid JSON array" "$output"
+}
+
+test_rollback_specific_snapshot_file() {
+    echo ""
+    echo "=== rollback.sh --snapshot: uses specific file ==="
+
+    local snap_dir
+    snap_dir="$(make_snapshot_dir)"
+
+    local old_file
+    old_file="$(make_snapshot_file "$snap_dir" "2024-01-01T00:00:00Z" \
+        '[{"id":"1","name":"old-agent","status":"offline"}]')"
+    make_snapshot_file "$snap_dir" "2024-01-15T10:00:00Z" \
+        '[{"id":"2","name":"new-agent","status":"active"}]' >/dev/null
+
+    # Ask for the old snapshot specifically
+    local output
+    output="$(AGAMEMNON_URL="http://localhost:19999" \
+        bash "${REPO_ROOT}/scripts/rollback.sh" \
+        --snapshot "$old_file" --dry-run 2>&1)"
+
+    assert_contains "uses specified snapshot file" "old-agent" "$output"
+    assert_not_contains "does not use newer snapshot" "new-agent" "$output"
+}
+
+# ── Test: apply.sh writes snapshot ───────────────────────────────────────────
+
+test_apply_snapshot_dir_flag() {
+    echo ""
+    echo "=== apply.sh --snapshot-dir: accepts flag without error ==="
+
+    local snap_dir="${TMPDIR_ROOT}/apply_snap_$$"
+
+    # apply.sh will fail at agamemnon_check_connection since no server is up,
+    # but we just need to confirm --snapshot-dir is a recognized flag.
+    local output exit_code
+    set +e
+    output="$(AGAMEMNON_URL="http://localhost:19999" \
+        bash "${REPO_ROOT}/scripts/apply.sh" \
+        --snapshot-dir "$snap_dir" 2>&1)"
+    exit_code=$?
+    set -e
+
+    # Should fail due to Agamemnon unreachable, not due to unknown flag
+    assert_not_contains "flag is recognized (no 'Unknown argument' error)" \
+        "Unknown argument" "$output"
+}
+
+# ── Test: default snapshot dir uses REPO_ROOT not root (issue #370) ───────────
+
+test_default_snapshot_dir_uses_repo_root() {
+    echo ""
+    echo "=== default snapshot dir resolves to REPO_ROOT, not / ==="
+
+    # Grep apply.sh directly: the default must reference REPO_ROOT (uppercase),
+    # not repo_root (lowercase undefined variable). Under set -u the lowercase
+    # form fatally aborts; when set -u is absent it silently expands to ""
+    # producing /.myrmidons/snapshots (a root-filesystem write attempt).
+    local occurrences
+    occurrences="$(grep -c '\${repo_root}' "${REPO_ROOT}/scripts/apply.sh" || true)"
+    assert_eq "no lowercase repo_root reference in apply.sh (issue #370)" "0" "$occurrences"
+}
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+
+run_all_tests() {
+    echo "Running rollback/snapshot tests..."
+
+    test_save_snapshot_creates_dir_and_file
+    test_save_snapshot_prunes_old_files
+    test_rollback_list_empty
+    test_rollback_list_shows_files
+    test_rollback_list_newest_first
+    test_rollback_dry_run_no_api_calls
+    test_rollback_dry_run_shows_agent_count
+    test_rollback_missing_snapshot_dir
+    test_rollback_invalid_json_snapshot
+    test_rollback_specific_snapshot_file
+    test_apply_snapshot_dir_flag
+    test_default_snapshot_dir_uses_repo_root
+
+    echo ""
+    echo "================================================"
+    echo "Results: ${PASS} passed, ${FAIL} failed"
+
+    if [[ $FAIL -gt 0 ]]; then
+        exit 1
+    fi
+    exit 0
+}
+
+run_all_tests

--- a/tools/reconciler/tests/test-url-validation.sh
+++ b/tools/reconciler/tests/test-url-validation.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# tests/test-url-validation.sh — Unit tests for AGAMEMNON_URL validation
+#
+# Tests the _agamemnon_validate_url function added to scripts/lib/api.sh
+# to prevent SSRF via environment variable injection (issue #20).
+#
+# Usage:
+#   ./tests/test-url-validation.sh
+#
+# Exit codes:
+#   0 = all tests passed
+#   1 = one or more tests failed
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Source only the validation function — avoid side effects from set -e on api.sh
+# by extracting and evaluating just the function definition.
+source "${REPO_ROOT}/scripts/lib/api.sh"
+
+PASS=0
+FAIL=0
+
+assert_valid() {
+    local url="$1"
+    if _agamemnon_validate_url "$url" 2>/dev/null; then
+        echo "  PASS (valid): ${url}"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL (expected valid, got rejected): ${url}"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_invalid() {
+    local url="$1"
+    if ! _agamemnon_validate_url "$url" 2>/dev/null; then
+        echo "  PASS (rejected): ${url}"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL (expected rejection, got accepted): ${url}"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+echo "Testing _agamemnon_validate_url..."
+echo ""
+
+echo "=== Valid URLs (should be accepted) ==="
+assert_valid "http://localhost:8080"
+assert_valid "http://localhost:23000"
+assert_valid "https://agamemnon.internal"
+assert_valid "http://192.168.1.100:8080"
+assert_valid "https://agamemnon.example.com:443"
+assert_valid "http://agamemnon-host.lan:8080"
+assert_valid "http://agamemnon.internal/api"
+assert_valid "https://my-host.example.com:9000/v1"
+
+echo ""
+echo "=== Invalid / malicious URLs (should be rejected) ==="
+assert_invalid "ftp://evil.example.com"
+assert_invalid "file:///etc/passwd"
+assert_invalid "http://user:password@evil.com"
+assert_invalid "http://evil.com#fragment"
+assert_invalid 'http://evil.com?query=1'
+assert_invalid "javascript:alert(1)"
+assert_invalid ""
+assert_invalid "not-a-url"
+assert_invalid "//evil.com"
+assert_invalid $'http://evil.com\nnewline'
+assert_invalid "http://evil.com:abc"
+assert_invalid "http://[evil.com]"
+
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+
+if [[ $FAIL -gt 0 ]]; then
+    exit 1
+fi
+exit 0

--- a/tools/reconciler/tests/unit/test_api.bats
+++ b/tools/reconciler/tests/unit/test_api.bats
@@ -1,0 +1,211 @@
+#!/usr/bin/env bats
+# tests/unit/test_api.bats — unit tests for scripts/lib/api.sh
+#
+# Uses a Python-based mock HTTP server (tests/helpers/mock_server.py)
+# to simulate ProjectAgamemnon API responses without a live server.
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+HELPERS_DIR="${SCRIPT_DIR}/tests/helpers"
+
+MOCK_PORT=18080
+MOCK_PID_FILE="/tmp/bats-mock-api-$$.pid"
+
+# ---------------------------------------------------------------------------
+# Mock HTTP server helpers
+# ---------------------------------------------------------------------------
+
+# Start the mock server with a fixed status + body response.
+# Uses a fixed 200ms sleep instead of polling to avoid set -e issues.
+_start_mock_server() {
+    local http_status="${1:-200}"
+    # Avoid ":-{}" default — bash parses it as "${2:-{" + literal "}" due to
+    # unbalanced braces in parameter expansion. Use explicit fallback instead.
+    local body="${2}"
+    [[ -z "$body" ]] && body='{}'
+
+    MOCK_STATUS="$http_status" MOCK_BODY="$body" \
+        python3 "${HELPERS_DIR}/mock_server.py" "$MOCK_PORT" \
+        > /dev/null 2>&1 &
+    echo $! > "$MOCK_PID_FILE"
+    sleep 0.2
+}
+
+_stop_mock_server() {
+    if [[ -f "$MOCK_PID_FILE" ]]; then
+        kill "$(cat "$MOCK_PID_FILE")" 2>/dev/null || true
+        rm -f "$MOCK_PID_FILE"
+    fi
+}
+
+setup() {
+    export AGAMEMNON_URL="http://127.0.0.1:${MOCK_PORT}"
+    # shellcheck source=/dev/null
+    source "${SCRIPT_DIR}/scripts/lib/api.sh"
+}
+
+teardown() {
+    _stop_mock_server
+}
+
+# ---------------------------------------------------------------------------
+# agamemnon_check_connection
+# ---------------------------------------------------------------------------
+
+@test "agamemnon_check_connection: succeeds when server returns 200" {
+    _start_mock_server 200 '{"status":"ok"}'
+    run agamemnon_check_connection
+    [[ "$status" -eq 0 ]]
+}
+
+@test "agamemnon_check_connection: fails when server is not running" {
+    export AGAMEMNON_URL="http://127.0.0.1:19999"
+    run agamemnon_check_connection
+    [[ "$status" -ne 0 ]]
+}
+
+# ---------------------------------------------------------------------------
+# agamemnon_list_agents
+# ---------------------------------------------------------------------------
+
+@test "agamemnon_list_agents: returns JSON array from server" {
+    local agents_json='[{"id":"abc","name":"agent1","status":"active"},{"id":"def","name":"agent2","status":"offline"}]'
+    _start_mock_server 200 "$agents_json"
+    result="$(agamemnon_list_agents)"
+    count="$(echo "$result" | jq 'length')"
+    [[ "$count" == "2" ]]
+}
+
+@test "agamemnon_list_agents: fails on HTTP 500" {
+    _start_mock_server 500 '{"error":"internal server error"}'
+    run agamemnon_list_agents
+    [[ "$status" -ne 0 ]]
+}
+
+# ---------------------------------------------------------------------------
+# agamemnon_get_agent
+# ---------------------------------------------------------------------------
+
+@test "agamemnon_get_agent: returns agent JSON by ID" {
+    local agent_json='{"id":"abc123","name":"my-agent","status":"active"}'
+    _start_mock_server 200 "$agent_json"
+    result="$(agamemnon_get_agent "abc123")"
+    name="$(echo "$result" | jq -r '.name')"
+    [[ "$name" == "my-agent" ]]
+}
+
+@test "agamemnon_get_agent: fails on 404" {
+    _start_mock_server 404 '{"error":"not found"}'
+    run agamemnon_get_agent "nonexistent"
+    [[ "$status" -ne 0 ]]
+}
+
+# ---------------------------------------------------------------------------
+# agamemnon_create_agent
+# ---------------------------------------------------------------------------
+
+@test "agamemnon_create_agent: sends POST and returns created agent JSON" {
+    local created_json='{"id":"new123","name":"new-agent","status":"offline"}'
+    _start_mock_server 201 "$created_json"
+    body='{"name":"new-agent","program":"claude-code","workingDirectory":"/tmp"}'
+    result="$(agamemnon_create_agent "$body")"
+    id="$(echo "$result" | jq -r '.id')"
+    [[ "$id" == "new123" ]]
+}
+
+@test "agamemnon_create_agent: fails on HTTP 400" {
+    _start_mock_server 400 '{"error":"bad request"}'
+    run agamemnon_create_agent '{"invalid":"body"}'
+    [[ "$status" -ne 0 ]]
+}
+
+# ---------------------------------------------------------------------------
+# agamemnon_update_agent
+# ---------------------------------------------------------------------------
+
+@test "agamemnon_update_agent: sends PATCH and returns updated agent JSON" {
+    local updated_json='{"id":"abc123","name":"my-agent","label":"Updated Label","status":"active"}'
+    _start_mock_server 200 "$updated_json"
+    result="$(agamemnon_update_agent "abc123" '{"label":"Updated Label"}')"
+    lbl="$(echo "$result" | jq -r '.label')"
+    [[ "$lbl" == "Updated Label" ]]
+}
+
+# ---------------------------------------------------------------------------
+# agamemnon_delete_agent
+# ---------------------------------------------------------------------------
+
+@test "agamemnon_delete_agent: succeeds on 200" {
+    _start_mock_server 200 '{"deleted":true}'
+    run agamemnon_delete_agent "abc123"
+    [[ "$status" -eq 0 ]]
+}
+
+@test "agamemnon_delete_agent: fails on 404" {
+    _start_mock_server 404 '{"error":"not found"}'
+    run agamemnon_delete_agent "nonexistent"
+    [[ "$status" -ne 0 ]]
+}
+
+# ---------------------------------------------------------------------------
+# agamemnon_wake_agent
+# ---------------------------------------------------------------------------
+
+@test "agamemnon_wake_agent: succeeds on 200" {
+    _start_mock_server 200 '{"id":"abc123","status":"active"}'
+    result="$(agamemnon_wake_agent "abc123")"
+    status_val="$(echo "$result" | jq -r '.status')"
+    [[ "$status_val" == "active" ]]
+}
+
+@test "agamemnon_wake_agent: fails on HTTP error" {
+    _start_mock_server 500 '{"error":"failed to start"}'
+    run agamemnon_wake_agent "abc123"
+    [[ "$status" -ne 0 ]]
+}
+
+# ---------------------------------------------------------------------------
+# agamemnon_hibernate_agent
+# ---------------------------------------------------------------------------
+
+@test "agamemnon_hibernate_agent: succeeds on 200" {
+    _start_mock_server 200 '{"id":"abc123","status":"offline"}'
+    result="$(agamemnon_hibernate_agent "abc123")"
+    status_val="$(echo "$result" | jq -r '.status')"
+    [[ "$status_val" == "offline" ]]
+}
+
+# ---------------------------------------------------------------------------
+# agamemnon_id_by_name
+# ---------------------------------------------------------------------------
+
+@test "agamemnon_id_by_name: returns correct ID when agent exists" {
+    local agents_json='[{"id":"id-001","name":"agent-alpha","status":"active"},{"id":"id-002","name":"agent-beta","status":"offline"}]'
+    _start_mock_server 200 "$agents_json"
+    result="$(agamemnon_id_by_name "agent-alpha")"
+    [[ "$result" == "id-001" ]]
+}
+
+@test "agamemnon_id_by_name: returns empty string when agent not found" {
+    local agents_json='[{"id":"id-001","name":"agent-alpha","status":"active"}]'
+    _start_mock_server 200 "$agents_json"
+    result="$(agamemnon_id_by_name "nonexistent")"
+    [[ -z "$result" ]]
+}
+
+# ---------------------------------------------------------------------------
+# agamemnon_status_by_name
+# ---------------------------------------------------------------------------
+
+@test "agamemnon_status_by_name: returns correct status when agent exists" {
+    local agents_json='[{"id":"id-001","name":"my-agent","status":"online"}]'
+    _start_mock_server 200 "$agents_json"
+    result="$(agamemnon_status_by_name "my-agent")"
+    [[ "$result" == "online" ]]
+}
+
+@test "agamemnon_status_by_name: returns unknown when agent not found" {
+    local agents_json='[]'
+    _start_mock_server 200 "$agents_json"
+    result="$(agamemnon_status_by_name "ghost-agent")"
+    [[ "$result" == "unknown" ]]
+}

--- a/tools/reconciler/tests/unit/test_api_auth.bats
+++ b/tools/reconciler/tests/unit/test_api_auth.bats
@@ -1,0 +1,183 @@
+#!/usr/bin/env bats
+# tests/unit/test_api_auth.bats — tests for auth header injection in scripts/lib/api.sh
+#
+# Verifies that AGAMEMNON_API_KEY correctly injects Authorization and X-API-Key
+# headers, and that no headers are sent when the key is unset.
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+HELPERS_DIR="${SCRIPT_DIR}/tests/helpers"
+
+MOCK_PORT=18081
+MOCK_PID_FILE="/tmp/bats-mock-api-auth-$$.pid"
+
+# Start the mock server with a fixed status + body response.
+_start_mock_server() {
+    local http_status="${1:-200}"
+    local body="${2}"
+    [[ -z "$body" ]] && body='{}'
+
+    MOCK_STATUS="$http_status" MOCK_BODY="$body" \
+        python3 "${HELPERS_DIR}/mock_server.py" "$MOCK_PORT" \
+        > /dev/null 2>&1 &
+    echo $! > "$MOCK_PID_FILE"
+    sleep 0.2
+}
+
+_stop_mock_server() {
+    if [[ -f "$MOCK_PID_FILE" ]]; then
+        kill "$(cat "$MOCK_PID_FILE")" 2>/dev/null || true
+        rm -f "$MOCK_PID_FILE"
+    fi
+}
+
+setup() {
+    export AGAMEMNON_URL="http://127.0.0.1:${MOCK_PORT}"
+}
+
+teardown() {
+    _stop_mock_server
+}
+
+# Helper: check if a string pattern appears in curl command
+# Uses set -x to trace curl invocations
+_check_curl_headers() {
+    local pattern="$1"
+    local script="$2"
+    local output
+
+    output=$( (set -x; eval "$script") 2>&1 )
+
+    if echo "$output" | grep -q "$pattern"; then
+        return 0
+    fi
+    return 1
+}
+
+# ---------------------------------------------------------------------------
+# Auth header injection tests
+# ---------------------------------------------------------------------------
+
+@test "auth: no headers when AGAMEMNON_API_KEY is unset" {
+    unset AGAMEMNON_API_KEY
+    _start_mock_server 200 '{"status":"ok"}'
+
+    # shellcheck source=/dev/null
+    source "${SCRIPT_DIR}/scripts/lib/api.sh"
+
+    # Check _agamemnon_auth_headers directly
+    _agamemnon_auth_headers
+    [[ "${#_AUTH_HEADERS[@]}" -eq 0 ]]
+}
+
+@test "auth: Authorization Bearer header injected when key is set" {
+    export AGAMEMNON_API_KEY="test-secret-key-12345"
+    _start_mock_server 200 '{"status":"ok"}'
+
+    # shellcheck source=/dev/null
+    source "${SCRIPT_DIR}/scripts/lib/api.sh"
+
+    # Call _agamemnon_auth_headers to build the array
+    _agamemnon_auth_headers
+
+    # Check that Authorization header is in the array
+    printf '%s\n' "${_AUTH_HEADERS[@]}" | grep -q "Authorization: Bearer test-secret-key-12345"
+}
+
+@test "auth: X-API-Key header injected when key is set" {
+    export AGAMEMNON_API_KEY="test-secret-key-12345"
+    _start_mock_server 200 '{"status":"ok"}'
+
+    # shellcheck source=/dev/null
+    source "${SCRIPT_DIR}/scripts/lib/api.sh"
+
+    # Call _agamemnon_auth_headers to build the array
+    _agamemnon_auth_headers
+
+    # Check that X-API-Key header is in the array
+    printf '%s\n' "${_AUTH_HEADERS[@]}" | grep -q "X-API-Key: test-secret-key-12345"
+}
+
+@test "auth: both Authorization and X-API-Key headers present when key is set" {
+    export AGAMEMNON_API_KEY="my-api-token"
+    _start_mock_server 200 '{"status":"ok"}'
+
+    # shellcheck source=/dev/null
+    source "${SCRIPT_DIR}/scripts/lib/api.sh"
+
+    # Call _agamemnon_auth_headers to build the array
+    _agamemnon_auth_headers
+
+    # Both headers should be present
+    local headers_str
+    headers_str="$(printf '%s\n' "${_AUTH_HEADERS[@]}")"
+    echo "$headers_str" | grep -q "Authorization: Bearer my-api-token"
+    echo "$headers_str" | grep -q "X-API-Key: my-api-token"
+}
+
+@test "auth: token value does not leak to stderr on API call failure" {
+    export AGAMEMNON_API_KEY="super-secret-api-key"
+    _start_mock_server 500 '{"error":"internal server error"}'
+
+    # shellcheck source=/dev/null
+    source "${SCRIPT_DIR}/scripts/lib/api.sh"
+
+    # Capture stderr from a failing API call
+    local stderr_output
+    stderr_output=$( { agamemnon_check_connection 2>&1 1>/dev/null; } || true)
+
+    # Token should NOT appear in stderr output
+    ! echo "$stderr_output" | grep -q "super-secret-api-key"
+}
+
+@test "auth: empty key treated as unset (no auth headers)" {
+    export AGAMEMNON_API_KEY=""
+    _start_mock_server 200 '{"status":"ok"}'
+
+    # shellcheck source=/dev/null
+    source "${SCRIPT_DIR}/scripts/lib/api.sh"
+
+    # Call _agamemnon_auth_headers
+    _agamemnon_auth_headers
+
+    # Empty key should result in no auth headers
+    [[ "${#_AUTH_HEADERS[@]}" -eq 0 ]]
+}
+
+@test "auth: Authorization header format is correct" {
+    export AGAMEMNON_API_KEY="my-test-token"
+    _start_mock_server 200 '{"status":"ok"}'
+
+    # shellcheck source=/dev/null
+    source "${SCRIPT_DIR}/scripts/lib/api.sh"
+
+    _agamemnon_auth_headers
+
+    # Check the exact format of the Authorization header
+    printf '%s\n' "${_AUTH_HEADERS[@]}" | grep -q "^Authorization: Bearer my-test-token\$"
+}
+
+@test "auth: X-API-Key header format is correct" {
+    export AGAMEMNON_API_KEY="my-test-token"
+    _start_mock_server 200 '{"status":"ok"}'
+
+    # shellcheck source=/dev/null
+    source "${SCRIPT_DIR}/scripts/lib/api.sh"
+
+    _agamemnon_auth_headers
+
+    # Check the exact format of the X-API-Key header
+    printf '%s\n' "${_AUTH_HEADERS[@]}" | grep -q "^X-API-Key: my-test-token\$"
+}
+
+@test "auth: API call succeeds when correct headers are sent" {
+    export AGAMEMNON_API_KEY="valid-token"
+    _start_mock_server 200 '[{"id":"agent1","name":"test-agent"}]'
+
+    # shellcheck source=/dev/null
+    source "${SCRIPT_DIR}/scripts/lib/api.sh"
+
+    # This should succeed because mock server returns 200
+    result="$(agamemnon_list_agents)"
+    [[ -n "$result" ]]
+    echo "$result" | jq -e '.[0].id == "agent1"'
+}

--- a/tools/reconciler/tests/unit/test_apply_args.bats
+++ b/tools/reconciler/tests/unit/test_apply_args.bats
@@ -1,0 +1,198 @@
+#!/usr/bin/env bats
+# tests/unit/test_apply_args.bats — unit tests for scripts/apply.sh argument parsing
+#
+# Tests verify argument passthrough behavior, specifically:
+# - --dry-run execs plan.sh instead of doing reconciliation
+# - --force flag is consumed and not passed to plan.sh
+# - --prune flag is accepted and parsed
+# - Unknown arguments are handled correctly
+#
+# These tests use a simplified approach: extract and test the parse_args function
+# in isolation, then verify the --dry-run exec behavior with a mock plan.sh.
+
+# Temporary directory for mock scripts
+MOCK_SCRIPTS_DIR=""
+
+setup() {
+    MOCK_SCRIPTS_DIR="$(mktemp -d)"
+    export PLAN_SH_ARGS_FILE="${MOCK_SCRIPTS_DIR}/plan_args.txt"
+
+    # Create mock plan.sh that records its arguments
+    cat > "${MOCK_SCRIPTS_DIR}/plan.sh" << 'MOCK_PLAN'
+#!/usr/bin/env bash
+# Mock plan.sh records all arguments
+printf '%s\n' "$@" > "$PLAN_SH_ARGS_FILE"
+exit 0
+MOCK_PLAN
+    chmod +x "${MOCK_SCRIPTS_DIR}/plan.sh"
+}
+
+teardown() {
+    [[ -n "$MOCK_SCRIPTS_DIR" ]] && rm -rf "$MOCK_SCRIPTS_DIR"
+    unset PLAN_SH_ARGS_FILE
+}
+
+# Helper: Test parse_args function directly
+_test_parse_args() {
+    local HOST=""
+    local PRUNE=0
+    local DRY_RUN=0
+    local _OUTPUT_FORMAT="text"
+    local _WEBHOOK_URL=""
+
+    parse_args() {
+        while [[ $# -gt 0 ]]; do
+            case "$1" in
+                --prune)            PRUNE=1; shift ;;
+                --dry-run)          DRY_RUN=1; shift ;;
+                --lock-timeout)     shift 2 ;;
+                --output)           shift 2 ;;
+                --webhook)          shift 2 ;;
+                --force)            shift ;;
+                -h|--help)          exit 0 ;;
+                *) HOST="$1"; shift ;;
+            esac
+        done
+    }
+
+    parse_args "$@"
+
+    # Return parsed values via stdout
+    echo "HOST=$HOST"
+    echo "DRY_RUN=$DRY_RUN"
+    echo "PRUNE=$PRUNE"
+}
+
+# Helper: Run a simplified apply.sh with our mock plan.sh
+_run_apply_test() {
+    local temp_apply
+    temp_apply="$(mktemp)"
+
+    cat > "$temp_apply" << 'APPLY_TEST'
+#!/usr/bin/env bash
+set -euo pipefail
+
+MOCK_SCRIPTS_DIR="$1"
+shift
+
+HOST=""
+PRUNE=0
+DRY_RUN=0
+OUTPUT_FORMAT="text"
+WEBHOOK_URL=""
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --prune)            PRUNE=1; shift ;;
+            --dry-run)          DRY_RUN=1; shift ;;
+            --lock-timeout)     shift 2 ;;
+            --output)           shift 2 ;;
+            --webhook)          shift 2 ;;
+            --force)            shift ;;
+            -h|--help)          exit 0 ;;
+            *) HOST="$1"; shift ;;
+        esac
+    done
+}
+
+parse_args "$@"
+
+if [[ $DRY_RUN -eq 1 ]]; then
+    # When --dry-run, pass original args to plan.sh (after parse_args consumes flags)
+    # For testing, we'll pass the remaining args
+    exec "${MOCK_SCRIPTS_DIR}/plan.sh" "$@"
+fi
+
+exit 0
+APPLY_TEST
+
+    bash "$temp_apply" "$MOCK_SCRIPTS_DIR" "$@"
+    local exit_code=$?
+    rm -f "$temp_apply"
+    return $exit_code
+}
+
+# ---------------------------------------------------------------------------
+# Test: parse_args function parses arguments correctly
+# ---------------------------------------------------------------------------
+
+@test "parse_args: --dry-run flag is recognized" {
+    result="$(_test_parse_args --dry-run)"
+    [[ "$result" == *"DRY_RUN=1"* ]]
+}
+
+@test "parse_args: --prune flag is recognized" {
+    result="$(_test_parse_args --prune)"
+    [[ "$result" == *"PRUNE=1"* ]]
+}
+
+@test "parse_args: --force flag is consumed silently" {
+    # --force is accepted in parse_args (line 55 of apply.sh)
+    # and consumed without setting any variable
+    result="$(_test_parse_args --force hermes)"
+    [[ "$result" == *"HOST=hermes"* ]]
+}
+
+@test "parse_args: host argument is captured" {
+    result="$(_test_parse_args hermes)"
+    [[ "$result" == *"HOST=hermes"* ]]
+}
+
+@test "parse_args: --dry-run with host" {
+    result="$(_test_parse_args --dry-run hermes)"
+    [[ "$result" == *"DRY_RUN=1"* ]]
+    [[ "$result" == *"HOST=hermes"* ]]
+}
+
+@test "parse_args: --dry-run --force --prune with host" {
+    result="$(_test_parse_args --dry-run --force --prune hermes)"
+    [[ "$result" == *"DRY_RUN=1"* ]]
+    [[ "$result" == *"PRUNE=1"* ]]
+    [[ "$result" == *"HOST=hermes"* ]]
+}
+
+@test "parse_args: last host wins when multiple hosts given" {
+    result="$(_test_parse_args hermes prometheus)"
+    [[ "$result" == *"HOST=prometheus"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test: --dry-run behavior (exec to plan.sh)
+# ---------------------------------------------------------------------------
+
+@test "--dry-run execs plan.sh (verified by env var passthrough)" {
+    # When --dry-run is set, apply.sh execs plan.sh
+    # We verify this by checking that plan.sh receives args
+    PLAN_SH_ARGS_FILE="${MOCK_SCRIPTS_DIR}/plan_args.txt" \
+        _run_apply_test "$MOCK_SCRIPTS_DIR" --dry-run hermes
+
+    [[ -f "${MOCK_SCRIPTS_DIR}/plan_args.txt" ]]
+}
+
+@test "--dry-run without arguments calls plan.sh" {
+    PLAN_SH_ARGS_FILE="${MOCK_SCRIPTS_DIR}/plan_args.txt" \
+        _run_apply_test "$MOCK_SCRIPTS_DIR" --dry-run
+
+    [[ -f "${MOCK_SCRIPTS_DIR}/plan_args.txt" ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test: Non-dry-run behavior
+# ---------------------------------------------------------------------------
+
+@test "apply.sh without --dry-run exits normally" {
+    PLAN_SH_ARGS_FILE="${MOCK_SCRIPTS_DIR}/plan_args.txt" \
+        _run_apply_test "$MOCK_SCRIPTS_DIR" hermes
+
+    # Without --dry-run, plan.sh should not be called
+    [[ ! -f "${MOCK_SCRIPTS_DIR}/plan_args.txt" ]]
+}
+
+@test "--prune without --dry-run is accepted" {
+    PLAN_SH_ARGS_FILE="${MOCK_SCRIPTS_DIR}/plan_args.txt" \
+        _run_apply_test "$MOCK_SCRIPTS_DIR" --prune
+
+    # plan.sh should not be called
+    [[ ! -f "${MOCK_SCRIPTS_DIR}/plan_args.txt" ]]
+}

--- a/tools/reconciler/tests/unit/test_apply_error.bats
+++ b/tools/reconciler/tests/unit/test_apply_error.bats
@@ -1,0 +1,531 @@
+#!/usr/bin/env bats
+# tests/unit/test_apply_error.bats — unit tests for scripts/apply.sh error handling
+#
+# Tests cover error paths in apply.sh:
+# - --fail-fast stops after first agent error
+# - failed-agents.txt is written with correct agent names
+# - Exit code semantics (0 success, 1 partial failure, 2 --fail-fast abort)
+# - --retry reads failed-agents.txt and filters agents correctly
+
+TEMP_TEST_DIR=""
+
+setup() {
+    TEMP_TEST_DIR="$(mktemp -d)"
+    export TEMP_TEST_DIR
+}
+
+teardown() {
+    [[ -n "$TEMP_TEST_DIR" ]] && rm -rf "$TEMP_TEST_DIR"
+}
+
+# ---------------------------------------------------------------------------
+# Helper: Create a minimal mock apply.sh for testing
+# This simplified version lets us test argument parsing and error handling
+# ---------------------------------------------------------------------------
+
+_create_mock_apply() {
+    local mock_apply="$1"
+    cat > "$mock_apply" << 'APPLY_MOCK'
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Mimic apply.sh structure for error handling tests
+FAIL_FAST=0
+RETRY=0
+RETRY_FILE=""
+ERRORS=0
+AGENTS_TO_APPLY=()
+FAILED_AGENTS=()
+EXIT_CODE=0
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --fail-fast)      FAIL_FAST=1; shift ;;
+            --retry)          RETRY=1; shift ;;
+            --retry-file)     RETRY_FILE="$2"; shift 2 ;;
+            -h|--help)        exit 0 ;;
+            *)                AGENTS_TO_APPLY+=("$1"); shift ;;
+        esac
+    done
+}
+
+apply_agent() {
+    local agent="$1"
+    # Agents prefixed with "fail:" will fail
+    if [[ "$agent" == fail:* ]]; then
+        return 1
+    fi
+    return 0
+}
+
+parse_args "$@"
+
+# If --retry, filter agents from retry file
+if [[ $RETRY -eq 1 && -n "$RETRY_FILE" && -f "$RETRY_FILE" ]]; then
+    local -a retry_agents=()
+    while IFS= read -r agent; do
+        [[ -n "$agent" ]] && retry_agents+=("$agent")
+    done < "$RETRY_FILE"
+    AGENTS_TO_APPLY=("${retry_agents[@]}")
+fi
+
+# Process agents
+for agent in "${AGENTS_TO_APPLY[@]}"; do
+    if ! apply_agent "$agent"; then
+        FAILED_AGENTS+=("$agent")
+        ERRORS=$((ERRORS + 1))
+        if [[ $FAIL_FAST -eq 1 ]]; then
+            # With --fail-fast, exit immediately
+            EXIT_CODE=2
+            break
+        fi
+    fi
+done
+
+# Write failed agents file if there were errors
+if [[ $ERRORS -gt 0 && -z "$RETRY_FILE" ]]; then
+    # Use temp dir + failed-agents.txt
+    failed_file="${TEMP_TEST_DIR:-/tmp}/failed-agents.txt"
+    for agent in "${FAILED_AGENTS[@]}"; do
+        echo "$agent" >> "$failed_file"
+    done
+fi
+
+# Exit code semantics
+if [[ $EXIT_CODE -eq 2 ]]; then
+    exit 2
+elif [[ $ERRORS -gt 0 ]]; then
+    exit 1
+fi
+exit 0
+APPLY_MOCK
+    chmod +x "$mock_apply"
+}
+
+# ---------------------------------------------------------------------------
+# Test: --fail-fast stops after first error
+# ---------------------------------------------------------------------------
+
+@test "--fail-fast: stops processing after first agent error" {
+    local mock_apply="${TEMP_TEST_DIR}/apply.sh"
+    _create_mock_apply "$mock_apply"
+
+    # Three agents: agent1 succeeds, fail:agent2 fails (should stop here with --fail-fast)
+    run "$mock_apply" --fail-fast agent1 fail:agent2 agent3
+
+    # Should exit with code 2 (fail-fast abort)
+    [[ "$status" -eq 2 ]]
+}
+
+@test "--fail-fast: does NOT process agents after first error" {
+    local mock_apply="${TEMP_TEST_DIR}/apply.sh"
+    _create_mock_apply "$mock_apply"
+
+    # Create a marker file that tracks which agents were processed
+    local trace_file="${TEMP_TEST_DIR}/trace.txt"
+
+    cat > "$mock_apply" << 'APPLY_WITH_TRACE'
+#!/usr/bin/env bash
+set -euo pipefail
+
+FAIL_FAST=0
+ERRORS=0
+AGENTS_TO_APPLY=()
+FAILED_AGENTS=()
+EXIT_CODE=0
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --fail-fast)      FAIL_FAST=1; shift ;;
+            -h|--help)        exit 0 ;;
+            *)                AGENTS_TO_APPLY+=("$1"); shift ;;
+        esac
+    done
+}
+
+apply_agent() {
+    local agent="$1"
+    echo "processed: $agent" >> "$TRACE_FILE"
+    [[ "$agent" == fail:* ]] && return 1 || return 0
+}
+
+parse_args "$@"
+
+for agent in "${AGENTS_TO_APPLY[@]}"; do
+    if ! apply_agent "$agent"; then
+        FAILED_AGENTS+=("$agent")
+        ERRORS=$((ERRORS + 1))
+        if [[ $FAIL_FAST -eq 1 ]]; then
+            EXIT_CODE=2
+            break
+        fi
+    fi
+done
+
+[[ $EXIT_CODE -eq 2 ]] && exit 2 || exit 0
+APPLY_WITH_TRACE
+    chmod +x "$mock_apply"
+    export TRACE_FILE="$trace_file"
+
+    # Run: agent1 succeeds, fail:agent2 fails (stops), agent3 not reached
+    "$mock_apply" --fail-fast agent1 fail:agent2 agent3 || true
+
+    # Check trace: agent1 and fail:agent2 should be present, agent3 should NOT be
+    [[ $(grep -c "processed: agent1" "$trace_file") -eq 1 ]]
+    [[ $(grep -c "processed: fail:agent2" "$trace_file") -eq 1 ]]
+    [[ ! -f "$trace_file" || ! $(grep -q "processed: agent3" "$trace_file" 2>/dev/null) ]]
+}
+
+@test "--fail-fast without errors: processes all agents normally" {
+    local mock_apply="${TEMP_TEST_DIR}/apply.sh"
+    _create_mock_apply "$mock_apply"
+
+    # All agents succeed
+    run "$mock_apply" --fail-fast agent1 agent2 agent3
+    [[ "$status" -eq 0 ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test: failed-agents.txt written with correct agent names
+# ---------------------------------------------------------------------------
+
+@test "failed-agents.txt: created with failed agent names" {
+    local mock_apply="${TEMP_TEST_DIR}/apply.sh"
+    _create_mock_apply "$mock_apply"
+
+    export TEMP_TEST_DIR
+    failed_file="${TEMP_TEST_DIR}/failed-agents.txt"
+
+    # Run with two failures
+    "$mock_apply" agent1 fail:agent2 fail:agent3 || true
+
+    # failed-agents.txt should exist with agent names (one per line)
+    [[ -f "$failed_file" ]]
+    [[ $(wc -l < "$failed_file") -eq 2 ]]
+    grep -q "fail:agent2" "$failed_file"
+    grep -q "fail:agent3" "$failed_file"
+}
+
+@test "failed-agents.txt: not created when no errors" {
+    local mock_apply="${TEMP_TEST_DIR}/apply.sh"
+    _create_mock_apply "$mock_apply"
+
+    export TEMP_TEST_DIR
+    failed_file="${TEMP_TEST_DIR}/failed-agents.txt"
+
+    # Run with all successes
+    run "$mock_apply" agent1 agent2 agent3
+    [[ "$status" -eq 0 ]]
+
+    # failed-agents.txt should NOT exist
+    [[ ! -f "$failed_file" ]]
+}
+
+@test "failed-agents.txt: lists all failed agents in order" {
+    local mock_apply="${TEMP_TEST_DIR}/apply.sh"
+    _create_mock_apply "$mock_apply"
+
+    export TEMP_TEST_DIR
+    failed_file="${TEMP_TEST_DIR}/failed-agents.txt"
+
+    # Run with mixed success/failure
+    "$mock_apply" agent1 fail:agent2 agent3 fail:agent4 agent5 || true
+
+    # Check file contains exactly the failed agents
+    [[ -f "$failed_file" ]]
+    line1="$(sed -n '1p' "$failed_file")"
+    line2="$(sed -n '2p' "$failed_file")"
+    [[ "$line1" == "fail:agent2" ]]
+    [[ "$line2" == "fail:agent4" ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test: Exit code semantics
+# ---------------------------------------------------------------------------
+
+@test "exit code 0: when all agents succeed" {
+    local mock_apply="${TEMP_TEST_DIR}/apply.sh"
+    _create_mock_apply "$mock_apply"
+
+    run "$mock_apply" agent1 agent2 agent3
+    [[ "$status" -eq 0 ]]
+}
+
+@test "exit code 1: on partial failure (without --fail-fast)" {
+    local mock_apply="${TEMP_TEST_DIR}/apply.sh"
+    _create_mock_apply "$mock_apply"
+
+    # Without --fail-fast, should process all and exit 1 on errors
+    run "$mock_apply" agent1 fail:agent2 agent3
+    [[ "$status" -eq 1 ]]
+}
+
+@test "exit code 2: on --fail-fast abort" {
+    local mock_apply="${TEMP_TEST_DIR}/apply.sh"
+    _create_mock_apply "$mock_apply"
+
+    # With --fail-fast, exit 2 when stopped early
+    run "$mock_apply" --fail-fast agent1 fail:agent2 agent3
+    [[ "$status" -eq 2 ]]
+}
+
+@test "exit code 2: --fail-fast with first agent failing" {
+    local mock_apply="${TEMP_TEST_DIR}/apply.sh"
+    _create_mock_apply "$mock_apply"
+
+    run "$mock_apply" --fail-fast fail:agent1 agent2
+    [[ "$status" -eq 2 ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test: --retry reads failed-agents.txt and filters correctly
+# ---------------------------------------------------------------------------
+
+@test "--retry: reads agents from failed-agents.txt" {
+    local mock_apply="${TEMP_TEST_DIR}/apply.sh"
+    _create_mock_apply "$mock_apply"
+
+    export TEMP_TEST_DIR
+    failed_file="${TEMP_TEST_DIR}/failed-agents.txt"
+
+    # First run: create failed-agents.txt
+    echo "fail:agent1" > "$failed_file"
+    echo "fail:agent2" >> "$failed_file"
+
+    # Second run: --retry should only process agents from failed_file
+    local trace_file="${TEMP_TEST_DIR}/trace2.txt"
+
+    cat > "$mock_apply" << 'APPLY_WITH_RETRY'
+#!/usr/bin/env bash
+set -euo pipefail
+
+RETRY=0
+RETRY_FILE=""
+AGENTS_TO_APPLY=()
+FAILED_AGENTS=()
+ERRORS=0
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --retry)          RETRY=1; shift ;;
+            --retry-file)     RETRY_FILE="$2"; shift 2 ;;
+            *)                AGENTS_TO_APPLY+=("$1"); shift ;;
+        esac
+    done
+}
+
+apply_agent() {
+    local agent="$1"
+    echo "processed: $agent" >> "$TRACE_FILE"
+    [[ "$agent" == fail:* ]] && return 1 || return 0
+}
+
+parse_args "$@"
+
+# If --retry, read from retry file and ignore passed agents
+if [[ $RETRY -eq 1 && -n "$RETRY_FILE" && -f "$RETRY_FILE" ]]; then
+    AGENTS_TO_APPLY=()
+    while IFS= read -r agent; do
+        [[ -n "$agent" ]] && AGENTS_TO_APPLY+=("$agent")
+    done < "$RETRY_FILE"
+fi
+
+for agent in "${AGENTS_TO_APPLY[@]}"; do
+    if ! apply_agent "$agent"; then
+        FAILED_AGENTS+=("$agent")
+        ERRORS=$((ERRORS + 1))
+    fi
+done
+
+[[ $ERRORS -gt 0 ]] && exit 1 || exit 0
+APPLY_WITH_RETRY
+    chmod +x "$mock_apply"
+    export TRACE_FILE="$trace_file"
+
+    run "$mock_apply" --retry --retry-file "$failed_file" ignored-agent
+    # Exit 1 because the agents fail
+    [[ "$status" -eq 1 ]]
+
+    # Trace should contain only the agents from failed-agents.txt
+    [[ $(grep -c "processed: fail:agent1" "$trace_file") -eq 1 ]]
+    [[ $(grep -c "processed: fail:agent2" "$trace_file") -eq 1 ]]
+    # ignored-agent should NOT appear
+    [[ ! $(grep -q "processed: ignored-agent" "$trace_file" 2>/dev/null) ]]
+}
+
+@test "--retry: ignores command-line agent list when reading file" {
+    local mock_apply="${TEMP_TEST_DIR}/apply.sh"
+    _create_mock_apply "$mock_apply"
+
+    export TEMP_TEST_DIR
+    failed_file="${TEMP_TEST_DIR}/failed-agents.txt"
+
+    # Setup
+    echo "retry-agent1" > "$failed_file"
+    echo "retry-agent2" >> "$failed_file"
+
+    local trace_file="${TEMP_TEST_DIR}/trace3.txt"
+
+    # Use the mock that respects --retry
+    cat > "$mock_apply" << 'APPLY_RETRY_FILTER'
+#!/usr/bin/env bash
+set -euo pipefail
+
+RETRY=0
+RETRY_FILE=""
+AGENTS_TO_APPLY=()
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --retry)          RETRY=1; shift ;;
+            --retry-file)     RETRY_FILE="$2"; shift 2 ;;
+            *)                AGENTS_TO_APPLY+=("$1"); shift ;;
+        esac
+    done
+}
+
+apply_agent() {
+    echo "processed: $1" >> "$TRACE_FILE"
+    return 0
+}
+
+parse_args "$@"
+
+# When --retry, use file content instead of CLI args
+if [[ $RETRY -eq 1 && -n "$RETRY_FILE" && -f "$RETRY_FILE" ]]; then
+    AGENTS_TO_APPLY=()
+    while IFS= read -r agent; do
+        [[ -n "$agent" ]] && AGENTS_TO_APPLY+=("$agent")
+    done < "$RETRY_FILE"
+fi
+
+for agent in "${AGENTS_TO_APPLY[@]}"; do
+    apply_agent "$agent"
+done
+
+exit 0
+APPLY_RETRY_FILTER
+    chmod +x "$mock_apply"
+    export TRACE_FILE="$trace_file"
+
+    # Pass command-line agents but with --retry (should be ignored)
+    run "$mock_apply" --retry --retry-file "$failed_file" cli-agent1 cli-agent2
+    [[ "$status" -eq 0 ]]
+
+    # Only agents from file should be processed
+    [[ $(grep -c "processed: retry-agent1" "$trace_file") -eq 1 ]]
+    [[ $(grep -c "processed: retry-agent2" "$trace_file") -eq 1 ]]
+    # CLI agents should NOT be processed
+    [[ ! $(grep -q "processed: cli-agent1" "$trace_file" 2>/dev/null) ]]
+}
+
+@test "--retry with missing file: no agents processed" {
+    local mock_apply="${TEMP_TEST_DIR}/apply.sh"
+
+    cat > "$mock_apply" << 'APPLY_RETRY_MISSING'
+#!/usr/bin/env bash
+set -euo pipefail
+
+RETRY=0
+RETRY_FILE=""
+AGENTS_TO_APPLY=()
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --retry)          RETRY=1; shift ;;
+            --retry-file)     RETRY_FILE="$2"; shift 2 ;;
+            *)                AGENTS_TO_APPLY+=("$1"); shift ;;
+        esac
+    done
+}
+
+parse_args "$@"
+
+# If retry file doesn't exist, process no agents
+if [[ $RETRY -eq 1 && -n "$RETRY_FILE" ]]; then
+    if [[ ! -f "$RETRY_FILE" ]]; then
+        exit 0
+    fi
+    AGENTS_TO_APPLY=()
+    while IFS= read -r agent; do
+        [[ -n "$agent" ]] && AGENTS_TO_APPLY+=("$agent")
+    done < "$RETRY_FILE"
+fi
+
+# Count agents processed
+[[ ${#AGENTS_TO_APPLY[@]} -eq 0 ]] && exit 0 || exit 1
+APPLY_RETRY_MISSING
+    chmod +x "$mock_apply"
+
+    # Retry with non-existent file
+    run "$mock_apply" --retry --retry-file "/nonexistent/failed-agents.txt" agent1
+    [[ "$status" -eq 0 ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test: Integration — combined error handling scenarios
+# ---------------------------------------------------------------------------
+
+@test "combined: --fail-fast with multiple agents, writes no failed file" {
+    local mock_apply="${TEMP_TEST_DIR}/apply.sh"
+    _create_mock_apply "$mock_apply"
+
+    export TEMP_TEST_DIR
+    failed_file="${TEMP_TEST_DIR}/failed-agents.txt"
+
+    # With --fail-fast, we exit early, so no failed-agents.txt is written
+    # (actual apply.sh may handle this differently; this tests the concept)
+    run "$mock_apply" --fail-fast agent1 fail:agent2 agent3
+    [[ "$status" -eq 2 ]]
+    # File may or may not exist depending on implementation; both valid
+}
+
+@test "combined: multiple failures without --fail-fast, creates failed file" {
+    local mock_apply="${TEMP_TEST_DIR}/apply.sh"
+    _create_mock_apply "$mock_apply"
+
+    export TEMP_TEST_DIR
+    failed_file="${TEMP_TEST_DIR}/failed-agents.txt"
+
+    # Without --fail-fast, process all agents
+    run "$mock_apply" fail:agent1 agent2 fail:agent3
+    [[ "$status" -eq 1 ]]
+
+    # failed-agents.txt should list the two failures
+    [[ -f "$failed_file" ]]
+    [[ $(grep -c "fail:agent" "$failed_file") -eq 2 ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test: Symbol visibility — write_failed_agents_file must not be public
+# ---------------------------------------------------------------------------
+
+@test "write_failed_agents_file: public symbol must not exist after sourcing apply.sh" {
+    local script
+    script="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)/../../scripts/apply.sh"
+
+    # Source apply.sh in a subshell, stripping lines that execute at source-time
+    # (library sources, load_config call, and the main "$@" invocation) so we
+    # can inspect only function definitions.
+    run bash -c "
+        stripped=\"\$(grep -v \
+            -e '^#!/' \
+            -e '^set -' \
+            -e 'SCRIPT_DIR=' \
+            -e 'REPO_ROOT=' \
+            -e '# shellcheck' \
+            -e '^source ' \
+            -e '^load_config$' \
+            -e '^main \"\\\$@\"$' \
+            \"$script\")\"
+        eval \"\$stripped\" 2>/dev/null
+        declare -f write_failed_agents_file
+    "
+
+    [ "$status" -ne 0 ]
+}

--- a/tools/reconciler/tests/unit/test_apply_plan_entrypoints.bats
+++ b/tools/reconciler/tests/unit/test_apply_plan_entrypoints.bats
@@ -1,0 +1,500 @@
+#!/usr/bin/env bats
+# tests/unit/test_apply_plan_entrypoints.bats — entry-point tests for apply.sh and plan.sh
+#
+# Issue #190: Add tests for apply.sh and plan.sh script entry points.
+#
+# Tests invoke apply.sh and plan.sh with various flags and verify:
+#   - Exit codes are correct
+#   - Stdout / stderr output contains expected content
+#   - --dry-run in apply.sh delegates to plan.sh
+#   - --help prints usage and exits 0
+#   - No-agent-directory case exits 0 with informational message
+#
+# Uses a mock HTTP server (tests/helpers/mock_server.py) and a temporary
+# agents/ directory so the scripts have valid YAML to work with.
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+HELPERS_DIR="${SCRIPT_DIR}/tests/helpers"
+
+MOCK_PORT=18082
+MOCK_PID_FILE=""
+TEMP_DIR=""
+
+# ── Mock server helpers ───────────────────────────────────────────────────────
+
+_start_mock_server() {
+    local http_status="${1:-200}"
+    local body="${2}"
+    [[ -z "$body" ]] && body='[]'
+
+    MOCK_PID_FILE="${TEMP_DIR}/mock.pid"
+    MOCK_STATUS="$http_status" MOCK_BODY="$body" \
+        python3 "${HELPERS_DIR}/mock_server.py" "$MOCK_PORT" \
+        > /dev/null 2>&1 &
+    echo $! > "$MOCK_PID_FILE"
+    sleep 0.2
+}
+
+_stop_mock_server() {
+    if [[ -n "$MOCK_PID_FILE" && -f "$MOCK_PID_FILE" ]]; then
+        kill "$(cat "$MOCK_PID_FILE")" 2>/dev/null || true
+        rm -f "$MOCK_PID_FILE"
+    fi
+}
+
+# ── setup / teardown ─────────────────────────────────────────────────────────
+
+setup() {
+    TEMP_DIR="$(mktemp -d)"
+    export AGAMEMNON_URL="http://127.0.0.1:${MOCK_PORT}"
+    export AIM_LOCK_FILE="${TEMP_DIR}/.myrmidons.lock"
+}
+
+teardown() {
+    _stop_mock_server
+    [[ -n "$TEMP_DIR" ]] && rm -rf "$TEMP_DIR"
+    unset AIM_LOCK_FILE
+}
+
+# ── Helper: create a minimal agents directory in TEMP_DIR ─────────────────────
+
+_make_agents_dir() {
+    local host="${1:-hermes}"
+    mkdir -p "${TEMP_DIR}/agents/${host}"
+    cat > "${TEMP_DIR}/agents/${host}/myagent.yaml" <<YAML
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: test-ep-agent
+  host: ${host}
+spec:
+  label: MyAgent
+  program: claude-code
+  workingDirectory: /tmp
+  programArgs: ""
+  taskDescription: "Entry-point test agent"
+  tags: []
+  owner: mvillmow
+  role: member
+  deployment:
+    type: local
+  desiredState: active
+YAML
+}
+
+# ── apply.sh --help ───────────────────────────────────────────────────────────
+
+@test "apply.sh --help: exits 0" {
+    run "${SCRIPT_DIR}/scripts/apply.sh" --help
+    [[ "$status" -eq 0 ]]
+}
+
+@test "apply.sh --help: prints usage information" {
+    run "${SCRIPT_DIR}/scripts/apply.sh" --help
+    [[ "$output" == *"Usage"* ]]
+}
+
+@test "apply.sh --help: mentions HIBERNATE_SETTLE_SECONDS" {
+    run "${SCRIPT_DIR}/scripts/apply.sh" --help
+    [[ "$output" == *"HIBERNATE_SETTLE_SECONDS"* ]]
+}
+
+# ── status.sh --help ──────────────────────────────────────────────────────────
+
+@test "status.sh --help: exits 0" {
+    run "${SCRIPT_DIR}/scripts/status.sh" --help
+    [[ "$status" -eq 0 ]]
+}
+
+@test "status.sh --help: prints usage information" {
+    run "${SCRIPT_DIR}/scripts/status.sh" --help
+    [[ "$output" == *"Usage"* ]]
+}
+
+@test "status.sh --help: lists MYRMIDONS_DEFAULT_OWNER in environment section" {
+    run "${SCRIPT_DIR}/scripts/status.sh" --help
+    [[ "$output" == *"MYRMIDONS_DEFAULT_OWNER"* ]]
+}
+
+# ── plan.sh --help ────────────────────────────────────────────────────────────
+
+@test "plan.sh --help: exits 0" {
+    run "${SCRIPT_DIR}/scripts/plan.sh" --help
+    [[ "$status" -eq 0 ]]
+}
+
+@test "plan.sh --help: prints usage information" {
+    run "${SCRIPT_DIR}/scripts/plan.sh" --help
+    [[ "$output" == *"Usage"* ]]
+}
+
+@test "plan.sh --help: lists MYRMIDONS_DEFAULT_OWNER in environment section" {
+    run "${SCRIPT_DIR}/scripts/plan.sh" --help
+    [[ "$output" == *"MYRMIDONS_DEFAULT_OWNER"* ]]
+}
+
+# ── apply.sh --dry-run delegates to plan.sh ──────────────────────────────────
+
+@test "apply.sh --dry-run: invokes plan.sh (mock server, no agents dir → exit 0)" {
+    # With no agents dir, plan.sh should exit 0 (no files found)
+    # But apply.sh will source api.sh which needs a reachable server for check_connection
+    _start_mock_server 200 '[]'
+
+    # Override REPO_ROOT so apply.sh doesn't find our repo's agents/
+    # We do this by symlinking scripts but using a clean tempdir as cwd
+    # apply.sh --dry-run execs plan.sh; plan.sh exits 0 when no YAML files found
+    # We run with HOME=TEMP_DIR to prevent real agents from being found
+    local empty_agents="${TEMP_DIR}/no-agents"
+    mkdir -p "${empty_agents}"
+
+    # Rather than fighting BASH_SOURCE path resolution, we invoke apply.sh directly
+    # and verify it exits via plan.sh's code path.
+    # plan.sh exits 0 when there are no YAML files (our temp dir has none).
+    # We need to point REPO_ROOT at a place with no agents/ — we do that by
+    # temporarily overriding via a wrapper that redefines get_agent_files.
+    run bash -c "
+        export AGAMEMNON_URL='http://127.0.0.1:${MOCK_PORT}'
+        export AIM_LOCK_FILE='${TEMP_DIR}/.myrmidons.lock'
+        # Override get_agent_files to return nothing
+        get_agent_files() { return 0; }
+        export -f get_agent_files
+        # plan.sh sources lib/*.sh which redefine get_agent_files, but we can't
+        # easily override via env. Instead we verify the delegation by checking
+        # apply.sh --dry-run calls plan.sh which accepts --dry-run arg silently.
+        '${SCRIPT_DIR}/scripts/plan.sh' --help
+    "
+    [[ "$status" -eq 0 ]]
+}
+
+@test "apply.sh --dry-run: passes host argument through to plan.sh" {
+    # Verify that --dry-run + host does not crash arg parsing
+    # We test the arg filtering logic by running a minimal version of the
+    # filter used in apply.sh main() to produce clean_args for plan.sh.
+    run bash -c "
+        orig_args=(hermes --dry-run --force --lock-timeout 30)
+        clean_args=()
+        skip_next=0
+        for arg in \"\${orig_args[@]}\"; do
+            if [[ \$skip_next -eq 1 ]]; then skip_next=0; continue; fi
+            case \"\$arg\" in
+                --force | --dry-run) continue ;;
+                --lock-timeout) skip_next=1; continue ;;
+                *) clean_args+=(\"\$arg\") ;;
+            esac
+        done
+        # Should be just: hermes
+        echo \"\${clean_args[*]}\"
+    "
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == "hermes" ]]
+}
+
+# ── plan.sh with mock server — agents exist in Agamemnon ─────────────────────
+
+@test "plan.sh: exits 0 when no YAML files found" {
+    _start_mock_server 200 '[]'
+
+    # Use a temp REPO_ROOT with no agents/ directory via a wrapper script
+    local wrapper="${TEMP_DIR}/plan_wrapper.sh"
+    cat > "$wrapper" <<WRAPPER
+#!/usr/bin/env bash
+set -euo pipefail
+export AGAMEMNON_URL="http://127.0.0.1:${MOCK_PORT}"
+
+# Source required libs from real location
+source "${SCRIPT_DIR}/scripts/lib/log.sh"
+source "${SCRIPT_DIR}/scripts/lib/api.sh"
+source "${SCRIPT_DIR}/scripts/lib/reconcile.sh"
+
+# Override get_agent_files to return nothing
+get_agent_files() { :; }
+
+HOST=""
+parse_args() {
+    while [[ \$# -gt 0 ]]; do
+        case "\$1" in
+            -h|--help) exit 0 ;;
+            --dry-run) shift ;;
+            *) HOST="\$1"; shift ;;
+        esac
+    done
+}
+
+main() {
+    parse_args "\$@"
+    agamemnon_check_connection
+
+    local agents_json
+    agents_json="\$(agamemnon_list_agents)"
+
+    local yaml_files=()
+    # get_agent_files returns nothing
+
+    if [[ \${#yaml_files[@]} -eq 0 ]]; then
+        echo "No agent YAML files found."
+        exit 0
+    fi
+}
+
+main "\$@"
+WRAPPER
+    chmod +x "$wrapper"
+
+    run "$wrapper"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"No agent YAML files found"* ]]
+}
+
+@test "plan.sh: exits 1 when YAML agents would be created" {
+    # Mock Agamemnon returns empty list (no existing agents)
+    _start_mock_server 200 '[]'
+    _make_agents_dir hermes
+
+    # Use a wrapper that overrides REPO_ROOT so get_agent_files finds our agents
+    local wrapper="${TEMP_DIR}/plan_wrapper2.sh"
+    cat > "$wrapper" <<WRAPPER
+#!/usr/bin/env bash
+set -euo pipefail
+export AGAMEMNON_URL="http://127.0.0.1:${MOCK_PORT}"
+
+SCRIPT_DIR_REAL="${SCRIPT_DIR}"
+TEMP_DIR_REAL="${TEMP_DIR}"
+
+source "\${SCRIPT_DIR_REAL}/scripts/lib/log.sh"
+source "\${SCRIPT_DIR_REAL}/scripts/lib/api.sh"
+
+# Override get_agent_files to use our temp agents dir
+get_agent_files() {
+    find "\${TEMP_DIR_REAL}/agents" -name "*.yaml" 2>/dev/null || true
+}
+
+source "\${SCRIPT_DIR_REAL}/scripts/lib/reconcile.sh"
+
+# Re-override after sourcing reconcile.sh since it redefines get_agent_files
+get_agent_files() {
+    find "\${TEMP_DIR_REAL}/agents" -name "*.yaml" 2>/dev/null || true
+}
+
+HOST=""
+parse_args() {
+    while [[ \$# -gt 0 ]]; do
+        case "\$1" in
+            -h|--help) exit 0 ;;
+            --dry-run) shift ;;
+            *) HOST="\$1"; shift ;;
+        esac
+    done
+}
+
+plan_agent() {
+    local yaml_file="\$1"
+    local agents_json="\$2"
+    local fields
+    declare -A fields
+    while IFS='=' read -r key value; do
+        fields["\$key"]="\${value}"
+    done < <(parse_agent_yaml "\$yaml_file")
+
+    local name="\${fields[name]}"
+    local actual_json
+    actual_json="\$(echo "\$agents_json" | jq -r --arg name "\$name" '.[] | select(.name == \$name)')"
+
+    if [[ -z "\$actual_json" ]]; then
+        echo "[+] CREATE \${name}"
+        return 1
+    fi
+    return 0
+}
+
+main() {
+    parse_args "\$@"
+    agamemnon_check_connection
+
+    local agents_json
+    agents_json="\$(agamemnon_list_agents)"
+
+    local yaml_files
+    mapfile -t yaml_files < <(get_agent_files)
+
+    if [[ \${#yaml_files[@]} -eq 0 ]]; then
+        echo "No agent YAML files found."
+        exit 0
+    fi
+
+    local has_changes=0
+    for yaml_file in "\${yaml_files[@]}"; do
+        plan_agent "\$yaml_file" "\$agents_json" || has_changes=1
+    done
+
+    if [[ \$has_changes -eq 0 ]]; then
+        exit 0
+    else
+        exit 1
+    fi
+}
+
+main "\$@"
+WRAPPER
+    chmod +x "$wrapper"
+
+    run "$wrapper"
+    # Should exit 1 because CREATE would be needed
+    [[ "$status" -eq 1 ]]
+    [[ "$output" == *"CREATE"* ]]
+}
+
+@test "plan.sh: exits 0 when all agents are UNCHANGED" {
+    # Mock Agamemnon returns an agent that matches our YAML exactly.
+    # owner/role are omitted (empty) because compute_drift is called without
+    # those args (positions $11/$12 default to ""), so actual must also be "".
+    _start_mock_server 200 '[{"id":"id-001","name":"test-ep-agent","status":"active","label":"MyAgent","program":"claude-code","workingDirectory":"/tmp","programArgs":"","taskDescription":"Entry-point test agent","tags":[],"owner":"","role":""}]'
+    _make_agents_dir hermes
+
+    local wrapper="${TEMP_DIR}/plan_wrapper3.sh"
+    cat > "$wrapper" <<WRAPPER
+#!/usr/bin/env bash
+set -euo pipefail
+export AGAMEMNON_URL="http://127.0.0.1:${MOCK_PORT}"
+
+SCRIPT_DIR_REAL="${SCRIPT_DIR}"
+TEMP_DIR_REAL="${TEMP_DIR}"
+
+source "\${SCRIPT_DIR_REAL}/scripts/lib/log.sh"
+source "\${SCRIPT_DIR_REAL}/scripts/lib/api.sh"
+source "\${SCRIPT_DIR_REAL}/scripts/lib/reconcile.sh"
+
+get_agent_files() {
+    find "\${TEMP_DIR_REAL}/agents" -name "*.yaml" 2>/dev/null || true
+}
+
+plan_agent() {
+    local yaml_file="\$1"
+    local agents_json="\$2"
+    local fields
+    declare -A fields
+    while IFS='=' read -r key value; do
+        fields["\$key"]="\${value}"
+    done < <(parse_agent_yaml "\$yaml_file")
+    local name="\${fields[name]}"
+    local desired_state="\${fields[desiredState]:-active}"
+    local label="\${fields[label]:-}"
+    local program="\${fields[program]:-}"
+    local workdir="\${fields[workingDirectory]:-}"
+    local args="\${fields[programArgs]:-}"
+    local desc="\${fields[taskDescription]:-}"
+    local tags="\${fields[tags]:-}"
+    local actual_json
+    actual_json="\$(echo "\$agents_json" | jq -r --arg n "\$name" '.[] | select(.name == \$n)')"
+    if [[ -z "\$actual_json" ]]; then return 1; fi
+    local action
+    action="\$(compute_drift "\$name" "\$desired_state" "\$actual_json" \
+        "\$label" "\$program" "\$workdir" "\$args" "\$desc" "\$tags" "" "" "" "local")"
+    [[ "\$action" == "UNCHANGED" ]]
+}
+
+main() {
+    agamemnon_check_connection
+    local agents_json
+    agents_json="\$(agamemnon_list_agents)"
+    local yaml_files
+    mapfile -t yaml_files < <(get_agent_files)
+    if [[ \${#yaml_files[@]} -eq 0 ]]; then exit 0; fi
+    local has_changes=0
+    for yaml_file in "\${yaml_files[@]}"; do
+        plan_agent "\$yaml_file" "\$agents_json" || has_changes=1
+    done
+    [[ \$has_changes -eq 0 ]] && exit 0 || exit 1
+}
+
+main "\$@"
+WRAPPER
+    chmod +x "$wrapper"
+
+    run "$wrapper"
+    [[ "$status" -eq 0 ]]
+}
+
+# ── apply.sh — connection failure ─────────────────────────────────────────────
+
+@test "apply.sh: non-zero exit when Agamemnon is unreachable" {
+    export AGAMEMNON_URL="http://127.0.0.1:19997"  # nothing listening here
+
+    run "${SCRIPT_DIR}/scripts/apply.sh"
+    [[ "$status" -ne 0 ]]
+}
+
+@test "plan.sh: non-zero exit when Agamemnon is unreachable" {
+    export AGAMEMNON_URL="http://127.0.0.1:19998"  # nothing listening here
+
+    run "${SCRIPT_DIR}/scripts/plan.sh"
+    [[ "$status" -ne 0 ]]
+}
+
+# ── apply.sh — no agents + no fleets directory ────────────────────────────────
+
+@test "apply.sh: exits non-zero when neither agents/ nor fleets/ dir exist" {
+    _start_mock_server 200 '[]'
+
+    # Run apply.sh with a REPO_ROOT that has no agents/ or fleets/
+    # We achieve this by running from TEMP_DIR which has neither
+    local wrapper="${TEMP_DIR}/apply_nodirs.sh"
+    cat > "$wrapper" <<WRAPPER
+#!/usr/bin/env bash
+set -euo pipefail
+export AGAMEMNON_URL="http://127.0.0.1:${MOCK_PORT}"
+SCRIPT_DIR_REAL="${SCRIPT_DIR}"
+TEMP_DIR_REAL="${TEMP_DIR}"
+
+source "\${SCRIPT_DIR_REAL}/scripts/lib/log.sh"
+source "\${SCRIPT_DIR_REAL}/scripts/lib/api.sh"
+source "\${SCRIPT_DIR_REAL}/scripts/lib/reconcile.sh"
+
+agamemnon_check_connection
+
+has_agents=false
+has_fleets=false
+[[ -d "\${TEMP_DIR_REAL}/agents/" ]] && has_agents=true
+[[ -d "\${TEMP_DIR_REAL}/fleets/" ]] && has_fleets=true
+
+if [[ "\$has_agents" == "false" && "\$has_fleets" == "false" ]]; then
+    echo "ERROR: Neither agents/ nor fleets/ directory found"
+    exit 1
+fi
+exit 0
+WRAPPER
+    chmod +x "$wrapper"
+
+    run "$wrapper"
+    [[ "$status" -eq 1 ]]
+    [[ "$output" == *"Neither agents/ nor fleets/"* ]]
+}
+
+# ── apply.sh argument parsing edge cases ─────────────────────────────────────
+
+@test "apply.sh parse_args: --prune + --dry-run + host round-trip via filter" {
+    # Simulate the clean_args filter in apply.sh main():
+    # --dry-run and --force should be stripped; --lock-timeout + value stripped;
+    # remaining args (host, --prune) passed through to plan.sh
+    run bash -c "
+        orig_args=(hermes --prune --dry-run --force --lock-timeout 60 --output json)
+        clean_args=()
+        skip_next=0
+        for arg in \"\${orig_args[@]}\"; do
+            if [[ \$skip_next -eq 1 ]]; then skip_next=0; continue; fi
+            case \"\$arg\" in
+                --force | --dry-run) continue ;;
+                --lock-timeout) skip_next=1; continue ;;
+                *) clean_args+=(\"\$arg\") ;;
+            esac
+        done
+        echo \"\${clean_args[*]}\"
+    "
+    [[ "$status" -eq 0 ]]
+    # hermes, --prune, --output, json should remain; --dry-run, --force, --lock-timeout 60 stripped
+    [[ "$output" == *"hermes"* ]]
+    [[ "$output" == *"--prune"* ]]
+    [[ "$output" != *"--dry-run"* ]]
+    [[ "$output" != *"--force"* ]]
+    [[ "$output" != *"--lock-timeout"* ]]
+    [[ "$output" != *"60"* ]]
+}

--- a/tools/reconciler/tests/unit/test_apply_sc2154.bats
+++ b/tools/reconciler/tests/unit/test_apply_sc2154.bats
@@ -1,0 +1,61 @@
+#!/usr/bin/env bats
+# tests/unit/test_apply_sc2154.bats — regression guard for issues #370 and #392
+#
+# Issue #370: ${repo_root} (lowercase, undefined) used instead of ${REPO_ROOT}
+# in the effective_snapshot_dir fallback expression inside apply.sh::main().
+# Under set -u this causes an unbound-variable abort; without set -u it writes
+# snapshots to /.myrmidons/snapshots on the root filesystem.
+#
+# Issue #392: Wires shellcheck SC2154 (referenced-but-not-assigned) into the
+# permanent lint entry points so the class of bug from #370 cannot reappear.
+#
+# These tests verify:
+#   - REPO_ROOT is defined (non-empty) in apply.sh's global scope
+#   - The snapshot_dir fallback references REPO_ROOT (correct case), not repo_root
+#   - No lowercase alias repo_root is defined in apply.sh
+#   - SC2154 is enabled in lint-shell.sh
+#   - SC2154 is enabled in .pre-commit-config.yaml's shellcheck hook args
+
+SCRIPT_DIR=""
+
+setup() {
+    SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+}
+
+# ---------------------------------------------------------------------------
+# #370 regression: REPO_ROOT casing
+# ---------------------------------------------------------------------------
+
+@test "apply.sh: REPO_ROOT is assigned at global scope" {
+    grep -qE '^REPO_ROOT=' "${SCRIPT_DIR}/scripts/apply.sh"
+}
+
+@test "apply.sh: no lowercase repo_root reference exists" {
+    # Any occurrence of \${repo_root} (lowercase) is a bug — the variable is REPO_ROOT.
+    ! grep -qE '\$\{?repo_root\}?' "${SCRIPT_DIR}/scripts/apply.sh"
+}
+
+@test "apply.sh: effective_snapshot_dir fallback uses REPO_ROOT (uppercase)" {
+    # The pattern must contain REPO_ROOT (not repo_root) in the snapshot dir expression.
+    grep -qE 'effective_snapshot_dir=.*REPO_ROOT' "${SCRIPT_DIR}/scripts/apply.sh"
+}
+
+@test "apply.sh: MYRMIDONS_STATE_DIR uses REPO_ROOT (uppercase)" {
+    grep -qE 'MYRMIDONS_STATE_DIR=.*REPO_ROOT' "${SCRIPT_DIR}/scripts/apply.sh"
+}
+
+# ---------------------------------------------------------------------------
+# #392: SC2154 is wired into permanent lint entry points
+# ---------------------------------------------------------------------------
+
+@test "lint-shell.sh: SC2154 is enabled in shellcheck invocation" {
+    grep -qF -- '--enable=SC2154' "${SCRIPT_DIR}/scripts/lint-shell.sh"
+}
+
+@test ".pre-commit-config.yaml: SC2154 is enabled in shellcheck hook args" {
+    grep -qF -- '--enable=SC2154' "${SCRIPT_DIR}/.pre-commit-config.yaml"
+}
+
+@test "pixi.toml: SC2154 is enabled in lint env lint-shell task" {
+    grep -qF -- '--enable=SC2154' "${SCRIPT_DIR}/pixi.toml"
+}

--- a/tools/reconciler/tests/unit/test_apply_update_patch.bats
+++ b/tools/reconciler/tests/unit/test_apply_update_patch.bats
@@ -1,0 +1,494 @@
+#!/usr/bin/env bats
+# tests/unit/test_apply_update_patch.bats — verify the JSON patch body sent on UPDATE
+#
+# Issue #99: Add shell-level tests for apply.sh UPDATE patch body.
+#
+# Uses a mock curl to capture the PATCH request body when apply.sh detects drift
+# and calls agamemnon_update_agent. Verifies the JSON patch contains the
+# expected fields: label, program, workingDirectory, programArgs,
+# taskDescription, tags, owner, role.
+#
+# Approach:
+#   - Source apply.sh helper functions directly (build_create_json is in reconcile.sh)
+#   - Source reconcile.sh directly and call apply_agent() with a mock agents_json
+#   - Mock agamemnon_update_agent to capture its body argument
+#   - Mock agamemnon_create_agent and agamemnon_wake_agent as no-ops
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+
+# ── shared variables ─────────────────────────────────────────────────────────
+
+TEMP_DIR=""
+CAPTURED_PATCH_FILE=""
+
+# ── setup / teardown ─────────────────────────────────────────────────────────
+
+setup() {
+    TEMP_DIR="$(mktemp -d)"
+    CAPTURED_PATCH_FILE="${TEMP_DIR}/patch_body.json"
+
+    export AGAMEMNON_URL="http://localhost:19999"
+    export OUTPUT_FORMAT="text"
+    export CREATED=0 UPDATED=0 WOKEN=0 HIBERNATED=0 UNCHANGED=0 PRUNED=0 ERRORS=0
+
+    # shellcheck source=/dev/null
+    source "${SCRIPT_DIR}/scripts/lib/log.sh"
+    # shellcheck source=/dev/null
+    source "${SCRIPT_DIR}/scripts/lib/reconcile.sh"
+
+    # Stub report functions (defined in report.sh which we don't need here)
+    report_add_agent() { : ; }
+    report_add_unmanaged() { : ; }
+
+    # Stub API functions that we don't want to call for real
+    agamemnon_create_agent() { echo '{"id":"new-id-001","name":"test"}'; }
+    agamemnon_wake_agent()   { : ; }
+    agamemnon_hibernate_agent() { : ; }
+
+    # Mock agamemnon_update_agent to capture the patch body
+    agamemnon_update_agent() {
+        # $1 = agent_id, $2 = patch body JSON
+        echo "$2" > "$CAPTURED_PATCH_FILE"
+        echo '{"id":"existing-id","name":"test"}' # return a valid response
+    }
+}
+
+teardown() {
+    [[ -n "$TEMP_DIR" ]] && rm -rf "$TEMP_DIR"
+    unset OUTPUT_FORMAT CREATED UPDATED WOKEN HIBERNATED UNCHANGED PRUNED ERRORS
+}
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+# Build a minimal actual_json simulating an existing agent returned by Agamemnon.
+# Arguments: status label program workdir args desc tags_json owner role
+_make_actual_json() {
+    # Note: $label is a reserved keyword in jq 1.6; use $lbl instead.
+    jq -n \
+        --arg id        "existing-id" \
+        --arg status    "$1" \
+        --arg lbl       "$2" \
+        --arg program   "$3" \
+        --arg workdir   "$4" \
+        --arg args      "$5" \
+        --arg desc      "$6" \
+        --argjson tags  "$7" \
+        --arg owner     "$8" \
+        --arg role      "$9" \
+        '{id: $id, status: $status, label: $lbl, program: $program,
+          workingDirectory: $workdir, programArgs: $args,
+          taskDescription: $desc, tags: $tags,
+          owner: $owner, role: $role}'
+}
+
+# Create a minimal agent YAML in TEMP_DIR for testing.
+_make_agent_yaml() {
+    local name="$1" label="$2" program="$3" workdir="$4" args="$5"
+    local desc="$6" tags="$7" owner="$8" role="$9" desired="${10:-active}"
+    cat > "${TEMP_DIR}/agent.yaml" <<YAML
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: ${name}
+  host: hermes
+spec:
+  label: ${label}
+  program: ${program}
+  workingDirectory: ${workdir}
+  programArgs: "${args}"
+  taskDescription: "${desc}"
+  tags: [${tags}]
+  owner: ${owner}
+  role: ${role}
+  deployment:
+    type: local
+  desiredState: ${desired}
+YAML
+    echo "${TEMP_DIR}/agent.yaml"
+}
+
+# ── source apply.sh functions in a controlled way ─────────────────────────────
+# We cannot exec apply.sh directly (it calls main() at the end), so we copy
+# just the apply_agent() function here, mirroring apply.sh exactly.
+
+apply_agent() {
+    local yaml_file="$1"
+    local agents_json="$2"
+
+    local name label program workdir args desc tags owner role desired_state
+    name="$(yq eval '.metadata.name' "$yaml_file")"
+    local agent_host
+    agent_host="$(yq eval '.metadata.host // "hermes"' "$yaml_file")"
+    label="$(yq eval '.spec.label // ""' "$yaml_file")"
+    program="$(yq eval '.spec.program // "claude-code"' "$yaml_file")"
+    workdir="$(yq eval '.spec.workingDirectory // ""' "$yaml_file")"
+    args="$(yq eval '.spec.programArgs // ""' "$yaml_file")"
+    desc="$(yq eval '.spec.taskDescription // ""' "$yaml_file")"
+    tags="$(yq eval '.spec.tags // [] | join(",")' "$yaml_file")"
+    owner="$(yq eval '.spec.owner // ""' "$yaml_file")"
+    role="$(yq eval '.spec.role // "member"' "$yaml_file")"
+    desired_state="$(yq eval '.spec.desiredState // "active"' "$yaml_file")"
+
+    local actual_json
+    actual_json="$(echo "$agents_json" | jq -r --arg n "$name" '.[] | select(.name == $n)')"
+
+    if [[ -z "$actual_json" ]]; then
+        local create_body
+        create_body="$(build_create_json "$name" "$label" "$program" "$workdir" "$args" "$desc" "$tags" "$owner" "$role")"
+        local result
+        if result="$(agamemnon_create_agent "$create_body" 2>&1)"; then
+            local new_id
+            new_id="$(echo "$result" | jq -r '.id // empty')"
+            CREATED=$((CREATED + 1))
+            if [[ "$desired_state" == "active" && -n "$new_id" ]]; then
+                agamemnon_wake_agent "$new_id" > /dev/null
+                WOKEN=$((WOKEN + 1))
+            fi
+            report_add_agent "$name" "$agent_host" "CREATE" "$desired_state" "created" "[]" ""
+        else
+            ERRORS=$((ERRORS + 1))
+            report_add_agent "$name" "$agent_host" "ERROR" "$desired_state" "unknown" "[]" "create failed"
+        fi
+        return
+    fi
+
+    local actual_id actual_status
+    actual_id="$(echo "$actual_json" | jq -r '.id')"
+    actual_status="$(echo "$actual_json" | jq -r '.status // "unknown"')"
+
+    local action
+    action="$(compute_drift "$name" "$desired_state" "$actual_json" \
+        "$label" "$program" "$workdir" "$args" "$desc" "$tags" "" "" "" "local")"
+
+    case "$action" in
+        UNCHANGED)
+            UNCHANGED=$((UNCHANGED + 1))
+            report_add_agent "$name" "$agent_host" "UNCHANGED" "$desired_state" "$actual_status" "[]" ""
+            ;;
+        WAKE)
+            agamemnon_wake_agent "$actual_id" > /dev/null
+            WOKEN=$((WOKEN + 1))
+            report_add_agent "$name" "$agent_host" "WAKE" "$desired_state" "$actual_status" "[]" ""
+            ;;
+        HIBERNATE)
+            agamemnon_hibernate_agent "$actual_id" > /dev/null
+            HIBERNATED=$((HIBERNATED + 1))
+            report_add_agent "$name" "$agent_host" "HIBERNATE" "$desired_state" "$actual_status" "[]" ""
+            ;;
+        UPDATE:*)
+            local _changed_fields="${action#UPDATE:}"
+
+            local tags_json
+            if [[ -z "$tags" ]]; then
+                tags_json="[]"
+            else
+                tags_json="$(echo "$tags" | jq -Rc 'split(",")')"
+            fi
+
+            local patch_body
+            patch_body="$(jq -n \
+                --arg label "$label" \
+                --arg program "$program" \
+                --arg workingDirectory "$workdir" \
+                --arg programArgs "$args" \
+                --arg taskDescription "$desc" \
+                --argjson tags "$tags_json" \
+                --arg owner "$owner" \
+                --arg role "$role" \
+                '{label: $label, program: $program, workingDirectory: $workingDirectory,
+                  programArgs: $programArgs, taskDescription: $taskDescription,
+                  tags: $tags, owner: $owner, role: $role}')"
+
+            if agamemnon_update_agent "$actual_id" "$patch_body" > /dev/null 2>&1; then
+                UPDATED=$((UPDATED + 1))
+                report_add_agent "$name" "$agent_host" "UPDATE" "$desired_state" "$actual_status" "[]" ""
+            else
+                ERRORS=$((ERRORS + 1))
+                report_add_agent "$name" "$agent_host" "ERROR" "$desired_state" "$actual_status" "[]" "update failed"
+            fi
+
+            if [[ "$desired_state" == "active" && "$actual_status" == "offline" ]]; then
+                agamemnon_wake_agent "$actual_id" > /dev/null
+                WOKEN=$((WOKEN + 1))
+            elif [[ "$desired_state" == "hibernated" && \
+                    ("$actual_status" == "active" || "$actual_status" == "online") ]]; then
+                agamemnon_hibernate_agent "$actual_id" > /dev/null
+                HIBERNATED=$((HIBERNATED + 1))
+            fi
+            ;;
+    esac
+}
+
+# ── Tests: patch body field presence ─────────────────────────────────────────
+
+@test "UPDATE patch body: contains 'label' field" {
+    local yaml_file
+    yaml_file="$(_make_agent_yaml "test-agent" "NewLabel" "claude-code" "/tmp" "" "" "" "mvillmow" "member")"
+
+    # Actual agent has a different label → triggers UPDATE
+    local agents_json
+    agents_json="$(jq -n '[{
+        "id":"existing-id","name":"test-agent","status":"active",
+        "label":"OldLabel","program":"claude-code",
+        "workingDirectory":"/tmp","programArgs":"",
+        "taskDescription":"","tags":[],"owner":"mvillmow","role":"member"
+    }]')"
+
+    apply_agent "$yaml_file" "$agents_json"
+
+    [[ -f "$CAPTURED_PATCH_FILE" ]]
+    local field
+    field="$(jq -r '.label' "$CAPTURED_PATCH_FILE")"
+    [[ "$field" == "NewLabel" ]]
+}
+
+@test "UPDATE patch body: contains 'program' field" {
+    local yaml_file
+    yaml_file="$(_make_agent_yaml "test-agent" "MyAgent" "aider" "/tmp" "" "" "" "mvillmow" "member")"
+
+    # Actual has claude-code → desired is aider → UPDATE
+    local agents_json
+    agents_json="$(jq -n '[{
+        "id":"existing-id","name":"test-agent","status":"active",
+        "label":"MyAgent","program":"claude-code",
+        "workingDirectory":"/tmp","programArgs":"",
+        "taskDescription":"","tags":[],"owner":"mvillmow","role":"member"
+    }]')"
+
+    apply_agent "$yaml_file" "$agents_json"
+
+    [[ -f "$CAPTURED_PATCH_FILE" ]]
+    local field
+    field="$(jq -r '.program' "$CAPTURED_PATCH_FILE")"
+    [[ "$field" == "aider" ]]
+}
+
+@test "UPDATE patch body: contains 'workingDirectory' field" {
+    local yaml_file
+    yaml_file="$(_make_agent_yaml "test-agent" "MyAgent" "claude-code" "/new/path" "" "" "" "mvillmow" "member")"
+
+    local agents_json
+    agents_json="$(jq -n '[{
+        "id":"existing-id","name":"test-agent","status":"active",
+        "label":"MyAgent","program":"claude-code",
+        "workingDirectory":"/old/path","programArgs":"",
+        "taskDescription":"","tags":[],"owner":"mvillmow","role":"member"
+    }]')"
+
+    apply_agent "$yaml_file" "$agents_json"
+
+    [[ -f "$CAPTURED_PATCH_FILE" ]]
+    local field
+    field="$(jq -r '.workingDirectory' "$CAPTURED_PATCH_FILE")"
+    [[ "$field" == "/new/path" ]]
+}
+
+@test "UPDATE patch body: contains 'programArgs' field" {
+    local yaml_file
+    yaml_file="$(_make_agent_yaml "test-agent" "MyAgent" "claude-code" "/tmp" "--new-flag" "" "" "mvillmow" "member")"
+
+    local agents_json
+    agents_json="$(jq -n '[{
+        "id":"existing-id","name":"test-agent","status":"active",
+        "label":"MyAgent","program":"claude-code",
+        "workingDirectory":"/tmp","programArgs":"--old-flag",
+        "taskDescription":"","tags":[],"owner":"mvillmow","role":"member"
+    }]')"
+
+    apply_agent "$yaml_file" "$agents_json"
+
+    [[ -f "$CAPTURED_PATCH_FILE" ]]
+    local field
+    field="$(jq -r '.programArgs' "$CAPTURED_PATCH_FILE")"
+    [[ "$field" == "--new-flag" ]]
+}
+
+@test "UPDATE patch body: contains 'taskDescription' field" {
+    local yaml_file
+    yaml_file="$(_make_agent_yaml "test-agent" "MyAgent" "claude-code" "/tmp" "" "New description" "" "mvillmow" "member")"
+
+    local agents_json
+    agents_json="$(jq -n '[{
+        "id":"existing-id","name":"test-agent","status":"active",
+        "label":"MyAgent","program":"claude-code",
+        "workingDirectory":"/tmp","programArgs":"",
+        "taskDescription":"Old description","tags":[],"owner":"mvillmow","role":"member"
+    }]')"
+
+    apply_agent "$yaml_file" "$agents_json"
+
+    [[ -f "$CAPTURED_PATCH_FILE" ]]
+    local field
+    field="$(jq -r '.taskDescription' "$CAPTURED_PATCH_FILE")"
+    [[ "$field" == "New description" ]]
+}
+
+@test "UPDATE patch body: contains 'tags' field as JSON array" {
+    local yaml_file
+    yaml_file="$(_make_agent_yaml "test-agent" "MyAgent" "claude-code" "/tmp" "" "" "ai,ops" "mvillmow" "member")"
+
+    local agents_json
+    agents_json="$(jq -n '[{
+        "id":"existing-id","name":"test-agent","status":"active",
+        "label":"MyAgent","program":"claude-code",
+        "workingDirectory":"/tmp","programArgs":"",
+        "taskDescription":"","tags":["old"],"owner":"mvillmow","role":"member"
+    }]')"
+
+    apply_agent "$yaml_file" "$agents_json"
+
+    [[ -f "$CAPTURED_PATCH_FILE" ]]
+    # tags should be a JSON array
+    local tag_count
+    tag_count="$(jq -r '.tags | length' "$CAPTURED_PATCH_FILE")"
+    [[ "$tag_count" == "2" ]]
+    local tag0 tag1
+    tag0="$(jq -r '.tags[0]' "$CAPTURED_PATCH_FILE")"
+    tag1="$(jq -r '.tags[1]' "$CAPTURED_PATCH_FILE")"
+    [[ "$tag0" == "ai" ]]
+    [[ "$tag1" == "ops" ]]
+}
+
+@test "UPDATE patch body: contains 'owner' field" {
+    local yaml_file
+    yaml_file="$(_make_agent_yaml "test-agent" "MyAgent" "claude-code" "/tmp" "" "" "" "alice" "member")"
+
+    local agents_json
+    agents_json="$(jq -n '[{
+        "id":"existing-id","name":"test-agent","status":"active",
+        "label":"MyAgent","program":"claude-code",
+        "workingDirectory":"/tmp","programArgs":"",
+        "taskDescription":"","tags":[],"owner":"bob","role":"member"
+    }]')"
+
+    apply_agent "$yaml_file" "$agents_json"
+
+    [[ -f "$CAPTURED_PATCH_FILE" ]]
+    local field
+    field="$(jq -r '.owner' "$CAPTURED_PATCH_FILE")"
+    [[ "$field" == "alice" ]]
+}
+
+@test "UPDATE patch body: contains 'role' field" {
+    local yaml_file
+    yaml_file="$(_make_agent_yaml "test-agent" "MyAgent" "claude-code" "/tmp" "" "" "" "mvillmow" "admin")"
+
+    local agents_json
+    agents_json="$(jq -n '[{
+        "id":"existing-id","name":"test-agent","status":"active",
+        "label":"MyAgent","program":"claude-code",
+        "workingDirectory":"/tmp","programArgs":"",
+        "taskDescription":"","tags":[],"owner":"mvillmow","role":"member"
+    }]')"
+
+    apply_agent "$yaml_file" "$agents_json"
+
+    [[ -f "$CAPTURED_PATCH_FILE" ]]
+    local field
+    field="$(jq -r '.role' "$CAPTURED_PATCH_FILE")"
+    [[ "$field" == "admin" ]]
+}
+
+@test "UPDATE patch body: is valid JSON" {
+    local yaml_file
+    yaml_file="$(_make_agent_yaml "test-agent" "NewLabel" "aider" "/tmp/new" "--flag" "A desc" "tag1,tag2" "alice" "admin")"
+
+    local agents_json
+    agents_json="$(jq -n '[{
+        "id":"existing-id","name":"test-agent","status":"active",
+        "label":"OldLabel","program":"claude-code",
+        "workingDirectory":"/tmp/old","programArgs":"",
+        "taskDescription":"","tags":[],"owner":"bob","role":"member"
+    }]')"
+
+    apply_agent "$yaml_file" "$agents_json"
+
+    [[ -f "$CAPTURED_PATCH_FILE" ]]
+    # Verify the captured body is valid JSON
+    jq . "$CAPTURED_PATCH_FILE" > /dev/null
+}
+
+@test "UPDATE patch body: all 8 required keys are present" {
+    local yaml_file
+    yaml_file="$(_make_agent_yaml "test-agent" "NewLabel" "claude-code" "/tmp" "" "" "" "mvillmow" "member")"
+
+    local agents_json
+    agents_json="$(jq -n '[{
+        "id":"existing-id","name":"test-agent","status":"active",
+        "label":"OldLabel","program":"claude-code",
+        "workingDirectory":"/tmp","programArgs":"",
+        "taskDescription":"","tags":[],"owner":"mvillmow","role":"member"
+    }]')"
+
+    apply_agent "$yaml_file" "$agents_json"
+
+    [[ -f "$CAPTURED_PATCH_FILE" ]]
+    # All 8 patch fields must be present
+    jq -e 'has("label")' "$CAPTURED_PATCH_FILE" > /dev/null
+    jq -e 'has("program")' "$CAPTURED_PATCH_FILE" > /dev/null
+    jq -e 'has("workingDirectory")' "$CAPTURED_PATCH_FILE" > /dev/null
+    jq -e 'has("programArgs")' "$CAPTURED_PATCH_FILE" > /dev/null
+    jq -e 'has("taskDescription")' "$CAPTURED_PATCH_FILE" > /dev/null
+    jq -e 'has("tags")' "$CAPTURED_PATCH_FILE" > /dev/null
+    jq -e 'has("owner")' "$CAPTURED_PATCH_FILE" > /dev/null
+    jq -e 'has("role")' "$CAPTURED_PATCH_FILE" > /dev/null
+}
+
+@test "UNCHANGED: agamemnon_update_agent is NOT called when no drift" {
+    local yaml_file
+    yaml_file="$(_make_agent_yaml "test-agent" "MyAgent" "claude-code" "/tmp" "" "" "" "mvillmow" "member")"
+
+    # Actual matches desired exactly → UNCHANGED.
+    # Note: apply.sh calls compute_drift without owner/role args (positions $11/$12 default to "").
+    # So actual_json must have owner="" and role="" to avoid spurious owner/role drift.
+    local agents_json
+    agents_json="$(jq -n '[{
+        "id":"existing-id","name":"test-agent","status":"active",
+        "label":"MyAgent","program":"claude-code",
+        "workingDirectory":"/tmp","programArgs":"",
+        "taskDescription":"","tags":[],"owner":"","role":""
+    }]')"
+
+    apply_agent "$yaml_file" "$agents_json"
+
+    # patch file should NOT be created (no update was sent)
+    [[ ! -f "$CAPTURED_PATCH_FILE" ]]
+    [[ "$UNCHANGED" -eq 1 ]]
+}
+
+@test "UPDATE increments UPDATED counter" {
+    local yaml_file
+    yaml_file="$(_make_agent_yaml "test-agent" "NewLabel" "claude-code" "/tmp" "" "" "" "mvillmow" "member")"
+
+    local agents_json
+    agents_json="$(jq -n '[{
+        "id":"existing-id","name":"test-agent","status":"active",
+        "label":"OldLabel","program":"claude-code",
+        "workingDirectory":"/tmp","programArgs":"",
+        "taskDescription":"","tags":[],"owner":"mvillmow","role":"member"
+    }]')"
+
+    apply_agent "$yaml_file" "$agents_json"
+    [[ "$UPDATED" -eq 1 ]]
+}
+
+@test "UPDATE patch body: empty tags field becomes empty JSON array" {
+    local yaml_file
+    # No tags in YAML → tags=[]
+    yaml_file="$(_make_agent_yaml "test-agent" "NewLabel" "claude-code" "/tmp" "" "" "" "mvillmow" "member")"
+
+    local agents_json
+    agents_json="$(jq -n '[{
+        "id":"existing-id","name":"test-agent","status":"active",
+        "label":"OldLabel","program":"claude-code",
+        "workingDirectory":"/tmp","programArgs":"",
+        "taskDescription":"","tags":["old"],"owner":"mvillmow","role":"member"
+    }]')"
+
+    apply_agent "$yaml_file" "$agents_json"
+
+    [[ -f "$CAPTURED_PATCH_FILE" ]]
+    local tag_count
+    tag_count="$(jq -r '.tags | length' "$CAPTURED_PATCH_FILE")"
+    [[ "$tag_count" == "0" ]]
+}

--- a/tools/reconciler/tests/unit/test_apply_yes.bats
+++ b/tools/reconciler/tests/unit/test_apply_yes.bats
@@ -1,0 +1,450 @@
+#!/usr/bin/env bats
+# tests/unit/test_apply_yes.bats — unit tests for apply.sh --yes flag and confirmation prompt
+#
+# The --yes flag (or -y) suppresses the interactive confirmation prompt that is
+# shown when --prune is used from a terminal.  These tests verify:
+#   - parse_args accepts --yes and -y
+#   - Confirmation prompt is shown (to TTY) without --yes
+#   - --yes bypasses the prompt and continues
+#   - Non-interactive (piped) stdin also bypasses the prompt
+
+TEMP_TEST_DIR=""
+
+setup() {
+    TEMP_TEST_DIR="$(mktemp -d)"
+    export TEMP_TEST_DIR
+}
+
+teardown() {
+    [[ -n "$TEMP_TEST_DIR" ]] && rm -rf "$TEMP_TEST_DIR"
+}
+
+# ---------------------------------------------------------------------------
+# Helper: create a trimmed apply.sh mock that exercises --yes / prompt logic
+# ---------------------------------------------------------------------------
+_create_prompt_mock() {
+    local mock="$1"
+    cat > "$mock" << 'MOCK'
+#!/usr/bin/env bash
+set -euo pipefail
+
+YES=0
+PRUNE=0
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --yes|-y)   YES=1; shift ;;
+            --prune)    PRUNE=1; shift ;;
+            *)          shift ;;
+        esac
+    done
+}
+
+parse_args "$@"
+
+if [[ $PRUNE -eq 1 && $YES -eq 0 && -t 0 ]]; then
+    echo "WARNING: --prune will hibernate and delete agents not in YAML."
+    printf 'Continue? [y/N] '
+    read -r reply
+    if [[ "${reply,,}" != "y" && "${reply,,}" != "yes" ]]; then
+        echo "Aborted."
+        exit 0
+    fi
+fi
+
+echo "APPLIED"
+exit 0
+MOCK
+    chmod +x "$mock"
+}
+
+# ---------------------------------------------------------------------------
+# Test: parse_args recognises --yes and -y
+# ---------------------------------------------------------------------------
+
+@test "parse_args: --yes sets YES=1" {
+    local YES=0
+    parse_args_test() {
+        while [[ $# -gt 0 ]]; do
+            case "$1" in
+                --yes|-y) YES=1; shift ;;
+                *) shift ;;
+            esac
+        done
+    }
+    parse_args_test --yes
+    [[ "$YES" -eq 1 ]]
+}
+
+@test "parse_args: -y sets YES=1" {
+    local YES=0
+    parse_args_test() {
+        while [[ $# -gt 0 ]]; do
+            case "$1" in
+                --yes|-y) YES=1; shift ;;
+                *) shift ;;
+            esac
+        done
+    }
+    parse_args_test -y
+    [[ "$YES" -eq 1 ]]
+}
+
+@test "parse_args: default YES is 0 (no flag)" {
+    local YES=0
+    parse_args_test() {
+        while [[ $# -gt 0 ]]; do
+            case "$1" in
+                --yes|-y) YES=1; shift ;;
+                *) shift ;;
+            esac
+        done
+    }
+    parse_args_test --prune
+    [[ "$YES" -eq 0 ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test: --yes bypasses prompt when --prune is used
+# ---------------------------------------------------------------------------
+
+@test "--yes with --prune: skips confirmation prompt and applies" {
+    local mock="${TEMP_TEST_DIR}/apply.sh"
+    _create_prompt_mock "$mock"
+
+    # With --yes, no stdin interaction needed; should print APPLIED
+    run "$mock" --prune --yes
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"APPLIED"* ]]
+}
+
+@test "-y with --prune: skips confirmation prompt and applies" {
+    local mock="${TEMP_TEST_DIR}/apply.sh"
+    _create_prompt_mock "$mock"
+
+    run "$mock" --prune -y
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"APPLIED"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test: non-interactive stdin (piped) skips the prompt check
+# ---------------------------------------------------------------------------
+
+@test "non-interactive stdin (piped 'y'): prompt accepts y and applies" {
+    local mock="${TEMP_TEST_DIR}/apply.sh"
+    # Create a version without the -t 0 guard so we can test prompt reply
+    cat > "$mock" << 'MOCK_NOTT'
+#!/usr/bin/env bash
+set -euo pipefail
+
+YES=0
+PRUNE=0
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --yes|-y) YES=1; shift ;;
+            --prune)  PRUNE=1; shift ;;
+            *)        shift ;;
+        esac
+    done
+}
+
+parse_args "$@"
+
+if [[ $PRUNE -eq 1 && $YES -eq 0 ]]; then
+    printf 'Continue? [y/N] '
+    read -r reply
+    if [[ "${reply,,}" != "y" && "${reply,,}" != "yes" ]]; then
+        echo "Aborted."
+        exit 0
+    fi
+fi
+
+echo "APPLIED"
+exit 0
+MOCK_NOTT
+    chmod +x "$mock"
+
+    # Pipe 'y' as stdin answer
+    run bash -c "echo y | '$mock' --prune"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"APPLIED"* ]]
+}
+
+@test "non-interactive stdin (piped 'n'): prompt declines and aborts" {
+    local mock="${TEMP_TEST_DIR}/apply.sh"
+    cat > "$mock" << 'MOCK_NOTT'
+#!/usr/bin/env bash
+set -euo pipefail
+
+YES=0
+PRUNE=0
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --yes|-y) YES=1; shift ;;
+            --prune)  PRUNE=1; shift ;;
+            *)        shift ;;
+        esac
+    done
+}
+
+parse_args "$@"
+
+if [[ $PRUNE -eq 1 && $YES -eq 0 ]]; then
+    printf 'Continue? [y/N] '
+    read -r reply
+    if [[ "${reply,,}" != "y" && "${reply,,}" != "yes" ]]; then
+        echo "Aborted."
+        exit 0
+    fi
+fi
+
+echo "APPLIED"
+exit 0
+MOCK_NOTT
+    chmod +x "$mock"
+
+    run bash -c "echo n | '$mock' --prune"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"Aborted"* ]]
+    [[ "$output" != *"APPLIED"* ]]
+}
+
+@test "non-interactive stdin (piped 'yes'): prompt accepts 'yes' and applies" {
+    local mock="${TEMP_TEST_DIR}/apply.sh"
+    cat > "$mock" << 'MOCK_NOTT'
+#!/usr/bin/env bash
+set -euo pipefail
+
+YES=0
+PRUNE=0
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --yes|-y) YES=1; shift ;;
+            --prune)  PRUNE=1; shift ;;
+            *)        shift ;;
+        esac
+    done
+}
+
+parse_args "$@"
+
+if [[ $PRUNE -eq 1 && $YES -eq 0 ]]; then
+    printf 'Continue? [y/N] '
+    read -r reply
+    if [[ "${reply,,}" != "y" && "${reply,,}" != "yes" ]]; then
+        echo "Aborted."
+        exit 0
+    fi
+fi
+
+echo "APPLIED"
+exit 0
+MOCK_NOTT
+    chmod +x "$mock"
+
+    run bash -c "echo yes | '$mock' --prune"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"APPLIED"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test: without --prune, no prompt is shown even without --yes
+# ---------------------------------------------------------------------------
+
+@test "without --prune: no prompt shown, proceeds normally" {
+    local mock="${TEMP_TEST_DIR}/apply.sh"
+    _create_prompt_mock "$mock"
+
+    # Without --prune, --yes is irrelevant — no prompt, just applies
+    run "$mock"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"APPLIED"* ]]
+    [[ "$output" != *"WARNING"* ]]
+}
+
+@test "without --prune but with --yes: still applies without prompt" {
+    local mock="${TEMP_TEST_DIR}/apply.sh"
+    _create_prompt_mock "$mock"
+
+    run "$mock" --yes
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"APPLIED"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test: --fail-fast flag interaction with --yes
+# ---------------------------------------------------------------------------
+
+@test "--yes and --fail-fast together are both recognised" {
+    local YES=0
+    local FAIL_FAST=0
+    parse_combined() {
+        while [[ $# -gt 0 ]]; do
+            case "$1" in
+                --yes|-y)    YES=1; shift ;;
+                --fail-fast) FAIL_FAST=1; shift ;;
+                *)           shift ;;
+            esac
+        done
+    }
+    parse_combined --yes --fail-fast
+    [[ "$YES" -eq 1 ]]
+    [[ "$FAIL_FAST" -eq 1 ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test: --retry passes --fail-fast through (issue #268)
+# ---------------------------------------------------------------------------
+
+@test "--retry: --fail-fast flag is preserved alongside --retry" {
+    # Simulate the retry invocation: build the args array the same way apply.sh
+    # would, and verify --fail-fast appears in the reconstructed flags.
+    local FAIL_FAST=0
+    local RETRY=0
+    local -a retry_flags=()
+
+    parse_retry_flags() {
+        while [[ $# -gt 0 ]]; do
+            case "$1" in
+                --fail-fast) FAIL_FAST=1; shift ;;
+                --retry)     RETRY=1; shift ;;
+                *)           shift ;;
+            esac
+        done
+        # Build retry invocation flags (as apply.sh should do)
+        [[ $FAIL_FAST -eq 1 ]] && retry_flags+=(--fail-fast)
+        [[ $RETRY -eq 1 ]]     && retry_flags+=(--retry)
+    }
+
+    parse_retry_flags --fail-fast --retry
+    [[ "${retry_flags[*]}" == *"--fail-fast"* ]]
+    [[ "${retry_flags[*]}" == *"--retry"* ]]
+}
+
+@test "--retry without --fail-fast: --fail-fast not in retry flags" {
+    local FAIL_FAST=0
+    local RETRY=0
+    local -a retry_flags=()
+
+    parse_retry_flags() {
+        while [[ $# -gt 0 ]]; do
+            case "$1" in
+                --fail-fast) FAIL_FAST=1; shift ;;
+                --retry)     RETRY=1; shift ;;
+                *)           shift ;;
+            esac
+        done
+        [[ $FAIL_FAST -eq 1 ]] && retry_flags+=(--fail-fast)
+        [[ $RETRY -eq 1 ]]     && retry_flags+=(--retry)
+    }
+
+    parse_retry_flags --retry
+    [[ "${retry_flags[*]}" == *"--retry"* ]]
+    [[ "${retry_flags[*]}" != *"--fail-fast"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test: read timeout — #378 — non-TTY stdin defaults to deny
+# ---------------------------------------------------------------------------
+
+# Helper: create a mock that mirrors the updated --prune prompt logic
+_create_timeout_mock() {
+    local mock="$1"
+    cat > "$mock" << 'MOCK_TIMEOUT'
+#!/usr/bin/env bash
+set -euo pipefail
+
+YES=0
+PRUNE=0
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --yes|-y) YES=1; shift ;;
+            --prune)  PRUNE=1; shift ;;
+            *)        shift ;;
+        esac
+    done
+}
+
+parse_args "$@"
+
+if [[ $PRUNE -eq 1 && $YES -eq 0 && "${MYRMIDONS_YES:-}" != "true" ]]; then
+    reply=""
+    if [[ ! -t 0 ]]; then
+        reply="N"
+    else
+        echo "WARNING: --prune will hibernate and delete agents not in YAML."
+        printf 'Continue? [y/N] '
+        read -t 30 -r reply || reply="N"
+    fi
+    if [[ "${reply,,}" != "y" && "${reply,,}" != "yes" ]]; then
+        echo "Aborted."
+        exit 0
+    fi
+fi
+
+echo "APPLIED"
+exit 0
+MOCK_TIMEOUT
+    chmod +x "$mock"
+}
+
+@test "timeout-mock: non-TTY stdin with --prune defaults to deny (aborts)" {
+    local mock="${TEMP_TEST_DIR}/apply_timeout.sh"
+    _create_timeout_mock "$mock"
+
+    # Pipe empty stdin — non-TTY, should default-deny
+    run bash -c "echo '' | '$mock' --prune"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"Aborted"* ]]
+    [[ "$output" != *"APPLIED"* ]]
+}
+
+@test "timeout-mock: MYRMIDONS_YES=true bypasses --prune prompt" {
+    local mock="${TEMP_TEST_DIR}/apply_timeout.sh"
+    _create_timeout_mock "$mock"
+
+    run bash -c "MYRMIDONS_YES=true '$mock' --prune"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"APPLIED"* ]]
+    [[ "$output" != *"Aborted"* ]]
+}
+
+@test "timeout-mock: MYRMIDONS_YES=false still requires confirmation (piped y applies)" {
+    local mock="${TEMP_TEST_DIR}/apply_timeout.sh"
+    _create_timeout_mock "$mock"
+
+    run bash -c "echo y | MYRMIDONS_YES=false '$mock' --prune"
+    [[ "$status" -eq 0 ]]
+    # Non-TTY stdin → default deny even when piping 'y' (guard fires before read)
+    [[ "$output" == *"Aborted"* ]]
+    [[ "$output" != *"APPLIED"* ]]
+}
+
+@test "timeout-mock: piped 'y' to --prune is rejected by non-TTY default-deny guard" {
+    local mock="${TEMP_TEST_DIR}/apply_timeout.sh"
+    _create_timeout_mock "$mock"
+
+    # The non-TTY guard fires before read, so piped 'y' has no effect
+    run bash -c "echo y | '$mock' --prune"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"Aborted"* ]]
+}
+
+@test "timeout-mock: --yes still bypasses prompt regardless of MYRMIDONS_YES" {
+    local mock="${TEMP_TEST_DIR}/apply_timeout.sh"
+    _create_timeout_mock "$mock"
+
+    run bash -c "'$mock' --prune --yes"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"APPLIED"* ]]
+}

--- a/tools/reconciler/tests/unit/test_check_adr_index.bats
+++ b/tools/reconciler/tests/unit/test_check_adr_index.bats
@@ -1,0 +1,186 @@
+#!/usr/bin/env bats
+# tests/unit/test_check_adr_index.bats
+#
+# Issue #441: lint guard for ADR README index completeness.
+#
+# These tests exercise scripts/check-adr-index.sh directly using temporary
+# docs/adr/ directories so they are hermetic and do not touch the real index.
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+CHECKER="${SCRIPT_DIR}/scripts/check-adr-index.sh"
+
+TMP_DIR=""
+
+setup() {
+    TMP_DIR="${SCRIPT_DIR}/_adr_index_test_$$_${RANDOM}"
+    mkdir -p "${TMP_DIR}/docs/adr"
+}
+
+teardown() {
+    if [[ -n "$TMP_DIR" && -d "$TMP_DIR" ]]; then
+        rm -rf "$TMP_DIR"
+    fi
+}
+
+# Helper: write a minimal README.md containing the given content
+_write_readme() {
+    printf '%s\n' "$1" > "${TMP_DIR}/docs/adr/README.md"
+}
+
+# Helper: create a dummy ADR file
+_write_adr() {
+    touch "${TMP_DIR}/docs/adr/$1"
+}
+
+# Helper: run the checker against TMP_DIR's docs/adr/ by overriding REPO_ROOT
+#
+# TODO(#643): This helper duplicates the logic from scripts/check-adr-index.sh
+# (lines 16–62). The duplication exists because we need hermetic, isolated test
+# dirs that don't touch the real repo. A better approach would be to refactor
+# check-adr-index.sh to export a reusable checker function that both the script
+# and the test can call. For now, keep both in sync: if check-adr-index.sh
+# changes, mirror the changes in the inlined logic below.
+_run_checker() {
+    # The script derives ADR_DIR as ${REPO_ROOT}/docs/adr.
+    # We symlink the script into TMP_DIR so SCRIPT_DIR resolution works,
+    # or we just call the real script and override REPO_ROOT via env.
+    # Simpler: run it in a subshell that sets REPO_ROOT.
+    run bash -c "
+        SCRIPT_DIR=\"\$(cd \"\$(dirname '${CHECKER}')\" && pwd)\"
+        REPO_ROOT='${TMP_DIR}'
+        ADR_DIR=\"\${REPO_ROOT}/docs/adr\"
+        README=\"\${ADR_DIR}/README.md\"
+        MISSING=0
+
+        if [[ ! -f \"\$README\" ]]; then
+            echo \"ERROR: \${README}: file not found — cannot check ADR index.\"
+            exit 1
+        fi
+
+        mapfile -t ADR_FILES < <(find \"\$ADR_DIR\" -maxdepth 1 -name '*.md' ! -name 'README.md' | sort)
+
+        for adr_file in \"\${ADR_FILES[@]}\"; do
+            [[ ! -f \"\$adr_file\" ]] && continue
+            filename=\"\$(basename \"\$adr_file\")\"
+            if ! grep -qF \"\$filename\" \"\$README\"; then
+                echo \"ERROR: \${README}: missing link for \${filename}\"
+                MISSING=\$((MISSING + 1))
+            fi
+        done
+
+        if [[ \$MISSING -gt 0 ]]; then
+            echo ''
+            echo \"check-adr-index: \${MISSING} ADR file(s) not linked in docs/adr/README.md.\"
+            echo 'Add a table entry for each missing ADR and re-run.'
+            exit 1
+        fi
+        exit 0
+    "
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: All ADR files appear in README → exit 0
+# ---------------------------------------------------------------------------
+
+@test "check-adr-index: all ADRs linked in README exits 0" {
+    _write_readme "| [ADR-007](ADR-007-foo.md) | Foo |
+| [ADR-008](ADR-008-bar.md) | Bar |"
+    _write_adr "ADR-007-foo.md"
+    _write_adr "ADR-008-bar.md"
+
+    _run_checker
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 2: One ADR file not in README → exit 1, error message
+# ---------------------------------------------------------------------------
+
+@test "check-adr-index: missing ADR link exits 1 with error message" {
+    _write_readme "| [ADR-007](ADR-007-foo.md) | Foo |"
+    _write_adr "ADR-007-foo.md"
+    _write_adr "ADR-008-bar.md"
+
+    _run_checker
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"ADR-008-bar.md"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 3: Multiple ADR files missing → exit 1, all listed
+# ---------------------------------------------------------------------------
+
+@test "check-adr-index: multiple missing ADR links all reported" {
+    _write_readme "| [ADR-007](ADR-007-foo.md) | Foo |"
+    _write_adr "ADR-007-foo.md"
+    _write_adr "ADR-008-bar.md"
+    _write_adr "ADR-009-baz.md"
+
+    _run_checker
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"ADR-008-bar.md"* ]]
+    [[ "$output" == *"ADR-009-baz.md"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 4: No ADR files (empty dir) → exit 0
+# ---------------------------------------------------------------------------
+
+@test "check-adr-index: no ADR files exits 0" {
+    _write_readme "# Architecture Decision Records"
+
+    _run_checker
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 5: README missing entirely → exit 1 with descriptive error
+# ---------------------------------------------------------------------------
+
+@test "check-adr-index: missing README exits 1 with error" {
+    _write_adr "ADR-007-foo.md"
+    # No README created
+
+    _run_checker
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"not found"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 6: README.md itself is excluded from the check
+# ---------------------------------------------------------------------------
+
+@test "check-adr-index: README.md not required to link itself" {
+    _write_readme "# Architecture Decision Records"
+    # Only README.md in the directory — no ADR files
+
+    _run_checker
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 7: script directly on real repo exits 0 (regression guard)
+# ---------------------------------------------------------------------------
+
+@test "check-adr-index: real repo docs/adr/ passes" {
+    run bash "$CHECKER"
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 8: adding an unlinked ADR to real repo (simulated) causes failure
+# ---------------------------------------------------------------------------
+
+@test "check-adr-index: unlinked ADR file in real docs/adr/ exits 1" {
+    local adr_dir="${SCRIPT_DIR}/docs/adr"
+    local tmp_adr="${adr_dir}/ADR-999-test-only-$$-${RANDOM}.md"
+
+    # Create a temporary unlinked ADR in the real docs/adr/
+    touch "$tmp_adr"
+    run bash "$CHECKER"
+    local exit_code="$status"
+    rm -f "$tmp_adr"
+
+    [ "$exit_code" -eq 1 ]
+    [[ "$output" == *"ADR-999"* ]]
+}

--- a/tools/reconciler/tests/unit/test_check_changelog_gaps.bats
+++ b/tools/reconciler/tests/unit/test_check_changelog_gaps.bats
@@ -1,0 +1,249 @@
+#!/usr/bin/env bats
+# tests/unit/test_check_changelog_gaps.bats
+#
+# Issue #451: unit tests for scripts/check-changelog-gaps.py
+#
+# Each test creates a minimal temp git repo with controlled commits and a
+# controlled CHANGELOG.md, then runs the script and asserts exit code + output.
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+CHECK_SCRIPT="${SCRIPT_DIR}/scripts/check-changelog-gaps.py"
+TMP_REPO=""
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_init_repo() {
+    TMP_REPO="${SCRIPT_DIR}/_changelog_test_$$_${RANDOM}"
+    mkdir -p "$TMP_REPO"
+    git -C "$TMP_REPO" init -q
+    git -C "$TMP_REPO" config user.email "test@example.com"
+    git -C "$TMP_REPO" config user.name "Test"
+    git -C "$TMP_REPO" config commit.gpgsign false
+    git -C "$TMP_REPO" config tag.gpgSign false
+    # Initial commit + tag so we have a base
+    touch "${TMP_REPO}/.gitkeep"
+    git -C "$TMP_REPO" add .
+    git -C "$TMP_REPO" commit -q --no-verify -m "chore: initial commit"
+    git -C "$TMP_REPO" tag v0.1.0
+}
+
+_add_commit() {
+    local msg="$1"
+    echo "$msg" >> "${TMP_REPO}/file.txt"
+    git -C "$TMP_REPO" add file.txt
+    git -C "$TMP_REPO" commit -q --no-verify -m "$msg"
+}
+
+_write_changelog() {
+    local body="$1"
+    cat > "${TMP_REPO}/CHANGELOG.md" <<EOF
+# Changelog
+
+## [Unreleased]
+
+${body}
+
+## [0.1.0] - 2026-01-01
+
+### Added
+- Initial release
+EOF
+}
+
+_run_script() {
+    (cd "$TMP_REPO" && python3 "$CHECK_SCRIPT" "$@") 2>&1
+}
+
+# ---------------------------------------------------------------------------
+# Lifecycle
+# ---------------------------------------------------------------------------
+
+setup() {
+    _init_repo
+}
+
+teardown() {
+    if [[ -n "$TMP_REPO" && -d "$TMP_REPO" ]]; then
+        rm -rf "$TMP_REPO"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+@test "exit 0 when no qualifying commits since tag" {
+    # Only a chore commit — not feat/fix/docs
+    _add_commit "chore: update README"
+    _write_changelog "### Added"
+
+    run _run_script
+    [ "$status" -eq 0 ]
+}
+
+@test "exit 0 when feat commit hash appears in [Unreleased]" {
+    _add_commit "feat: add shiny new feature"
+    local hash
+    hash=$(git -C "$TMP_REPO" log -1 --format="%h")
+    _write_changelog "### Added
+- add shiny new feature (${hash})"
+
+    run _run_script
+    [ "$status" -eq 0 ]
+}
+
+@test "exit 0 when feat commit description fragment appears in [Unreleased]" {
+    _add_commit "feat: implement webhook support"
+    _write_changelog "### Added
+- implement webhook support for notifications"
+
+    run _run_script
+    [ "$status" -eq 0 ]
+}
+
+@test "exit 1 when feat commit has no [Unreleased] entry" {
+    _add_commit "feat: add missing feature"
+    _write_changelog "### Added"
+
+    run _run_script
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"add missing feature"* ]]
+}
+
+@test "exit 1 when fix commit has no [Unreleased] entry" {
+    _add_commit "fix: correct null pointer dereference"
+    _write_changelog "### Fixed"
+
+    run _run_script
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"correct null pointer"* ]]
+}
+
+@test "exit 1 when docs commit has no [Unreleased] entry" {
+    _add_commit "docs: update API reference"
+    _write_changelog "### Added"
+
+    run _run_script
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"update api reference"* || "$output" == *"update API reference"* ]]
+}
+
+@test "exit 0 when [skip changelog] in commit subject" {
+    _add_commit "feat: hidden feature [skip changelog]"
+    _write_changelog "### Added"
+
+    run _run_script
+    [ "$status" -eq 0 ]
+}
+
+@test "exit 0 when merge commits are excluded (no-merges flag)" {
+    # Merge commits are filtered by --no-merges in the script; this test
+    # verifies a commit message with 'Merge' is not manually checked
+    _add_commit "chore: Merge branch feature into main"
+    _write_changelog "### Added"
+
+    run _run_script
+    [ "$status" -eq 0 ]
+}
+
+@test "exit 0 for feat with scope when entry present" {
+    _add_commit "feat(core): add retry logic"
+    _write_changelog "### Added
+- add retry logic for core operations"
+
+    run _run_script
+    [ "$status" -eq 0 ]
+}
+
+@test "exit 1 for feat with scope when entry missing" {
+    _add_commit "feat(auth): add OAuth2 support"
+    _write_changelog "### Added"
+
+    run _run_script
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"add oauth2 support"* || "$output" == *"add OAuth2 support"* ]]
+}
+
+@test "exit 0 with no release tag — warns and skips" {
+    # Delete the v0.1.0 tag so no tags exist
+    git -C "$TMP_REPO" tag -d v0.1.0 > /dev/null 2>&1
+    _add_commit "feat: untagged feature"
+    _write_changelog "### Added"
+
+    run _run_script
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"no release tag"* || "$output" == *"WARNING"* ]]
+}
+
+@test "exit 1 when multiple gaps found — all listed" {
+    _add_commit "feat: feature alpha"
+    _add_commit "fix: bug beta"
+    _write_changelog "### Added"
+
+    run _run_script
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"feature alpha"* ]]
+    [[ "$output" == *"bug beta"* ]]
+}
+
+@test "exit 0 when only refactor commits — not in CHANGELOG_TYPES" {
+    _add_commit "refactor: extract helper module"
+    _add_commit "ci: add parallel job"
+    _add_commit "test: add unit tests for parser"
+    _write_changelog "### Added"
+
+    run _run_script
+    [ "$status" -eq 0 ]
+}
+
+@test "--since flag overrides tag detection" {
+    # Add a second tag, then a feat commit after it
+    git -C "$TMP_REPO" tag v0.2.0
+    _add_commit "feat: post-v0.2.0 feature"
+    _write_changelog "### Added
+- post-v0.2.0 feature enhancements"
+
+    # With --since v0.2.0, script checks only commits after v0.2.0
+    run _run_script --since v0.2.0
+    [ "$status" -eq 0 ]
+}
+
+@test "--changelog flag points to custom path" {
+    _add_commit "feat: use custom changelog path"
+    local custom_cl="${TMP_REPO}/docs/CHANGES.md"
+    mkdir -p "${TMP_REPO}/docs"
+    cat > "$custom_cl" <<EOF
+# Changelog
+
+## [Unreleased]
+
+### Added
+- use custom changelog path feature
+
+## [0.1.0] - 2026-01-01
+EOF
+
+    run _run_script --changelog "$custom_cl"
+    [ "$status" -eq 0 ]
+}
+
+@test "exit 0 when all qualifying commits are covered" {
+    _add_commit "feat: full coverage feature"
+    _add_commit "fix: full coverage fix"
+    _add_commit "docs: full coverage docs update"
+    local hash1 hash2 hash3
+    hash1=$(git -C "$TMP_REPO" log --format="%h" | sed -n '3p')
+    hash2=$(git -C "$TMP_REPO" log --format="%h" | sed -n '2p')
+    hash3=$(git -C "$TMP_REPO" log --format="%h" | sed -n '1p')
+    _write_changelog "### Added
+- full coverage feature (${hash1})
+### Fixed
+- full coverage fix (${hash2})
+### Changed
+- full coverage docs update (${hash3})"
+
+    run _run_script
+    [ "$status" -eq 0 ]
+}

--- a/tools/reconciler/tests/unit/test_check_docs_crossref.bats
+++ b/tools/reconciler/tests/unit/test_check_docs_crossref.bats
@@ -1,0 +1,172 @@
+#!/usr/bin/env bats
+# tests/unit/test_check_docs_crossref.bats
+#
+# Issue #387: test coverage for scripts/check-docs-crossref.sh.
+#
+# The script asserts:
+#   1. AGENTS.md exists at the repo root.
+#   2. CLAUDE.md exists at the repo root.
+#   3. CLAUDE.md contains a reference to AGENTS.md.
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+CROSSREF_SCRIPT="${SCRIPT_DIR}/scripts/check-docs-crossref.sh"
+
+TMP_DIR=""
+
+setup() {
+    TMP_DIR="${SCRIPT_DIR}/_crossref_test_$$_${RANDOM}"
+    mkdir -p "$TMP_DIR"
+}
+
+teardown() {
+    if [[ -n "$TMP_DIR" && -d "$TMP_DIR" ]]; then
+        rm -rf "$TMP_DIR"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Helper: run the script with REPO_ROOT overridden to TMP_DIR by temporarily
+# symlinking scripts/ into the temp dir and calling it from there.
+# We use env var injection via a wrapper to avoid modifying the script itself.
+# Instead, we copy the script and patch REPO_ROOT inline.
+# ---------------------------------------------------------------------------
+
+_run_check() {
+    # Run the script with SCRIPT_DIR pointing to a scripts/ subdir of TMP_DIR
+    # so that REPO_ROOT resolves to TMP_DIR.
+    local tmp_scripts="${TMP_DIR}/scripts"
+    mkdir -p "$tmp_scripts"
+    cp "$CROSSREF_SCRIPT" "${tmp_scripts}/check-docs-crossref.sh"
+    chmod +x "${tmp_scripts}/check-docs-crossref.sh"
+    run bash "${tmp_scripts}/check-docs-crossref.sh"
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: Both files present with reference → exit 0
+# ---------------------------------------------------------------------------
+
+@test "check-docs-crossref.sh: AGENTS.md present and CLAUDE.md has reference → exits 0" {
+    echo "# AGENTS.md content" > "${TMP_DIR}/AGENTS.md"
+    cat > "${TMP_DIR}/CLAUDE.md" <<'EOF'
+# My Project
+
+> For agent safety boundaries and permitted tool use, see [AGENTS.md](AGENTS.md).
+
+Some other content here.
+EOF
+
+    _run_check
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"PASSED"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 2: AGENTS.md missing → exit 1
+# ---------------------------------------------------------------------------
+
+@test "check-docs-crossref.sh: AGENTS.md missing → exits 1" {
+    cat > "${TMP_DIR}/CLAUDE.md" <<'EOF'
+# My Project
+
+> For agent safety boundaries and permitted tool use, see [AGENTS.md](AGENTS.md).
+EOF
+    # No AGENTS.md created
+
+    _run_check
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"AGENTS.md not found"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 3: CLAUDE.md missing reference → exit 1
+# ---------------------------------------------------------------------------
+
+@test "check-docs-crossref.sh: CLAUDE.md has no reference to AGENTS.md → exits 1" {
+    echo "# AGENTS.md content" > "${TMP_DIR}/AGENTS.md"
+    cat > "${TMP_DIR}/CLAUDE.md" <<'EOF'
+# My Project
+
+Some content with no cross-reference to the safety doc.
+EOF
+
+    _run_check
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"no reference to AGENTS.md"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 4: CLAUDE.md missing entirely → exit 1
+# ---------------------------------------------------------------------------
+
+@test "check-docs-crossref.sh: CLAUDE.md missing entirely → exits 1" {
+    echo "# AGENTS.md content" > "${TMP_DIR}/AGENTS.md"
+    # No CLAUDE.md created
+
+    _run_check
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"CLAUDE.md not found"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 5: Both files missing → exit 1 with 2 violations
+# ---------------------------------------------------------------------------
+
+@test "check-docs-crossref.sh: both AGENTS.md and CLAUDE.md missing → exits 1" {
+    # Neither file created
+
+    _run_check
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"AGENTS.md not found"* ]]
+    [[ "$output" == *"CLAUDE.md not found"* ]]
+    [[ "$output" == *"2 violation(s)"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 6: AGENTS.md absent but reference exists in CLAUDE.md → exit 1
+# (AGENTS.md existence check runs first; both failures reported)
+# ---------------------------------------------------------------------------
+
+@test "check-docs-crossref.sh: reference present in CLAUDE.md but AGENTS.md absent → exits 1" {
+    cat > "${TMP_DIR}/CLAUDE.md" <<'EOF'
+# My Project
+
+> See [AGENTS.md](AGENTS.md) for safety boundaries.
+EOF
+    # No AGENTS.md created
+
+    _run_check
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"AGENTS.md not found"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 7: Reference to AGENTS.md appears only in a code block → still passes
+# (grep matches anywhere; benign false-positive is acceptable)
+# ---------------------------------------------------------------------------
+
+@test "check-docs-crossref.sh: reference to AGENTS.md in code block still passes" {
+    echo "# AGENTS.md" > "${TMP_DIR}/AGENTS.md"
+    cat > "${TMP_DIR}/CLAUDE.md" <<'EOF'
+# My Project
+
+```
+cat AGENTS.md
+```
+EOF
+
+    _run_check
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 8: Violation count reported correctly for single violation
+# ---------------------------------------------------------------------------
+
+@test "check-docs-crossref.sh: single violation reports 1 violation" {
+    echo "# AGENTS.md content" > "${TMP_DIR}/AGENTS.md"
+    echo "# CLAUDE.md with no crossref" > "${TMP_DIR}/CLAUDE.md"
+
+    _run_check
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"1 violation(s)"* ]]
+}

--- a/tools/reconciler/tests/unit/test_check_duplicate_functions.bats
+++ b/tools/reconciler/tests/unit/test_check_duplicate_functions.bats
@@ -1,0 +1,171 @@
+#!/usr/bin/env bats
+# tests/unit/test_check_duplicate_functions.bats
+#
+# Issue #410: lint guard for duplicate shell function definitions.
+# Verifies scripts/check-duplicate-functions.sh behavior:
+#   - clean file passes (exit 0)
+#   - file with one duplicate fails (exit 1) with correct output
+#   - file with two duplicates reports both
+#   - suppression annotation skips the duplicate
+#   - apply.sh and scripts/lib/report.sh pass today (regression guard)
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+CHECKER="${SCRIPT_DIR}/scripts/check-duplicate-functions.sh"
+
+TEMP_DIR=""
+
+setup() {
+    TEMP_DIR="$(mktemp -d)"
+    export TEMP_DIR
+}
+
+teardown() {
+    [[ -n "$TEMP_DIR" ]] && rm -rf "$TEMP_DIR"
+}
+
+# ---------------------------------------------------------------------------
+# Helper: write a shell fixture and run the checker against it
+# ---------------------------------------------------------------------------
+
+_write_fixture() {
+    local name="$1"
+    local content="$2"
+    local path="${TEMP_DIR}/${name}.sh"
+    printf '%s\n' "$content" > "$path"
+    echo "$path"
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: clean file → exit 0, no output
+# ---------------------------------------------------------------------------
+
+@test "check-duplicate-functions: clean script exits 0" {
+    local f
+    f="$(_write_fixture "clean" "#!/usr/bin/env bash
+foo() { echo foo; }
+bar() { echo bar; }
+")"
+    run bash "$CHECKER" "$f"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 2: single duplicate → exit 1 with error message
+# ---------------------------------------------------------------------------
+
+@test "check-duplicate-functions: single duplicate exits 1 and reports it" {
+    local f
+    f="$(_write_fixture "single_dup" "#!/usr/bin/env bash
+foo() { echo first; }
+bar() { echo bar; }
+foo() { echo second; }
+")"
+    run bash "$CHECKER" "$f"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"duplicate function definition 'foo'"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 3: two distinct duplicates → both reported
+# ---------------------------------------------------------------------------
+
+@test "check-duplicate-functions: two duplicates both reported" {
+    local f
+    f="$(_write_fixture "two_dups" "#!/usr/bin/env bash
+alpha() { echo a1; }
+beta()  { echo b1; }
+alpha() { echo a2; }
+beta()  { echo b2; }
+")"
+    run bash "$CHECKER" "$f"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"duplicate function definition 'alpha'"* ]]
+    [[ "$output" == *"duplicate function definition 'beta'"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 4: suppression annotation → exit 0
+# ---------------------------------------------------------------------------
+
+@test "check-duplicate-functions: suppression annotation skips duplicate" {
+    local f
+    f="$(_write_fixture "suppressed" "#!/usr/bin/env bash
+foo() { echo first; }
+foo() { echo second; }  # allow-duplicate-function: if/else branch for TTY vs plain
+")"
+    run bash "$CHECKER" "$f"
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 5: duplicate without suppression on the second definition → exit 1
+# (suppression only on the first definition does NOT count)
+# ---------------------------------------------------------------------------
+
+@test "check-duplicate-functions: suppression only on first definition still fails" {
+    local f
+    f="$(_write_fixture "wrong_suppress" "#!/usr/bin/env bash
+foo() { echo first; }  # allow-duplicate-function: this is on the wrong line
+foo() { echo second; }
+")"
+    run bash "$CHECKER" "$f"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"duplicate function definition 'foo'"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 6: 'function' keyword syntax also detected
+# ---------------------------------------------------------------------------
+
+@test "check-duplicate-functions: 'function' keyword syntax detected" {
+    local f
+    f="$(_write_fixture "func_kw" "#!/usr/bin/env bash
+function my_func() { echo first; }
+function my_func() { echo second; }
+")"
+    run bash "$CHECKER" "$f"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"duplicate function definition 'my_func'"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 7: 'function' keyword syntax with suppression → exit 0
+# ---------------------------------------------------------------------------
+
+@test "check-duplicate-functions: 'function' keyword syntax with suppression passes" {
+    local f
+    f="$(_write_fixture "func_kw_supp" "#!/usr/bin/env bash
+function my_func() { echo first; }
+function my_func() { echo second; }  # allow-duplicate-function: conditional redefinition
+")"
+    run bash "$CHECKER" "$f"
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 8: regression — apply.sh must pass (no real duplicates today)
+# ---------------------------------------------------------------------------
+
+@test "check-duplicate-functions: apply.sh has no duplicate function definitions" {
+    run bash "$CHECKER" "${SCRIPT_DIR}/scripts/apply.sh"
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 9: regression — scripts/lib/report.sh must pass
+# ---------------------------------------------------------------------------
+
+@test "check-duplicate-functions: scripts/lib/report.sh has no duplicate function definitions" {
+    run bash "$CHECKER" "${SCRIPT_DIR}/scripts/lib/report.sh"
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 10: regression — full scripts/ directory must pass (all scripts clean)
+# ---------------------------------------------------------------------------
+
+@test "check-duplicate-functions: entire scripts/ directory passes" {
+    run bash "$CHECKER"
+    [ "$status" -eq 0 ]
+}

--- a/tools/reconciler/tests/unit/test_check_gitleaks_coe.bats
+++ b/tools/reconciler/tests/unit/test_check_gitleaks_coe.bats
@@ -1,0 +1,166 @@
+#!/usr/bin/env bats
+# tests/unit/test_check_gitleaks_coe.bats
+#
+# Issue #567: test coverage for scripts/check-gitleaks-coe.sh.
+#
+# The script enforces policy: gitleaks security scanning steps must not have
+# 'continue-on-error: true', which would silently suppress results. The correct
+# approach is using .gitleaks.toml allowlist entries with justification comments.
+#
+# The script must handle both Unix (LF) and Windows (CRLF) line endings.
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+CHECKER="${SCRIPT_DIR}/scripts/check-gitleaks-coe.sh"
+
+TMP_DIR=""
+TMP_WORKFLOWS=""
+
+setup() {
+    TMP_DIR="${SCRIPT_DIR}/_gitleaks_coe_test_$$_${RANDOM}"
+    TMP_WORKFLOWS="${TMP_DIR}/.github/workflows"
+    mkdir -p "$TMP_WORKFLOWS"
+}
+
+teardown() {
+    if [[ -n "$TMP_DIR" && -d "$TMP_DIR" ]]; then
+        rm -rf "$TMP_DIR"
+    fi
+}
+
+# Helper: run the checker with REPO_ROOT overridden to TMP_DIR
+_run_checker() {
+    run bash -c "
+        REPO_ROOT='${TMP_DIR}' bash '${CHECKER}'
+    "
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: Workflow with gitleaks but no continue-on-error → exit 0
+# ---------------------------------------------------------------------------
+
+@test "check-gitleaks-coe: workflow with gitleaks, no continue-on-error → exits 0" {
+    cat > "${TMP_WORKFLOWS}/test.yml" <<'EOF'
+name: Security
+on: push
+jobs:
+  secrets:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Scan for secrets (gitleaks)
+        run: gitleaks detect --source . --config .gitleaks.toml
+EOF
+
+    _run_checker
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 2: Workflow with gitleaks AND continue-on-error → exit 1 with error
+# ---------------------------------------------------------------------------
+
+@test "check-gitleaks-coe: workflow with gitleaks and continue-on-error → exits 1" {
+    cat > "${TMP_WORKFLOWS}/test.yml" <<'EOF'
+name: Security
+on: push
+jobs:
+  secrets:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Scan for secrets (gitleaks)
+        run: gitleaks detect --source . --config .gitleaks.toml
+      - continue-on-error: true
+EOF
+
+    _run_checker
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"continue-on-error"* ]]
+    [[ "$output" == *"gitleaks"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 3: Multiple workflows; only one has the violation → exit 1, report the bad one
+# ---------------------------------------------------------------------------
+
+@test "check-gitleaks-coe: multiple workflows, one violates → exits 1, reports violating file" {
+    cat > "${TMP_WORKFLOWS}/good.yml" <<'EOF'
+name: Good
+jobs:
+  lint:
+    steps:
+      - name: Check secrets
+        run: gitleaks detect
+EOF
+
+    cat > "${TMP_WORKFLOWS}/bad.yml" <<'EOF'
+name: Bad
+jobs:
+  secrets:
+    steps:
+      - name: Scan for secrets (gitleaks)
+        run: gitleaks detect
+      - continue-on-error: true
+EOF
+
+    _run_checker
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"bad.yml"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 4: Workflow without gitleaks, but has continue-on-error → exit 0
+# ---------------------------------------------------------------------------
+
+@test "check-gitleaks-coe: workflow without gitleaks, has continue-on-error → exits 0" {
+    cat > "${TMP_WORKFLOWS}/other.yml" <<'EOF'
+name: Other
+jobs:
+  build:
+    steps:
+      - name: Some other step
+        run: echo hello
+      - continue-on-error: true
+EOF
+
+    _run_checker
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 5: Handles Windows line endings (CRLF) → still detects violation
+# ---------------------------------------------------------------------------
+
+@test "check-gitleaks-coe: detects violation with CRLF line endings" {
+    # Create a file with CRLF line endings
+    printf '%s\r\n' \
+        'name: Security' \
+        'jobs:' \
+        '  secrets:' \
+        '    steps:' \
+        '      - name: Scan for secrets (gitleaks)' \
+        '        run: gitleaks detect' \
+        '      - continue-on-error: true' \
+        > "${TMP_WORKFLOWS}/crlf.yml"
+
+    _run_checker
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"continue-on-error"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 6: Empty workflows directory → exit 0
+# ---------------------------------------------------------------------------
+
+@test "check-gitleaks-coe: empty workflows directory → exits 0" {
+    # TMP_WORKFLOWS is already created but empty
+    _run_checker
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 7: Script runs without error on real repo (regression check)
+# ---------------------------------------------------------------------------
+
+@test "check-gitleaks-coe: real repo workflows pass" {
+    run bash "$CHECKER"
+    [ "$status" -eq 0 ]
+}

--- a/tools/reconciler/tests/unit/test_check_schema_hints.bats
+++ b/tools/reconciler/tests/unit/test_check_schema_hints.bats
@@ -1,0 +1,218 @@
+#!/usr/bin/env bats
+bats_require_minimum_version 1.5.0
+# tests/unit/test_check_schema_hints.bats
+#
+# Issue #467: backfill BATS unit tests for scripts/check-schema-hints.sh.
+#
+# Mirrors the cases in tests/test-check-schema-hints.sh so the hook is covered
+# by the standard `bats test-unit` task and CI output is consistent.
+#
+# The script accepts explicit file arguments, so each test simply invokes the
+# checker against a temporary fixture file — no REPO_ROOT override needed.
+
+# shellcheck disable=SC2034
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+CHECKER="${SCRIPT_DIR}/scripts/check-schema-hints.sh"
+
+TMP_DIR=""
+
+setup() {
+    TMP_DIR="$(mktemp -d)"
+}
+
+teardown() {
+    if [[ -n "$TMP_DIR" && -d "$TMP_DIR" ]]; then
+        rm -rf "$TMP_DIR"
+    fi
+}
+
+# Helper: write content to a YAML file under TMP_DIR.
+_write_yaml() {
+    local name="$1"
+    local content="$2"
+    local path="${TMP_DIR}/${name}"
+    mkdir -p "$(dirname "$path")"
+    printf '%s' "$content" > "$path"
+    printf '%s\n' "$path"
+}
+
+# ---------------------------------------------------------------------------
+# Test: correct canonical hint on line 1 → exit 0
+# ---------------------------------------------------------------------------
+
+@test "check-schema-hints: correct canonical \$schema= hint exits 0" {
+    file="$(_write_yaml correct.yaml '# yaml-language-server: $schema=../../schemas/agent-v1.schema.json
+apiVersion: myrmidons/v1
+kind: Agent
+')"
+    run bash "$CHECKER" "$file"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "check-schema-hints: canonical hint with URL schema exits 0" {
+    file="$(_write_yaml url.yaml '# yaml-language-server: $schema=https://example.com/agent-v1.schema.json
+apiVersion: myrmidons/v1
+')"
+    run bash "$CHECKER" "$file"
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test: missing hint entirely → exit 1
+# ---------------------------------------------------------------------------
+
+@test "check-schema-hints: missing hint on line 1 exits 1 with diagnostic" {
+    file="$(_write_yaml missing.yaml 'apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: test-agent
+')"
+    run bash "$CHECKER" "$file"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"missing or malformed"* ]]
+    [[ "$output" == *"yaml-language-server"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test: malformed — missing "$schema=" prefix entirely
+# ---------------------------------------------------------------------------
+
+@test "check-schema-hints: malformed hint missing \$schema= prefix exits 1" {
+    file="$(_write_yaml malformed-no-prefix.yaml '# yaml-language-server: =../../schemas/agent-v1.schema.json
+apiVersion: myrmidons/v1
+')"
+    run bash "$CHECKER" "$file"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"missing or malformed"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test: malformed — "schema=" without leading dollar sign (the #69 bug)
+# ---------------------------------------------------------------------------
+
+@test "check-schema-hints: malformed hint schema= without dollar exits 1" {
+    file="$(_write_yaml malformed-no-dollar.yaml '# yaml-language-server: schema=../../schemas/agent-v1.schema.json
+apiVersion: myrmidons/v1
+')"
+    run bash "$CHECKER" "$file"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"missing or malformed"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test: malformed — wrong case ($Schema= instead of $schema=)
+# ---------------------------------------------------------------------------
+
+@test "check-schema-hints: malformed hint with wrong case \$Schema= exits 1" {
+    file="$(_write_yaml malformed-case.yaml '# yaml-language-server: $Schema=../../schemas/agent-v1.schema.json
+apiVersion: myrmidons/v1
+')"
+    run bash "$CHECKER" "$file"
+    [ "$status" -eq 1 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test: suppression annotation on line 1 → exit 0
+# ---------------------------------------------------------------------------
+
+@test "check-schema-hints: # schema-hint-skip suppression exits 0" {
+    file="$(_write_yaml suppressed.yaml '# schema-hint-skip: template file, schema path varies per deployment target
+apiVersion: myrmidons/v1
+kind: Agent
+')"
+    run bash "$CHECKER" "$file"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+# ---------------------------------------------------------------------------
+# Test: files under a _templates/ directory are skipped (no enforcement)
+# ---------------------------------------------------------------------------
+
+@test "check-schema-hints: file under _templates/ is skipped" {
+    file="$(_write_yaml _templates/no-hint.yaml 'apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: template-agent
+')"
+    run bash "$CHECKER" "$file"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+# ---------------------------------------------------------------------------
+# Edge case: empty file → exit 1 (head -1 yields empty first line)
+# ---------------------------------------------------------------------------
+
+@test "check-schema-hints: empty file exits 1" {
+    file="${TMP_DIR}/empty.yaml"
+    : > "$file"
+    run bash "$CHECKER" "$file"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"missing or malformed"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Edge case: file whose only content is a non-hint comment → exit 1
+# ---------------------------------------------------------------------------
+
+@test "check-schema-hints: comment-only file without hint exits 1" {
+    file="$(_write_yaml comment-only.yaml '# Just a header comment, no schema hint here
+# more comments
+')"
+    run bash "$CHECKER" "$file"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"missing or malformed"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Edge case: hint correct but not on line 1 → exit 1
+# ---------------------------------------------------------------------------
+
+@test "check-schema-hints: correct hint on line 2 (not line 1) exits 1" {
+    file="$(_write_yaml hint-line-2.yaml '# header comment
+# yaml-language-server: $schema=../../schemas/agent-v1.schema.json
+apiVersion: myrmidons/v1
+')"
+    run bash "$CHECKER" "$file"
+    [ "$status" -eq 1 ]
+}
+
+# ---------------------------------------------------------------------------
+# Non-existent file: silently skipped, exits 0
+# ---------------------------------------------------------------------------
+
+@test "check-schema-hints: non-existent file path is silently skipped" {
+    run bash "$CHECKER" "${TMP_DIR}/does-not-exist.yaml"
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Multi-file: violation count reflects all bad files
+# ---------------------------------------------------------------------------
+
+@test "check-schema-hints: multiple bad files reported with violation count" {
+    good="$(_write_yaml good.yaml '# yaml-language-server: $schema=../../schemas/agent-v1.schema.json
+apiVersion: myrmidons/v1
+')"
+    bad1="$(_write_yaml bad1.yaml 'apiVersion: myrmidons/v1
+')"
+    bad2="$(_write_yaml bad2.yaml '# yaml-language-server: schema=foo
+apiVersion: myrmidons/v1
+')"
+    run bash "$CHECKER" "$good" "$bad1" "$bad2"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"2 violation(s)"* ]]
+    [[ "$output" == *"bad1.yaml"* ]]
+    [[ "$output" == *"bad2.yaml"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Regression guard: real repo default scan exits 0
+# ---------------------------------------------------------------------------
+
+@test "check-schema-hints: real repo agents/ and fleets/ scan exits 0" {
+    run bash "$CHECKER"
+    [ "$status" -eq 0 ]
+}

--- a/tools/reconciler/tests/unit/test_compute_drift_arity.bats
+++ b/tools/reconciler/tests/unit/test_compute_drift_arity.bats
@@ -1,0 +1,77 @@
+#!/usr/bin/env bats
+# tests/unit/test_compute_drift_arity.bats — arity guard tests for compute_drift
+#
+# Ensures compute_drift rejects calls with wrong argument counts, catching
+# callers that were not updated in lockstep when a new parameter was added.
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+
+setup() {
+    export AGAMEMNON_URL="http://localhost:19999"
+    # shellcheck source=/dev/null
+    source "${SCRIPT_DIR}/scripts/lib/reconcile.sh"
+}
+
+# Minimal valid actual_json for 13-arg success tests
+_minimal_actual() {
+    jq -n '{status: "active", label: "A", program: "claude-code",
+            workingDirectory: "/tmp", programArgs: "", taskDescription: "",
+            tags: [], model: "", owner: "", role: "member",
+            deployment: {type: "local"}}'
+}
+
+# ---------------------------------------------------------------------------
+# Wrong-arity calls must fail with a descriptive error message
+# ---------------------------------------------------------------------------
+
+@test "compute_drift arity: 0 args → non-zero exit and error message" {
+    run compute_drift
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"requires exactly 13 arguments"* ]]
+}
+
+@test "compute_drift arity: 12 args → non-zero exit and error message" {
+    run compute_drift a b c d e f g h i j k l
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"requires exactly 13 arguments"* ]]
+}
+
+@test "compute_drift arity: 12 args → error message mentions got 12" {
+    run compute_drift a b c d e f g h i j k l
+    [[ "$output" == *"got 12"* ]]
+}
+
+@test "compute_drift arity: 14 args → non-zero exit and error message" {
+    run compute_drift a b c d e f g h i j k l m n
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"requires exactly 13 arguments"* ]]
+}
+
+@test "compute_drift arity: 14 args → error message mentions got 14" {
+    run compute_drift a b c d e f g h i j k l m n
+    [[ "$output" == *"got 14"* ]]
+}
+
+@test "compute_drift arity: 1 arg → non-zero exit and error message" {
+    run compute_drift only-one-arg
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"requires exactly 13 arguments"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Correct arity (13 args) succeeds
+# ---------------------------------------------------------------------------
+
+@test "compute_drift arity: exactly 13 args → exits zero" {
+    actual="$(_minimal_actual)"
+    run compute_drift "agent" "active" "$actual" \
+        "A" "claude-code" "/tmp" "" "" "" "" "" "member" "local"
+    [[ "$status" -eq 0 ]]
+}
+
+@test "compute_drift arity: exactly 13 args → produces valid output" {
+    actual="$(_minimal_actual)"
+    run compute_drift "agent" "active" "$actual" \
+        "A" "claude-code" "/tmp" "" "" "" "" "" "member" "local"
+    [[ "$output" == "UNCHANGED" || "$output" == WAKE || "$output" == HIBERNATE || "$output" == UPDATE:* ]]
+}

--- a/tools/reconciler/tests/unit/test_config.bats
+++ b/tools/reconciler/tests/unit/test_config.bats
@@ -1,0 +1,276 @@
+#!/usr/bin/env bats
+# tests/unit/test_config.bats — unit tests for scripts/lib/config.sh
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+
+# Create a temporary directory for test config files
+setup() {
+    TEST_TMP_DIR="$(mktemp -d)"
+    export TEST_TMP_DIR
+    ORIGINAL_DIR="$(pwd)"
+    export ORIGINAL_DIR
+
+    # Create a justfile to mark repo root
+    touch "${TEST_TMP_DIR}/justfile"
+
+    # Change to the test directory so _cfg_repo_root finds our files
+    cd "$TEST_TMP_DIR" || return 1
+
+    # Clear any environment variables that might interfere
+    unset AGAMEMNON_URL
+    unset MYRM_LOG_LEVEL
+    unset MYRM_PRUNE_POLICY
+    unset MYRM_SNAPSHOT_RETENTION
+    unset HOST
+
+    # shellcheck source=/dev/null
+    source "${SCRIPT_DIR}/scripts/lib/config.sh"
+}
+
+teardown() {
+    cd "$ORIGINAL_DIR" || return 1
+    rm -rf "$TEST_TMP_DIR"
+}
+
+# ---------------------------------------------------------------------------
+# Defaults when no config files exist
+# ---------------------------------------------------------------------------
+
+@test "load_config: uses defaults when no config files exist" {
+    load_config
+    [[ "$MYRM_DEFAULT_HOST" == "hermes" ]]
+    [[ "$MYRM_AIM_HOST" == "http://localhost:8080" ]]
+    [[ "$MYRM_LOG_LEVEL" == "info" ]]
+    [[ "$MYRM_PRUNE_POLICY" == "manual" ]]
+    [[ "$MYRM_SNAPSHOT_RETENTION" == "7" ]]
+}
+
+# ---------------------------------------------------------------------------
+# Project config overrides defaults
+# ---------------------------------------------------------------------------
+
+@test "load_config: project config overrides defaults" {
+    cat > "${TEST_TMP_DIR}/.myrmidons.yaml" <<'EOF'
+defaultHost: apollo
+aimHost: http://agamemnon.example.com:9000
+logLevel: debug
+prunePolicy: auto
+snapshotRetention: 14
+EOF
+
+    load_config
+    [[ "$MYRM_DEFAULT_HOST" == "apollo" ]]
+    [[ "$MYRM_AIM_HOST" == "http://agamemnon.example.com:9000" ]]
+    [[ "$MYRM_LOG_LEVEL" == "debug" ]]
+    [[ "$MYRM_PRUNE_POLICY" == "auto" ]]
+    [[ "$MYRM_SNAPSHOT_RETENTION" == "14" ]]
+}
+
+@test "load_config: project config partial override (some fields)" {
+    cat > "${TEST_TMP_DIR}/.myrmidons.yaml" <<'EOF'
+defaultHost: zeus
+logLevel: warn
+EOF
+
+    load_config
+    [[ "$MYRM_DEFAULT_HOST" == "zeus" ]]
+    [[ "$MYRM_LOG_LEVEL" == "warn" ]]
+    # Check defaults for other fields
+    [[ "$MYRM_AIM_HOST" == "http://localhost:8080" ]]
+    [[ "$MYRM_PRUNE_POLICY" == "manual" ]]
+}
+
+# ---------------------------------------------------------------------------
+# Local config overrides project config
+# ---------------------------------------------------------------------------
+
+@test "load_config: local config overrides project config" {
+    cat > "${TEST_TMP_DIR}/.myrmidons.yaml" <<'EOF'
+defaultHost: apollo
+aimHost: http://project.example.com:8080
+logLevel: debug
+EOF
+
+    cat > "${TEST_TMP_DIR}/.myrmidons.local.yaml" <<'EOF'
+defaultHost: poseidon
+aimHost: http://local.example.com:9999
+EOF
+
+    load_config
+    # Local should win
+    [[ "$MYRM_DEFAULT_HOST" == "poseidon" ]]
+    [[ "$MYRM_AIM_HOST" == "http://local.example.com:9999" ]]
+    # Project config for unset fields in local
+    [[ "$MYRM_LOG_LEVEL" == "debug" ]]
+}
+
+@test "load_config: local config partial override (some fields)" {
+    cat > "${TEST_TMP_DIR}/.myrmidons.yaml" <<'EOF'
+defaultHost: apollo
+logLevel: info
+prunePolicy: auto
+EOF
+
+    cat > "${TEST_TMP_DIR}/.myrmidons.local.yaml" <<'EOF'
+defaultHost: hades
+EOF
+
+    load_config
+    # Local overrides host
+    [[ "$MYRM_DEFAULT_HOST" == "hades" ]]
+    # Project config for other fields
+    [[ "$MYRM_LOG_LEVEL" == "info" ]]
+    [[ "$MYRM_PRUNE_POLICY" == "auto" ]]
+}
+
+# ---------------------------------------------------------------------------
+# Environment variables override file-based values
+# ---------------------------------------------------------------------------
+
+@test "load_config: env var AGAMEMNON_URL overrides all file configs" {
+    cat > "${TEST_TMP_DIR}/.myrmidons.yaml" <<'EOF'
+aimHost: http://project.example.com:8080
+EOF
+
+    export AGAMEMNON_URL="http://env.example.com:7000"
+    load_config
+    [[ "$MYRM_AIM_HOST" == "http://env.example.com:7000" ]]
+}
+
+@test "load_config: env var HOST overrides all file configs" {
+    cat > "${TEST_TMP_DIR}/.myrmidons.yaml" <<'EOF'
+defaultHost: apollo
+EOF
+
+    export HOST="heracles"
+    load_config
+    [[ "$MYRM_DEFAULT_HOST" == "heracles" ]]
+}
+
+@test "load_config: env var MYRM_LOG_LEVEL overrides all file configs" {
+    cat > "${TEST_TMP_DIR}/.myrmidons.yaml" <<'EOF'
+logLevel: info
+EOF
+
+    export MYRM_LOG_LEVEL="error"
+    load_config
+    [[ "$MYRM_LOG_LEVEL" == "error" ]]
+}
+
+@test "load_config: env var MYRM_PRUNE_POLICY overrides all file configs" {
+    cat > "${TEST_TMP_DIR}/.myrmidons.yaml" <<'EOF'
+prunePolicy: manual
+EOF
+
+    export MYRM_PRUNE_POLICY="auto"
+    load_config
+    [[ "$MYRM_PRUNE_POLICY" == "auto" ]]
+}
+
+@test "load_config: env var MYRM_SNAPSHOT_RETENTION overrides all file configs" {
+    cat > "${TEST_TMP_DIR}/.myrmidons.yaml" <<'EOF'
+snapshotRetention: 7
+EOF
+
+    export MYRM_SNAPSHOT_RETENTION="30"
+    load_config
+    [[ "$MYRM_SNAPSHOT_RETENTION" == "30" ]]
+}
+
+# ---------------------------------------------------------------------------
+# Full precedence chain
+# ---------------------------------------------------------------------------
+
+@test "load_config: full precedence chain (defaults < project < local < env)" {
+    cat > "${TEST_TMP_DIR}/.myrmidons.yaml" <<'EOF'
+defaultHost: apollo
+aimHost: http://project.example.com:8080
+logLevel: debug
+prunePolicy: auto
+snapshotRetention: 14
+EOF
+
+    cat > "${TEST_TMP_DIR}/.myrmidons.local.yaml" <<'EOF'
+defaultHost: poseidon
+logLevel: warn
+EOF
+
+    export MYRM_SNAPSHOT_RETENTION="30"
+
+    load_config
+
+    # Host: local config wins
+    [[ "$MYRM_DEFAULT_HOST" == "poseidon" ]]
+    # aimHost: project config (no local override)
+    [[ "$MYRM_AIM_HOST" == "http://project.example.com:8080" ]]
+    # logLevel: local config wins
+    [[ "$MYRM_LOG_LEVEL" == "warn" ]]
+    # prunePolicy: project config (no local or env)
+    [[ "$MYRM_PRUNE_POLICY" == "auto" ]]
+    # snapshotRetention: env var wins
+    [[ "$MYRM_SNAPSHOT_RETENTION" == "30" ]]
+}
+
+# ---------------------------------------------------------------------------
+# show_config output format
+# ---------------------------------------------------------------------------
+
+@test "show_config: produces output with header and field rows" {
+    load_config
+    output="$(show_config)"
+
+    # Check for header
+    [[ "$output" == *"Effective Myrmidons configuration"* ]]
+    [[ "$output" == *"Sources (lowest → highest precedence):"* ]]
+    [[ "$output" == *"[defaults]"* ]]
+    [[ "$output" == *"[env]"* ]]
+}
+
+@test "show_config: lists all fields with values and sources" {
+    cat > "${TEST_TMP_DIR}/.myrmidons.yaml" <<'EOF'
+defaultHost: apollo
+logLevel: debug
+EOF
+
+    export MYRM_PRUNE_POLICY="custom"
+
+    output="$(show_config)"
+
+    # Check that all fields appear
+    [[ "$output" == *"defaultHost"* ]]
+    [[ "$output" == *"aimHost"* ]]
+    [[ "$output" == *"logLevel"* ]]
+    [[ "$output" == *"prunePolicy"* ]]
+    [[ "$output" == *"snapshotRetention"* ]]
+
+    # Check that values appear
+    [[ "$output" == *"apollo"* ]]
+    [[ "$output" == *"debug"* ]]
+    [[ "$output" == *"custom"* ]]
+}
+
+@test "show_config: identifies correct source for each field" {
+    cat > "${TEST_TMP_DIR}/.myrmidons.yaml" <<'EOF'
+defaultHost: apollo
+logLevel: debug
+EOF
+
+    export AGAMEMNON_URL="http://env.example.com:9000"
+
+    output="$(show_config)"
+
+    # defaultHost should show source=project
+    [[ "$output" == *"defaultHost"*"apollo"*"project"* ]]
+    # aimHost should show source=env (from AGAMEMNON_URL)
+    [[ "$output" == *"aimHost"*"http://env.example.com:9000"*"env"* ]]
+    # logLevel should show source=project
+    [[ "$output" == *"logLevel"*"debug"*"project"* ]]
+}
+
+@test "show_config: indicates missing config files" {
+    output="$(show_config)"
+
+    # Should indicate project config not found
+    [[ "$output" == *".myrmidons.yaml"* ]]
+    [[ "$output" == *"not found"* ]]
+}

--- a/tools/reconciler/tests/unit/test_convergence.bats
+++ b/tools/reconciler/tests/unit/test_convergence.bats
@@ -1,0 +1,408 @@
+#!/usr/bin/env bats
+# tests/unit/test_convergence.bats — regression guard for issue #369
+#
+# Issue #369: dual verify_convergence definition — second definition shadowed
+# the first, and the call at (former) line 602 passed no args, causing the
+# second definition to iterate zero files and silently report success.
+#
+# These tests verify:
+#   - Single definition: verify_convergence takes no positional args
+#   - Non-converged agent returns exit 1
+#   - All-converged returns exit 0
+#   - _PRUNED_NAMES check is executed (pruned agent still present → exit 1)
+#   - _PRUNED_NAMES check passes when pruned agent is absent
+#   - Empty _MODIFIED_NAMES with empty _PRUNED_NAMES returns exit 0 immediately
+
+# ---------------------------------------------------------------------------
+# Helper: build a minimal verify_convergence harness that extracts the logic
+# from apply.sh without requiring a live Agamemnon server.
+# ---------------------------------------------------------------------------
+
+_make_verify_script() {
+    local script="$1"
+    local agents_json="$2"       # JSON array returned by the stub API
+    local modified_names="$3"    # space-separated agent names
+    local modified_desired="$4"  # space-separated desired states (parallel to names)
+    local pruned_names="$5"      # space-separated pruned agent names
+
+    cat > "$script" << SCRIPT
+#!/usr/bin/env bash
+set -euo pipefail
+
+OUTPUT_FORMAT="text"
+
+# Stub agamemnon_list_agents returns fixed JSON
+agamemnon_list_agents() {
+    cat <<'JSON'
+${agents_json}
+JSON
+}
+
+# Populate global arrays from args
+_MODIFIED_NAMES=()
+_MODIFIED_DESIRED=()
+_PRUNED_NAMES=()
+
+IFS=' ' read -r -a _MODIFIED_NAMES <<< "${modified_names}" 2>/dev/null || true
+IFS=' ' read -r -a _MODIFIED_DESIRED <<< "${modified_desired}" 2>/dev/null || true
+IFS=' ' read -r -a _PRUNED_NAMES <<< "${pruned_names}" 2>/dev/null || true
+
+$(declare -f verify_convergence_impl)
+
+verify_convergence_impl
+SCRIPT
+    chmod +x "$script"
+}
+
+# Inline the verify_convergence logic for isolated unit testing
+# (avoids sourcing the entire apply.sh which requires Agamemnon deps)
+verify_convergence_impl() {
+    if [[ ${#_MODIFIED_NAMES[@]} -eq 0 && ${#_PRUNED_NAMES[@]} -eq 0 ]]; then
+        return 0
+    fi
+
+    local failed=0
+    local verified=0
+    local pruned_verified=0
+
+    if [[ "$OUTPUT_FORMAT" != "json" ]]; then
+        echo ""
+        echo "Verifying convergence for ${#_MODIFIED_NAMES[@]} modified agent(s)..."
+        if [[ ${#_PRUNED_NAMES[@]} -gt 0 ]]; then
+            echo "Verifying ${#_PRUNED_NAMES[@]} pruned agent(s) are absent..."
+        fi
+    fi
+
+    local agents_json_fresh
+    agents_json_fresh="$(agamemnon_list_agents)"
+
+    for i in "${!_MODIFIED_NAMES[@]}"; do
+        local agent_name="${_MODIFIED_NAMES[$i]}"
+        local desired="${_MODIFIED_DESIRED[$i]}"
+        local actual_json actual_status
+
+        actual_json="$(echo "$agents_json_fresh" | jq -r --arg n "$agent_name" '.[] | select(.name == $n)')"
+
+        if [[ -z "$actual_json" ]]; then
+            echo "  [!] ${agent_name}: NOT FOUND in Agamemnon after apply (convergence failed)"
+            failed=$((failed + 1))
+            continue
+        fi
+
+        actual_status="$(echo "$actual_json" | jq -r '.status // "unknown"')"
+
+        local converged=0
+        if [[ "$desired" == "active" ]]; then
+            [[ "$actual_status" == "active" || "$actual_status" == "online" || \
+               "$actual_status" == "starting" ]] && converged=1
+        elif [[ "$desired" == "hibernated" ]]; then
+            [[ "$actual_status" == "offline" || "$actual_status" == "hibernated" ]] && converged=1
+        else
+            converged=1
+        fi
+
+        if [[ $converged -eq 1 ]]; then
+            echo "  [ok] ${agent_name}: converged (status=${actual_status})"
+            verified=$((verified + 1))
+        else
+            echo "  [!] ${agent_name}: NOT converged (desired=${desired}, actual_status=${actual_status})"
+            failed=$((failed + 1))
+        fi
+    done
+
+    # Verify pruned agents are gone from the API
+    if [[ ${#_PRUNED_NAMES[@]} -gt 0 ]]; then
+        for pruned_name in "${_PRUNED_NAMES[@]}"; do
+            local still_exists
+            still_exists="$(echo "$agents_json_fresh" | jq -r --arg n "$pruned_name" '.[] | select(.name == $n) | .name')"
+            if [[ -n "$still_exists" ]]; then
+                echo "  [!] ${pruned_name}: pruned but still present in API (convergence failed)"
+                failed=$((failed + 1))
+            else
+                echo "  [ok] ${pruned_name}: confirmed absent (pruned)"
+                pruned_verified=$((pruned_verified + 1))
+            fi
+        done
+    fi
+
+    if [[ ${#_PRUNED_NAMES[@]} -gt 0 ]]; then
+        echo "Convergence: ${verified} converged, ${pruned_verified} pruned, ${failed} failed."
+    else
+        echo "Convergence: ${verified} converged, ${failed} failed."
+    fi
+
+    if [[ $failed -gt 0 ]]; then
+        return 1
+    fi
+    return 0
+}
+
+TEMP_TEST_DIR=""
+
+setup() {
+    TEMP_TEST_DIR="$(mktemp -d)"
+    export TEMP_TEST_DIR
+}
+
+teardown() {
+    [[ -n "$TEMP_TEST_DIR" ]] && rm -rf "$TEMP_TEST_DIR"
+}
+
+# ---------------------------------------------------------------------------
+# #369 regression: verify_convergence accepts NO positional arguments
+# The bug was a second definition taking positional args; when called with
+# no args that second definition's yaml_files was empty → silent success.
+# ---------------------------------------------------------------------------
+
+@test "verify_convergence signature: called with zero args, not positional params" {
+    # Confirm the canonical definition is the only one by grepping apply.sh
+    SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+    count="$(grep -c '^verify_convergence()' "${SCRIPT_DIR}/scripts/apply.sh")"
+    [[ "$count" -eq 1 ]]
+}
+
+@test "verify_convergence: shadowing second definition comment is gone from apply.sh" {
+    SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+    # The second definition was introduced by this exact comment line.
+    # Its removal confirms the shadowing definition is gone.
+    ! grep -qF 'verify_convergence — after apply, confirm each agent reached its desired state.' \
+        "${SCRIPT_DIR}/scripts/apply.sh"
+}
+
+# ---------------------------------------------------------------------------
+# Behavioural: non-converged agent → exit 1
+# ---------------------------------------------------------------------------
+
+@test "verify_convergence: returns 1 when agent did not converge (offline, desired active)" {
+    _MODIFIED_NAMES=("my-agent")
+    _MODIFIED_DESIRED=("active")
+    _PRUNED_NAMES=()
+
+    agamemnon_list_agents() {
+        echo '[{"name":"my-agent","status":"offline"}]'
+    }
+
+    run verify_convergence_impl
+    [[ "$status" -eq 1 ]]
+    [[ "$output" == *"NOT converged"* ]]
+}
+
+@test "verify_convergence: returns 1 when agent is not found in API" {
+    _MODIFIED_NAMES=("missing-agent")
+    _MODIFIED_DESIRED=("active")
+    _PRUNED_NAMES=()
+
+    agamemnon_list_agents() {
+        echo '[]'
+    }
+
+    run verify_convergence_impl
+    [[ "$status" -eq 1 ]]
+    [[ "$output" == *"NOT FOUND"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Behavioural: converged agent → exit 0
+# ---------------------------------------------------------------------------
+
+@test "verify_convergence: returns 0 when agent is active and desired active" {
+    _MODIFIED_NAMES=("my-agent")
+    _MODIFIED_DESIRED=("active")
+    _PRUNED_NAMES=()
+
+    agamemnon_list_agents() {
+        echo '[{"name":"my-agent","status":"active"}]'
+    }
+
+    run verify_convergence_impl
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"converged"* ]]
+}
+
+@test "verify_convergence: returns 0 when agent is online and desired active" {
+    _MODIFIED_NAMES=("my-agent")
+    _MODIFIED_DESIRED=("active")
+    _PRUNED_NAMES=()
+
+    agamemnon_list_agents() {
+        echo '[{"name":"my-agent","status":"online"}]'
+    }
+
+    run verify_convergence_impl
+    [[ "$status" -eq 0 ]]
+}
+
+@test "verify_convergence: returns 0 when agent is offline and desired hibernated" {
+    _MODIFIED_NAMES=("my-agent")
+    _MODIFIED_DESIRED=("hibernated")
+    _PRUNED_NAMES=()
+
+    agamemnon_list_agents() {
+        echo '[{"name":"my-agent","status":"offline"}]'
+    }
+
+    run verify_convergence_impl
+    [[ "$status" -eq 0 ]]
+}
+
+# ---------------------------------------------------------------------------
+# Behavioural: _PRUNED_NAMES check
+# ---------------------------------------------------------------------------
+
+@test "verify_convergence: returns 1 when pruned agent still present in API" {
+    _MODIFIED_NAMES=()
+    _MODIFIED_DESIRED=()
+    _PRUNED_NAMES=("old-agent")
+
+    agamemnon_list_agents() {
+        echo '[{"name":"old-agent","status":"offline"}]'
+    }
+
+    run verify_convergence_impl
+    [[ "$status" -eq 1 ]]
+    [[ "$output" == *"pruned but still present"* ]]
+}
+
+@test "verify_convergence: returns 0 when pruned agent is absent from API" {
+    _MODIFIED_NAMES=()
+    _MODIFIED_DESIRED=()
+    _PRUNED_NAMES=("old-agent")
+
+    agamemnon_list_agents() {
+        echo '[]'
+    }
+
+    run verify_convergence_impl
+    [[ "$status" -eq 0 ]]
+}
+
+# ---------------------------------------------------------------------------
+# Behavioural: empty arrays → early return (no API call needed)
+# ---------------------------------------------------------------------------
+
+@test "verify_convergence: returns 0 immediately when both arrays empty" {
+    _MODIFIED_NAMES=()
+    _MODIFIED_DESIRED=()
+    _PRUNED_NAMES=()
+
+    agamemnon_list_calls=0
+    agamemnon_list_agents() {
+        agamemnon_list_calls=$((agamemnon_list_calls + 1))
+        echo '[]'
+    }
+
+    run verify_convergence_impl
+    [[ "$status" -eq 0 ]]
+}
+
+# ---------------------------------------------------------------------------
+# Behavioural: mixed modified + pruned in one pass
+# ---------------------------------------------------------------------------
+
+@test "verify_convergence: checks both modified agents and pruned agents in one pass" {
+    _MODIFIED_NAMES=("live-agent")
+    _MODIFIED_DESIRED=("active")
+    _PRUNED_NAMES=("dead-agent")
+
+    agamemnon_list_agents() {
+        # live-agent is active (converged); dead-agent still present (prune failed)
+        echo '[{"name":"live-agent","status":"active"},{"name":"dead-agent","status":"offline"}]'
+    }
+
+    run verify_convergence_impl
+    [[ "$status" -eq 1 ]]
+    [[ "$output" == *"[ok] live-agent"* ]]
+    [[ "$output" == *"pruned but still present"* ]]
+}
+
+@test "verify_convergence: all pass when modified converged and pruned agent absent" {
+    _MODIFIED_NAMES=("live-agent")
+    _MODIFIED_DESIRED=("active")
+    _PRUNED_NAMES=("dead-agent")
+
+    agamemnon_list_agents() {
+        echo '[{"name":"live-agent","status":"active"}]'
+    }
+
+    run verify_convergence_impl
+    [[ "$status" -eq 0 ]]
+}
+
+# ---------------------------------------------------------------------------
+# Issue #408: prune-only run prints prune-specific header
+# ---------------------------------------------------------------------------
+
+@test "verify_convergence: prune-only run prints 'Verifying N pruned agent(s) are absent' header" {
+    _MODIFIED_NAMES=()
+    _MODIFIED_DESIRED=()
+    _PRUNED_NAMES=("old-agent" "gone-agent")
+
+    agamemnon_list_agents() {
+        echo '[]'
+    }
+
+    run verify_convergence_impl
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"Verifying 2 pruned agent(s) are absent"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# #407: pruned_verified counter and conditional summary line
+# ---------------------------------------------------------------------------
+
+@test "verify_convergence: prune-only run increments pruned_verified, returns 0" {
+    _MODIFIED_NAMES=()
+    _MODIFIED_DESIRED=()
+    _PRUNED_NAMES=("agent-x" "agent-y" "agent-z")
+
+    agamemnon_list_agents() {
+        echo '[]'
+    }
+
+    run verify_convergence_impl
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"3 pruned"* ]]
+    [[ "$output" == *"0 failed"* ]]
+}
+
+@test "verify_convergence: prune-only run summary reads '0 converged, 3 pruned, 0 failed.'" {
+    _MODIFIED_NAMES=()
+    _MODIFIED_DESIRED=()
+    _PRUNED_NAMES=("agent-x" "agent-y" "agent-z")
+
+    agamemnon_list_agents() {
+        echo '[]'
+    }
+
+    run verify_convergence_impl
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"Convergence: 0 converged, 3 pruned, 0 failed."* ]]
+}
+
+@test "verify_convergence: pruned agent confirmed absent emits ok line" {
+    _MODIFIED_NAMES=()
+    _MODIFIED_DESIRED=()
+    _PRUNED_NAMES=("gone-agent")
+
+    agamemnon_list_agents() {
+        echo '[]'
+    }
+
+    run verify_convergence_impl
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"[ok] gone-agent: confirmed absent (pruned)"* ]]
+}
+
+@test "verify_convergence: no-prune run summary does not contain 'pruned'" {
+    _MODIFIED_NAMES=("my-agent")
+    _MODIFIED_DESIRED=("active")
+    _PRUNED_NAMES=()
+
+    agamemnon_list_agents() {
+        echo '[{"name":"my-agent","status":"active"}]'
+    }
+
+    run verify_convergence_impl
+    [[ "$status" -eq 0 ]]
+    [[ "$output" != *" pruned"* ]]
+}

--- a/tools/reconciler/tests/unit/test_curl_cleanup.bats
+++ b/tools/reconciler/tests/unit/test_curl_cleanup.bats
@@ -1,0 +1,250 @@
+#!/usr/bin/env bats
+# tests/unit/test_curl_cleanup.bats — tests for _agamemnon_curl temp file
+# cleanup guarantees (#117)
+#
+# _agamemnon_curl_retry creates a mktemp file per attempt and removes it with
+# `rm -f "$tmpfile"` after reading the response.  These tests verify that no
+# temp files are leaked to the filesystem on success, on permanent error
+# (non-retried HTTP error), and on transient error (all retries exhausted).
+#
+# Strategy: intercept mktemp to record every temp-file path created during a
+# _agamemnon_curl_retry call, then assert all recorded paths have been removed
+# after the call returns.
+#
+# NOTE: curl and mktemp must be overridden BEFORE sourcing api.sh so that
+# the overrides are in scope when set -euo pipefail from api.sh takes effect.
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+
+# ---------------------------------------------------------------------------
+# Setup / teardown
+# ---------------------------------------------------------------------------
+
+setup() {
+    # Working directory for all per-test tracking files
+    TRACKED_TMPDIR="$(command mktemp -d)"
+    export TRACKED_TMPDIR
+
+    # File that records every path returned by our mktemp override
+    TRACKED_LIST="${TRACKED_TMPDIR}/tracked_tmps"
+    : > "$TRACKED_LIST"
+    export TRACKED_LIST
+
+    # File recording curl invocation count
+    CALL_FILE="${TRACKED_TMPDIR}/calls"
+    echo 0 > "$CALL_FILE"
+    export CALL_FILE
+
+    # File driving mock responses; entries are "exit_code,http_code" separated
+    # by | (the last entry repeats for subsequent calls).
+    SEQ_FILE="${TRACKED_TMPDIR}/seq"
+    export SEQ_FILE
+
+    # Body written to curl's -o output file
+    BODY_FILE="${TRACKED_TMPDIR}/body"
+    echo '{"ok":true}' > "$BODY_FILE"
+    export BODY_FILE
+
+    # Override sleep so tests run instantly (must be exported for subshells)
+    sleep() { :; }
+    export -f sleep
+
+    # Override mktemp: create a real temp file via the external binary,
+    # record its path, and echo it.  Defined BEFORE sourcing api.sh so that
+    # the override is active when set -euo pipefail takes effect.
+    mktemp() {
+        local real_tmp
+        real_tmp="$(command mktemp)"
+        echo "$real_tmp" >> "$TRACKED_LIST"
+        echo "$real_tmp"
+    }
+    export -f mktemp
+
+    # Override curl to avoid real network calls.  Defined BEFORE sourcing api.sh
+    # for the same reason as mktemp above.
+    curl() {
+        local count
+        count=$(<"$CALL_FILE")
+        echo $((count + 1)) > "$CALL_FILE"
+
+        # Read next sequence entry; entries separated by |; last entry repeats
+        local seq entry rest exit_code http_code
+        seq=$(<"$SEQ_FILE")
+        entry="${seq%%|*}"
+        rest="${seq#*|}"
+        exit_code="${entry%%,*}"
+        http_code="${entry#*,}"
+        [[ "$rest" != "$seq" ]] && echo "$rest" > "$SEQ_FILE"
+
+        # Write mock body to curl's -o destination
+        local args=("$@") i
+        for (( i=0; i<${#args[@]}; i++ )); do
+            if [[ "${args[$i]}" == "-o" ]]; then
+                cat "$BODY_FILE" > "${args[$((i+1))]}"; break
+            fi
+        done
+
+        echo -n "$http_code"
+        return "$exit_code"
+    }
+    export -f curl
+
+    # Source api.sh after overrides are in place
+    export AGAMEMNON_URL="http://mock.test:19999"
+    export AGAMEMNON_TIMEOUT=1
+    # shellcheck source=/dev/null
+    source "${SCRIPT_DIR}/scripts/lib/api.sh"
+}
+
+teardown() {
+    [[ -d "${TRACKED_TMPDIR:-}" ]] && rm -rf "$TRACKED_TMPDIR"
+}
+
+# ---------------------------------------------------------------------------
+# Helper: assert all tracked temp files have been removed
+# ---------------------------------------------------------------------------
+_assert_no_leaked_tmpfiles() {
+    local leaked=()
+    while IFS= read -r path; do
+        [[ -z "$path" ]] && continue
+        [[ -f "$path" ]] && leaked+=("$path")
+    done < "$TRACKED_LIST"
+
+    if [[ ${#leaked[@]} -gt 0 ]]; then
+        echo "LEAKED temp files:" >&2
+        printf '  %s\n' "${leaked[@]}" >&2
+        return 1
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: Success on first attempt — temp file is cleaned up
+# ---------------------------------------------------------------------------
+
+@test "_agamemnon_curl_retry: temp file removed on success (HTTP 200)" {
+    echo "0,200" > "$SEQ_FILE"
+
+    _agamemnon_curl_retry "http://mock.test:19999/v1/agents" >/dev/null 2>/dev/null
+    _assert_no_leaked_tmpfiles
+}
+
+# ---------------------------------------------------------------------------
+# Test 2: Permanent error (HTTP 404) — temp file is cleaned up
+# ---------------------------------------------------------------------------
+
+@test "_agamemnon_curl_retry: temp file removed on permanent HTTP error (404)" {
+    echo "0,404" > "$SEQ_FILE"
+
+    run _agamemnon_curl_retry "http://mock.test:19999/v1/agents" 2>/dev/null
+    _assert_no_leaked_tmpfiles
+}
+
+# ---------------------------------------------------------------------------
+# Test 3: Permanent error (HTTP 401) — temp file is cleaned up
+# ---------------------------------------------------------------------------
+
+@test "_agamemnon_curl_retry: temp file removed on permanent HTTP error (401)" {
+    echo "0,401" > "$SEQ_FILE"
+
+    run _agamemnon_curl_retry "http://mock.test:19999/v1/agents" 2>/dev/null
+    _assert_no_leaked_tmpfiles
+}
+
+# ---------------------------------------------------------------------------
+# Test 4: Transient error (exit 7) then success — both temp files cleaned up
+# ---------------------------------------------------------------------------
+
+@test "_agamemnon_curl_retry: temp files removed after retry (exit 7 then 200)" {
+    # Pipe-separated sequence: first call returns exit 7, second returns 200
+    echo "7,000|0,200" > "$SEQ_FILE"
+
+    # Use `run` so that set -e from api.sh does not abort the test on curl's
+    # transient exit 7; the function should retry internally and succeed.
+    run _agamemnon_curl_retry "http://mock.test:19999/v1/agents" 2>/dev/null
+    [[ "$status" -eq 0 ]]
+    _assert_no_leaked_tmpfiles
+}
+
+# ---------------------------------------------------------------------------
+# Test 5: All retries exhausted (exit 7 x3) — all temp files cleaned up
+# ---------------------------------------------------------------------------
+
+@test "_agamemnon_curl_retry: temp files removed when all 3 attempts fail (exit 7)" {
+    echo "7,000" > "$SEQ_FILE"
+
+    run _agamemnon_curl_retry "http://mock.test:19999/v1/agents" 2>/dev/null
+    _assert_no_leaked_tmpfiles
+}
+
+# ---------------------------------------------------------------------------
+# Test 6: All retries exhausted (HTTP 503 x3) — all temp files cleaned up
+# ---------------------------------------------------------------------------
+
+@test "_agamemnon_curl_retry: temp files removed when all 3 attempts return HTTP 503" {
+    echo "0,503" > "$SEQ_FILE"
+
+    run _agamemnon_curl_retry "http://mock.test:19999/v1/agents" 2>/dev/null
+    _assert_no_leaked_tmpfiles
+}
+
+# ---------------------------------------------------------------------------
+# Test 7: Exactly one temp file per attempt is created and removed on success
+# ---------------------------------------------------------------------------
+
+@test "_agamemnon_curl_retry: exactly 1 temp file created and removed on success" {
+    echo "0,200" > "$SEQ_FILE"
+    # Reset tracked list so we only count what this test creates
+    : > "$TRACKED_LIST"
+
+    _agamemnon_curl_retry "http://mock.test:19999/v1/agents" >/dev/null 2>/dev/null
+
+    local count
+    count=$(grep -c . "$TRACKED_LIST" || true)
+    # One attempt → exactly 1 temp file created
+    [[ $count -eq 1 ]]
+    # And it must be cleaned up
+    _assert_no_leaked_tmpfiles
+}
+
+# ---------------------------------------------------------------------------
+# Test 8: Three temp files created and removed when all retries fail
+# ---------------------------------------------------------------------------
+
+@test "_agamemnon_curl_retry: 3 temp files created and all removed when all retries fail" {
+    echo "7,000" > "$SEQ_FILE"
+    # Reset tracked list so we only count what this test creates
+    : > "$TRACKED_LIST"
+
+    run _agamemnon_curl_retry "http://mock.test:19999/v1/agents" 2>/dev/null
+
+    local count
+    count=$(grep -c . "$TRACKED_LIST" || true)
+    # Three attempts → 3 temp files tracked
+    [[ $count -eq 3 ]]
+    _assert_no_leaked_tmpfiles
+}
+
+# ---------------------------------------------------------------------------
+# Test 9: Transient timeout (exit 28) then success — temp files cleaned up
+# ---------------------------------------------------------------------------
+
+@test "_agamemnon_curl_retry: temp files removed after exit-28 retry then success" {
+    echo "28,000|0,200" > "$SEQ_FILE"
+
+    # Use `run` so that set -e from api.sh does not abort the test on curl's
+    # transient exit 28; the function should retry internally and succeed.
+    run _agamemnon_curl_retry "http://mock.test:19999/v1/agents" 2>/dev/null
+    [[ "$status" -eq 0 ]]
+    _assert_no_leaked_tmpfiles
+}
+
+# ---------------------------------------------------------------------------
+# Test 10: HTTP 500 (transient) then success — temp files cleaned up
+# ---------------------------------------------------------------------------
+
+@test "_agamemnon_curl_retry: temp files removed after HTTP 500 retry then success" {
+    echo "0,500|0,200" > "$SEQ_FILE"
+
+    _agamemnon_curl_retry "http://mock.test:19999/v1/agents" >/dev/null 2>/dev/null
+    _assert_no_leaked_tmpfiles
+}

--- a/tools/reconciler/tests/unit/test_deps.bats
+++ b/tools/reconciler/tests/unit/test_deps.bats
@@ -1,0 +1,161 @@
+#!/usr/bin/env bats
+# tests/unit/test_deps.bats — unit tests for check_deps function
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+
+# Source reconcile.sh which defines check_deps
+setup() {
+    export AGAMEMNON_URL="http://localhost:19999"
+    # shellcheck source=/dev/null
+    source "${SCRIPT_DIR}/scripts/lib/log.sh"
+    # shellcheck source=/dev/null
+    source "${SCRIPT_DIR}/scripts/lib/reconcile.sh"
+
+    # Save original PATH for restoration
+    ORIGINAL_PATH="$PATH"
+}
+
+teardown() {
+    # Restore original PATH
+    export PATH="$ORIGINAL_PATH"
+    # Clean up any test directories (safely, with full PATH restored)
+    if [[ -n "${TOOLS_BIN:-}" && -d "$TOOLS_BIN" ]]; then
+        /bin/rm -rf "$TOOLS_BIN" || true
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# check_deps — all dependencies present
+# ---------------------------------------------------------------------------
+
+@test "check_deps: returns 0 when all required tools (yq, jq, curl) are in PATH" {
+    # All tools should be available by default in the test environment
+    check_deps
+    # If we get here without error, the function succeeded
+    [[ $? -eq 0 ]]
+}
+
+# ---------------------------------------------------------------------------
+# check_deps — missing individual tools
+# ---------------------------------------------------------------------------
+
+@test "check_deps: returns 1 and logs error when yq is missing" {
+    # Create a minimal PATH with only jq and curl
+    TOOLS_BIN="$(mktemp -d)"
+
+    local jq_path curl_path
+    jq_path="$(command -v jq)"
+    curl_path="$(command -v curl)"
+
+    /bin/cp "$jq_path" "$TOOLS_BIN/jq"
+    /bin/cp "$curl_path" "$TOOLS_BIN/curl"
+
+    # Set PATH to only have our TOOLS_BIN (which has jq and curl but NOT yq).
+    # Exclude /bin, /usr/bin, and pixi-managed dirs so pixi-installed yq isn't found.
+    PATH="$TOOLS_BIN:/usr/sbin:/sbin"
+
+    # check_deps should fail because yq is not in PATH
+    ! check_deps
+}
+
+@test "check_deps: returns 1 and logs error when jq is missing" {
+    # Create a minimal PATH with only yq and curl
+    TOOLS_BIN="$(mktemp -d)"
+
+    local yq_path curl_path
+    yq_path="$(command -v yq)"
+    curl_path="$(command -v curl)"
+
+    /bin/cp "$yq_path" "$TOOLS_BIN/yq"
+    /bin/cp "$curl_path" "$TOOLS_BIN/curl"
+
+    # Set PATH to only have our TOOLS_BIN (which has yq and curl but NOT jq)
+    # Exclude /bin and /usr/bin to avoid picking up system jq
+    PATH="$TOOLS_BIN:/usr/sbin:/sbin"
+
+    # check_deps should fail because jq is not in PATH
+    ! check_deps
+}
+
+@test "check_deps: returns 1 and logs error when curl is missing" {
+    # Create a minimal PATH with only yq and jq
+    TOOLS_BIN="$(mktemp -d)"
+
+    local yq_path jq_path
+    yq_path="$(command -v yq)"
+    jq_path="$(command -v jq)"
+
+    /bin/cp "$yq_path" "$TOOLS_BIN/yq"
+    /bin/cp "$jq_path" "$TOOLS_BIN/jq"
+
+    # Set PATH to only have our TOOLS_BIN (which has yq and jq but NOT curl)
+    # Exclude /bin and /usr/bin to avoid picking up system curl
+    PATH="$TOOLS_BIN:/usr/sbin:/sbin"
+
+    # check_deps should fail because curl is not in PATH
+    ! check_deps
+}
+
+# ---------------------------------------------------------------------------
+# check_deps — multiple missing tools
+# ---------------------------------------------------------------------------
+
+@test "check_deps: returns 1 when multiple tools are missing" {
+    # Create an empty PATH
+    TOOLS_BIN="$(mktemp -d)"
+
+    # Set PATH to only have our empty TOOLS_BIN (none of the required tools)
+    # Exclude /bin and /usr/bin to avoid picking up system tools
+    PATH="$TOOLS_BIN:/usr/sbin:/sbin"
+
+    # check_deps should fail because none of the required tools are available
+    ! check_deps
+}
+
+@test "check_deps: error message lists all missing tools" {
+    # Create an empty PATH
+    TOOLS_BIN="$(mktemp -d)"
+
+    # Set PATH to only have our empty TOOLS_BIN
+    # Exclude /bin and /usr/bin to avoid picking up system tools
+    PATH="$TOOLS_BIN:/usr/sbin:/sbin"
+
+    # Capture stderr and stdout
+    output=$(check_deps 2>&1 || true)
+
+    # Should mention "Missing required tools"
+    [[ "$output" == *"Missing required tools"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# check_deps — tool detection robustness
+# ---------------------------------------------------------------------------
+
+@test "check_deps: finds tools in standard locations (/usr/bin, /bin, /usr/local/bin)" {
+    # This test verifies that check_deps uses 'command -v' which respects PATH
+    # The default PATH should have yq, jq, curl in common locations
+    check_deps
+    [[ $? -eq 0 ]]
+}
+
+@test "check_deps: handles tools in non-standard PATH entries" {
+    # Create a temp directory with our tools
+    TOOLS_BIN="$(mktemp -d)"
+
+    local yq_path jq_path curl_path
+    yq_path="$(command -v yq)"
+    jq_path="$(command -v jq)"
+    curl_path="$(command -v curl)"
+
+    # Create symlinks
+    /bin/ln -s "$yq_path" "$TOOLS_BIN/yq"
+    /bin/ln -s "$jq_path" "$TOOLS_BIN/jq"
+    /bin/ln -s "$curl_path" "$TOOLS_BIN/curl"
+
+    # Prepend our temp bin to PATH
+    PATH="$TOOLS_BIN:$PATH"
+
+    # check_deps should succeed
+    check_deps
+    [[ $? -eq 0 ]]
+}

--- a/tools/reconciler/tests/unit/test_doctor.bats
+++ b/tools/reconciler/tests/unit/test_doctor.bats
@@ -1,0 +1,297 @@
+#!/usr/bin/env bats
+# tests/unit/test_doctor.bats — unit tests for scripts/doctor.sh
+#
+# Tests verify:
+#   - doctor.sh exits 0 when all checks pass
+#   - doctor.sh exits 1 when required tools are missing
+#   - Connectivity failure is reported as FAIL
+#   - --skip-connectivity flag prevents connectivity check
+#   - YAML validation catches invalid files
+#   - Summary line shows pass/fail counts
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+DOCTOR_SCRIPT="${SCRIPT_DIR}/scripts/doctor.sh"
+TEMP_TEST_DIR=""
+
+setup() {
+    TEMP_TEST_DIR="$(mktemp -d)"
+    export TEMP_TEST_DIR
+    # Default: point at an unreachable URL so connectivity fails predictably
+    export AGAMEMNON_URL="http://127.0.0.1:19999"
+}
+
+teardown() {
+    [[ -n "$TEMP_TEST_DIR" ]] && rm -rf "$TEMP_TEST_DIR"
+    unset AGAMEMNON_URL
+}
+
+# ---------------------------------------------------------------------------
+# Helper: run doctor.sh with --skip-connectivity (avoids network I/O in unit tests)
+# ---------------------------------------------------------------------------
+# shellcheck disable=SC2120
+_run_doctor() {
+    run bash "$DOCTOR_SCRIPT" --skip-connectivity "$@"
+}
+
+# ---------------------------------------------------------------------------
+# Test: basic invocation
+# ---------------------------------------------------------------------------
+
+@test "doctor.sh: script is executable / can be run with bash" {
+    [[ -f "$DOCTOR_SCRIPT" ]]
+    run bash -n "$DOCTOR_SCRIPT"
+    [[ "$status" -eq 0 ]]
+}
+
+@test "doctor.sh: --skip-connectivity exits 0 or 1 (valid exit code)" {
+    _run_doctor
+    # Exit code must be 0 (all pass) or 1 (some fail) — never unexpected
+    [[ "$status" -eq 0 || "$status" -eq 1 ]]
+}
+
+@test "doctor.sh: output contains summary line" {
+    _run_doctor
+    [[ "$output" == *"Summary:"* ]]
+}
+
+@test "doctor.sh: output contains 'passed' and 'failed' in summary" {
+    _run_doctor
+    [[ "$output" == *"passed"* ]]
+    [[ "$output" == *"failed"* ]]
+}
+
+@test "doctor.sh: output contains Check 1 (Required tools)" {
+    _run_doctor
+    [[ "$output" == *"Check 1"* ]]
+}
+
+@test "doctor.sh: output contains Check 2 (Agamemnon connectivity)" {
+    _run_doctor
+    [[ "$output" == *"Check 2"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test: --skip-connectivity flag
+# ---------------------------------------------------------------------------
+
+@test "doctor.sh: --skip-connectivity skips connectivity check" {
+    _run_doctor
+    # Should mention the skip in output
+    [[ "$output" == *"skip"* || "$output" == *"skipped"* || "$output" == *"WARN"* ]]
+}
+
+@test "doctor.sh: connectivity check warns when --skip-connectivity is set" {
+    _run_doctor
+    # The connectivity section should show WARN (not FAIL) when skipped
+    [[ "$output" == *"WARN"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test: connectivity failure detection (without --skip-connectivity)
+# ---------------------------------------------------------------------------
+
+@test "doctor.sh: fails connectivity when Agamemnon is unreachable" {
+    # Use a port that is definitely not listening
+    AGAMEMNON_URL="http://127.0.0.1:19999" run bash "$DOCTOR_SCRIPT"
+    # Should exit 1 (at least one check failed)
+    [[ "$status" -eq 1 ]]
+}
+
+@test "doctor.sh: connectivity failure message mentions AGAMEMNON_URL" {
+    AGAMEMNON_URL="http://127.0.0.1:19999" run bash "$DOCTOR_SCRIPT"
+    [[ "$output" == *"127.0.0.1:19999"* || "$output" == *"AGAMEMNON_URL"* || "$output" == *"FAIL"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test: required tools check
+# ---------------------------------------------------------------------------
+
+@test "doctor.sh: reports PASS for yq when installed" {
+    if ! command -v yq &>/dev/null; then
+        skip "yq not installed"
+    fi
+    _run_doctor
+    [[ "$output" == *"PASS"* ]]
+    [[ "$output" == *"yq"* ]]
+}
+
+@test "doctor.sh: reports PASS for jq when installed" {
+    if ! command -v jq &>/dev/null; then
+        skip "jq not installed"
+    fi
+    _run_doctor
+    [[ "$output" == *"jq"* ]]
+}
+
+@test "doctor.sh: reports PASS for curl when installed" {
+    if ! command -v curl &>/dev/null; then
+        skip "curl not installed"
+    fi
+    _run_doctor
+    [[ "$output" == *"curl"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test: tool missing scenario (simulate by PATH manipulation)
+# ---------------------------------------------------------------------------
+
+@test "doctor.sh: reports FAIL when a required tool is missing from PATH" {
+    # Wrap doctor.sh so that 'command -v yq' fails — achieved by placing a
+    # stub 'yq' that does not exist (but keeping bash, jq, curl available).
+    # We do this by prepending a fake dir where yq is absent to PATH and
+    # ensuring PATH still contains bash, jq, curl.
+    local fake_dir="${TEMP_TEST_DIR}/fake_bin"
+    mkdir -p "$fake_dir"
+
+    # Create a wrapper script that hides yq from doctor.sh
+    local wrapper="${TEMP_TEST_DIR}/run_no_yq.sh"
+    cat > "$wrapper" << WRAPPER_EOF
+#!/usr/bin/env bash
+# Intercept 'command -v yq' and 'yq' calls to simulate missing yq
+# by placing a non-executable placeholder that will cause command -v to fail
+# We do this by overriding command in the environment isn't easily done,
+# so instead we create a doctor_check_tools subshell wrapper.
+
+# Create a stub that fails when called as yq
+mkdir -p "${fake_dir}"
+# No yq in fake_dir on purpose
+
+# Override PATH: bash is still found via full PATH; we just add fake_dir first
+# so that if doctor.sh uses 'command -v yq' it searches fake_dir first (no yq there)
+# but current PATH still has bash/jq/curl
+export PATH="${fake_dir}:\${PATH}"
+export AGAMEMNON_URL="http://127.0.0.1:19999"
+
+exec bash "${DOCTOR_SCRIPT}" --skip-connectivity "\$@"
+WRAPPER_EOF
+    chmod +x "$wrapper"
+
+    run bash "$wrapper"
+
+    # Should report FAIL for yq (not found in fake_dir, real yq still in PATH after)
+    # This approach only works if fake_dir/yq is absent AND real yq comes after.
+    # Since PATH is fake_dir:real_PATH, and yq IS in real PATH, yq will still be found.
+    # Instead verify the FAIL path by checking output structure exists.
+    # The real scenario is tested by checking doctor.sh correctly calls command -v.
+    # At minimum, the script should run and produce output.
+    [[ "$status" -eq 0 || "$status" -eq 1 ]]
+    [[ "$output" == *"Check 1"* ]]
+    [[ "$output" == *"Summary:"* ]]
+}
+
+@test "doctor.sh: check_tools detects missing tool (unit-level simulation)" {
+    # Test the check_tools logic in isolation by creating a minimal script
+    # that mimics the doctor.sh check_tools function with a fake missing tool.
+    local test_script="${TEMP_TEST_DIR}/check_tools_test.sh"
+    cat > "$test_script" << 'CHECK_TOOLS_EOF'
+#!/usr/bin/env bash
+PASS=0; FAIL=0
+pass() { PASS=$((PASS+1)); echo "  [PASS] $1"; }
+fail() { FAIL=$((FAIL+1)); echo "  [FAIL] $1"; }
+green() { printf '%s' "$*"; }
+red()   { printf '%s' "$*"; }
+
+tools=(yq jq curl)
+fake_missing="yq"  # pretend yq is not installed
+
+for cmd in "${tools[@]}"; do
+    if [[ "$cmd" == "$fake_missing" ]]; then
+        fail "$cmd not found"
+    elif command -v "$cmd" &>/dev/null; then
+        pass "$cmd"
+    else
+        fail "$cmd not found"
+    fi
+done
+
+echo "FAIL_COUNT=$FAIL"
+[[ $FAIL -gt 0 ]] && exit 1 || exit 0
+CHECK_TOOLS_EOF
+    chmod +x "$test_script"
+
+    run bash "$test_script"
+    [[ "$status" -eq 1 ]]
+    [[ "$output" == *"[FAIL]"* ]]
+    [[ "$output" == *"yq"* ]]
+    [[ "$output" == *"FAIL_COUNT=1"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test: YAML validation
+# ---------------------------------------------------------------------------
+
+@test "doctor.sh: YAML check warns when no agent/fleet files found" {
+    # Run from a temp dir with no agents/ or fleets/ directories
+    REPO_ROOT_OVERRIDE="${TEMP_TEST_DIR}" \
+        AGAMEMNON_URL="http://127.0.0.1:19999" \
+        run bash "$DOCTOR_SCRIPT" --skip-connectivity
+
+    # Should mention no files found or warn (not fail) — overall check still runs
+    [[ "$output" == *"Check 3"* ]]
+}
+
+@test "doctor.sh: YAML check section heading always present" {
+    _run_doctor
+    [[ "$output" == *"Check 3"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test: git hooks check
+# ---------------------------------------------------------------------------
+
+@test "doctor.sh: Check 4 (git hooks) section is present in output" {
+    _run_doctor
+    [[ "$output" == *"Check 4"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test: pixi check
+# ---------------------------------------------------------------------------
+
+@test "doctor.sh: Check 5 (pixi) section is present in output" {
+    _run_doctor
+    [[ "$output" == *"Check 5"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test: exit codes
+# ---------------------------------------------------------------------------
+
+@test "doctor.sh: exits 0 when no failures" {
+    # The only reliable way to get 0 is if all installed tools pass and connectivity
+    # is skipped. We accept either 0 or 1 since hook/pixi checks may fail in CI.
+    _run_doctor
+    [[ "$status" -eq 0 || "$status" -eq 1 ]]
+}
+
+@test "doctor.sh: exits 1 when connectivity fails (no --skip-connectivity)" {
+    AGAMEMNON_URL="http://127.0.0.1:19999" run bash "$DOCTOR_SCRIPT"
+    [[ "$status" -eq 1 ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test: output format — no hard-coded ANSI in piped mode
+# ---------------------------------------------------------------------------
+
+@test "doctor.sh: when piped, output contains no ANSI escape codes" {
+    _run_doctor
+    # In non-TTY mode the color helpers should print plain text
+    # ANSI codes look like ESC[...m (\033[...)
+    if echo "$output" | grep -qP '\x1b\['; then
+        echo "ANSI codes found in piped output" >&2
+        false
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Test: summary counts are numeric
+# ---------------------------------------------------------------------------
+
+@test "doctor.sh: summary shows numeric passed and failed counts" {
+    _run_doctor
+    # Extract summary line: "Summary: N passed, N failed (of N checks)"
+    local summary_line
+    summary_line="$(echo "$output" | grep "Summary:" | tail -1)"
+    [[ "$summary_line" =~ [0-9]+\ passed ]]
+    [[ "$summary_line" =~ [0-9]+\ failed ]]
+}

--- a/tools/reconciler/tests/unit/test_drift.bats
+++ b/tools/reconciler/tests/unit/test_drift.bats
@@ -1,0 +1,159 @@
+#!/usr/bin/env bats
+# tests/unit/test_drift.bats — unit tests for compute_drift function in scripts/lib/reconcile.sh
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+
+# Source reconcile.sh before each test (without api.sh dependency)
+setup() {
+    # Stub out api.sh sourcing to avoid connection errors
+    export AGAMEMNON_URL="http://localhost:19999"
+    # shellcheck source=/dev/null
+    source "${SCRIPT_DIR}/scripts/lib/reconcile.sh"
+}
+
+# ---------------------------------------------------------------------------
+# compute_drift: Test helpers
+# ---------------------------------------------------------------------------
+
+# Helper to build a minimal actual_json
+# Note: $label is a reserved keyword in jq 1.6; use $lbl to avoid parser conflict.
+_make_actual() {
+    jq -n \
+        --arg status "$1" \
+        --arg lbl "$2" \
+        --arg program "$3" \
+        --arg workingDirectory "$4" \
+        --arg programArgs "$5" \
+        --arg taskDescription "$6" \
+        --argjson tags "$7" \
+        '{status: $status, label: $lbl, program: $program,
+          workingDirectory: $workingDirectory, programArgs: $programArgs,
+          taskDescription: $taskDescription, tags: $tags}'
+}
+
+# ---------------------------------------------------------------------------
+# compute_drift: UNCHANGED paths
+# ---------------------------------------------------------------------------
+
+@test "compute_drift UNCHANGED: all fields match, agent active" {
+    actual="$(_make_actual "active" "Test Agent" "claude-code" "/home/mvillmow/TestProject" "" "A test agent" '["ci","testing"]')"
+    result="$(compute_drift "test-agent" "active" "$actual" "Test Agent" "claude-code" "/home/mvillmow/TestProject" "" "A test agent" "ci,testing" "" "" "" "local")"
+    [[ "$result" == "UNCHANGED" ]]
+}
+
+@test "compute_drift UNCHANGED: hibernated agent matches hibernated desired state" {
+    actual="$(_make_actual "offline" "Sleeping Agent" "aider" "/tmp/proj" "" "" '[]')"
+    result="$(compute_drift "sleep-agent" "hibernated" "$actual" "Sleeping Agent" "aider" "/tmp/proj" "" "" "" "" "" "" "local")"
+    [[ "$result" == "UNCHANGED" ]]
+}
+
+@test "compute_drift UNCHANGED: tags in different order sorted to same result" {
+    actual="$(_make_actual "active" "Agent" "claude-code" "/tmp" "" "" '["beta","alpha"]')"
+    result="$(compute_drift "agent" "active" "$actual" "Agent" "claude-code" "/tmp" "" "" "alpha,beta" "" "" "" "local")"
+    [[ "$result" == "UNCHANGED" ]]
+}
+
+@test "compute_drift UNCHANGED: tilde path normalized with full path" {
+    actual="$(_make_actual "active" "Agent" "claude-code" "${HOME}/Projects" "" "" '[]')"
+    # shellcheck disable=SC2088
+    result="$(compute_drift "agent" "active" "$actual" "Agent" "claude-code" '~/Projects' "" "" "" "" "" "" "local")"
+    [[ "$result" == "UNCHANGED" ]]
+}
+
+@test "compute_drift UNCHANGED: both tags empty" {
+    actual="$(_make_actual "active" "Agent" "claude-code" "/tmp" "" "" '[]')"
+    result="$(compute_drift "agent" "active" "$actual" "Agent" "claude-code" "/tmp" "" "" "" "" "" "" "local")"
+    [[ "$result" == "UNCHANGED" ]]
+}
+
+# ---------------------------------------------------------------------------
+# compute_drift: WAKE path (desired=active, actual=offline)
+# ---------------------------------------------------------------------------
+
+@test "compute_drift WAKE: desired=active, actual=offline" {
+    actual="$(_make_actual "offline" "Agent" "claude-code" "/tmp" "" "" '[]')"
+    result="$(compute_drift "agent" "active" "$actual" "Agent" "claude-code" "/tmp" "" "" "" "" "" "" "local")"
+    [[ "$result" == "WAKE" ]]
+}
+
+@test "compute_drift WAKE: returns WAKE even if other fields differ" {
+    actual="$(_make_actual "offline" "Old Label" "old-prog" "/old/path" "--old" "Old desc" '["old-tag"]')"
+    result="$(compute_drift "agent" "active" "$actual" "New Label" "new-prog" "/new/path" "--new" "New desc" "new-tag" "" "" "" "local")"
+    [[ "$result" == "WAKE" ]]
+}
+
+# ---------------------------------------------------------------------------
+# compute_drift: HIBERNATE path (desired=hibernated, actual=active/online)
+# ---------------------------------------------------------------------------
+
+@test "compute_drift HIBERNATE: desired=hibernated, actual=active" {
+    actual="$(_make_actual "active" "Agent" "claude-code" "/tmp" "" "" '[]')"
+    result="$(compute_drift "agent" "hibernated" "$actual" "Agent" "claude-code" "/tmp" "" "" "" "" "" "" "local")"
+    [[ "$result" == "HIBERNATE" ]]
+}
+
+@test "compute_drift HIBERNATE: desired=hibernated, actual=online" {
+    actual="$(_make_actual "online" "Agent" "claude-code" "/tmp" "" "" '[]')"
+    result="$(compute_drift "agent" "hibernated" "$actual" "Agent" "claude-code" "/tmp" "" "" "" "" "" "" "local")"
+    [[ "$result" == "HIBERNATE" ]]
+}
+
+@test "compute_drift HIBERNATE: returns HIBERNATE even if other fields differ" {
+    actual="$(_make_actual "active" "Old Label" "old-prog" "/old/path" "--old" "Old desc" '["old-tag"]')"
+    result="$(compute_drift "agent" "hibernated" "$actual" "New Label" "new-prog" "/new/path" "--new" "New desc" "new-tag" "" "" "" "local")"
+    [[ "$result" == "HIBERNATE" ]]
+}
+
+# ---------------------------------------------------------------------------
+# compute_drift: UPDATE path (field-level differences)
+# ---------------------------------------------------------------------------
+
+@test "compute_drift UPDATE: label differs" {
+    actual="$(_make_actual "active" "Old Label" "claude-code" "/tmp" "" "" '[]')"
+    result="$(compute_drift "agent" "active" "$actual" "New Label" "claude-code" "/tmp" "" "" "" "" "" "" "local")"
+    [[ "$result" == UPDATE:* ]]
+    [[ "$result" == *"label"* ]]
+}
+
+@test "compute_drift UPDATE: program differs" {
+    actual="$(_make_actual "active" "Agent" "claude-code" "/tmp" "" "" '[]')"
+    result="$(compute_drift "agent" "active" "$actual" "Agent" "aider" "/tmp" "" "" "" "" "" "" "local")"
+    [[ "$result" == UPDATE:* ]]
+    [[ "$result" == *"program"* ]]
+}
+
+@test "compute_drift UPDATE: workingDirectory differs" {
+    actual="$(_make_actual "active" "Agent" "claude-code" "/old/path" "" "" '[]')"
+    result="$(compute_drift "agent" "active" "$actual" "Agent" "claude-code" "/new/path" "" "" "" "" "" "" "local")"
+    [[ "$result" == UPDATE:* ]]
+    [[ "$result" == *"workingDirectory"* ]]
+}
+
+@test "compute_drift UPDATE: programArgs differs" {
+    actual="$(_make_actual "active" "Agent" "claude-code" "/tmp" "--old" "" '[]')"
+    result="$(compute_drift "agent" "active" "$actual" "Agent" "claude-code" "/tmp" "--new" "" "" "" "" "" "local")"
+    [[ "$result" == UPDATE:* ]]
+    [[ "$result" == *"programArgs"* ]]
+}
+
+@test "compute_drift UPDATE: taskDescription differs" {
+    actual="$(_make_actual "active" "Agent" "claude-code" "/tmp" "" "Old description" '[]')"
+    result="$(compute_drift "agent" "active" "$actual" "Agent" "claude-code" "/tmp" "" "New description" "" "" "" "" "local")"
+    [[ "$result" == UPDATE:* ]]
+    [[ "$result" == *"taskDescription"* ]]
+}
+
+@test "compute_drift UPDATE: tags differ" {
+    actual="$(_make_actual "active" "Agent" "claude-code" "/tmp" "" "" '["tag1"]')"
+    result="$(compute_drift "agent" "active" "$actual" "Agent" "claude-code" "/tmp" "" "" "tag1,tag2" "" "" "" "local")"
+    [[ "$result" == UPDATE:* ]]
+    [[ "$result" == *"tags"* ]]
+}
+
+@test "compute_drift UPDATE: multiple fields differ, lists all in comma-separated format" {
+    actual="$(_make_actual "active" "Old Label" "old-prog" "/tmp" "" "" '[]')"
+    result="$(compute_drift "agent" "active" "$actual" "New Label" "new-prog" "/tmp" "" "" "" "" "" "" "local")"
+    [[ "$result" == UPDATE:* ]]
+    [[ "$result" == *"label"* ]]
+    [[ "$result" == *"program"* ]]
+}

--- a/tools/reconciler/tests/unit/test_drift_owner_role_tags.bats
+++ b/tools/reconciler/tests/unit/test_drift_owner_role_tags.bats
@@ -1,0 +1,174 @@
+#!/usr/bin/env bats
+# tests/unit/test_drift_owner_role_tags.bats — Smoke tests for compute_drift with
+# owner, role, and tags fields (#87)
+#
+# These tests exercise compute_drift using a full actual_json that includes
+# owner, role, model, and deployment fields — matching what the Agamemnon API
+# returns in production.  The _make_actual helper in test_drift.bats omits those
+# fields; this file ensures drift is detected when they change.
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+
+setup() {
+    export AGAMEMNON_URL="http://localhost:19999"
+    # shellcheck source=/dev/null
+    source "${SCRIPT_DIR}/scripts/lib/reconcile.sh"
+}
+
+# Build a full agent JSON that matches what the Agamemnon API returns,
+# including owner, role, model, and deployment sub-object.
+_make_full_actual() {
+    local status="$1" lbl="$2" program="$3" workdir="$4"
+    local args="$5" desc="$6" tags_json="$7"
+    local model="$8" owner="$9" role="${10}" deploy_type="${11}"
+    # Note: $label is a reserved keyword in jq 1.6; use $lbl.
+    jq -n \
+        --arg status "$status" \
+        --arg lbl "$lbl" \
+        --arg program "$program" \
+        --arg workingDirectory "$workdir" \
+        --arg programArgs "$args" \
+        --arg taskDescription "$desc" \
+        --argjson tags "$tags_json" \
+        --arg model "$model" \
+        --arg owner "$owner" \
+        --arg role "$role" \
+        --arg deployType "$deploy_type" \
+        '{
+            status: $status,
+            label: $lbl,
+            program: $program,
+            workingDirectory: $workingDirectory,
+            programArgs: $programArgs,
+            taskDescription: $taskDescription,
+            tags: $tags,
+            model: $model,
+            owner: $owner,
+            role: $role,
+            deployment: { type: $deployType }
+        }'
+}
+
+# ---------------------------------------------------------------------------
+# Smoke: UNCHANGED with owner/role/tags all set
+# ---------------------------------------------------------------------------
+
+@test "compute_drift smoke: UNCHANGED when owner matches" {
+    actual="$(_make_full_actual "active" "Agent" "claude-code" "/tmp" "" "" '[]' "" "alice" "member" "local")"
+    result="$(compute_drift "agent" "active" "$actual" "Agent" "claude-code" "/tmp" "" "" "" "" "alice" "member" "local")"
+    [[ "$result" == "UNCHANGED" ]]
+}
+
+@test "compute_drift smoke: UNCHANGED when role matches" {
+    actual="$(_make_full_actual "active" "Agent" "claude-code" "/tmp" "" "" '[]' "" "alice" "admin" "local")"
+    result="$(compute_drift "agent" "active" "$actual" "Agent" "claude-code" "/tmp" "" "" "" "" "alice" "admin" "local")"
+    [[ "$result" == "UNCHANGED" ]]
+}
+
+@test "compute_drift smoke: UNCHANGED when tags match (single tag)" {
+    actual="$(_make_full_actual "active" "Agent" "claude-code" "/tmp" "" "" '["ops"]' "" "alice" "member" "local")"
+    result="$(compute_drift "agent" "active" "$actual" "Agent" "claude-code" "/tmp" "" "" "ops" "" "alice" "member" "local")"
+    [[ "$result" == "UNCHANGED" ]]
+}
+
+@test "compute_drift smoke: UNCHANGED when tags match (multiple tags, same order)" {
+    actual="$(_make_full_actual "active" "Agent" "claude-code" "/tmp" "" "" '["alpha","beta","gamma"]' "" "mvillmow" "member" "local")"
+    result="$(compute_drift "agent" "active" "$actual" "Agent" "claude-code" "/tmp" "" "" "alpha,beta,gamma" "" "mvillmow" "member" "local")"
+    [[ "$result" == "UNCHANGED" ]]
+}
+
+@test "compute_drift smoke: UNCHANGED when tags match out-of-order (sorted comparison)" {
+    actual="$(_make_full_actual "active" "Agent" "claude-code" "/tmp" "" "" '["gamma","alpha","beta"]' "" "mvillmow" "member" "local")"
+    result="$(compute_drift "agent" "active" "$actual" "Agent" "claude-code" "/tmp" "" "" "beta,alpha,gamma" "" "mvillmow" "member" "local")"
+    [[ "$result" == "UNCHANGED" ]]
+}
+
+# ---------------------------------------------------------------------------
+# Smoke: drift detected when owner changes
+# ---------------------------------------------------------------------------
+
+@test "compute_drift smoke: UPDATE:owner when owner changes" {
+    actual="$(_make_full_actual "active" "Agent" "claude-code" "/tmp" "" "" '[]' "" "alice" "member" "local")"
+    result="$(compute_drift "agent" "active" "$actual" "Agent" "claude-code" "/tmp" "" "" "" "" "bob" "member" "local")"
+    [[ "$result" == UPDATE:* ]]
+    [[ "$result" == *"owner"* ]]
+}
+
+@test "compute_drift smoke: UPDATE:owner only when only owner changes" {
+    actual="$(_make_full_actual "active" "Agent" "claude-code" "/tmp" "" "" '[]' "" "alice" "member" "local")"
+    result="$(compute_drift "agent" "active" "$actual" "Agent" "claude-code" "/tmp" "" "" "" "" "bob" "member" "local")"
+    # Should be exactly UPDATE:owner (no other fields drifted)
+    [[ "$result" == "UPDATE:owner" ]]
+}
+
+# ---------------------------------------------------------------------------
+# Smoke: drift detected when role changes
+# ---------------------------------------------------------------------------
+
+@test "compute_drift smoke: UPDATE:role when role changes" {
+    actual="$(_make_full_actual "active" "Agent" "claude-code" "/tmp" "" "" '[]' "" "alice" "member" "local")"
+    result="$(compute_drift "agent" "active" "$actual" "Agent" "claude-code" "/tmp" "" "" "" "" "alice" "admin" "local")"
+    [[ "$result" == UPDATE:* ]]
+    [[ "$result" == *"role"* ]]
+}
+
+@test "compute_drift smoke: UPDATE:role only when only role changes" {
+    actual="$(_make_full_actual "active" "Agent" "claude-code" "/tmp" "" "" '[]' "" "alice" "member" "local")"
+    result="$(compute_drift "agent" "active" "$actual" "Agent" "claude-code" "/tmp" "" "" "" "" "alice" "admin" "local")"
+    [[ "$result" == "UPDATE:role" ]]
+}
+
+# ---------------------------------------------------------------------------
+# Smoke: drift detected when tags change
+# ---------------------------------------------------------------------------
+
+@test "compute_drift smoke: UPDATE:tags when tag is added" {
+    actual="$(_make_full_actual "active" "Agent" "claude-code" "/tmp" "" "" '["ai"]' "" "mvillmow" "member" "local")"
+    result="$(compute_drift "agent" "active" "$actual" "Agent" "claude-code" "/tmp" "" "" "ai,ops" "" "mvillmow" "member" "local")"
+    [[ "$result" == UPDATE:* ]]
+    [[ "$result" == *"tags"* ]]
+}
+
+@test "compute_drift smoke: UPDATE:tags when tag is removed" {
+    actual="$(_make_full_actual "active" "Agent" "claude-code" "/tmp" "" "" '["ai","ops"]' "" "mvillmow" "member" "local")"
+    result="$(compute_drift "agent" "active" "$actual" "Agent" "claude-code" "/tmp" "" "" "ai" "" "mvillmow" "member" "local")"
+    [[ "$result" == UPDATE:* ]]
+    [[ "$result" == *"tags"* ]]
+}
+
+@test "compute_drift smoke: UPDATE:tags when tags cleared (non-empty to empty)" {
+    actual="$(_make_full_actual "active" "Agent" "claude-code" "/tmp" "" "" '["tag1"]' "" "mvillmow" "member" "local")"
+    result="$(compute_drift "agent" "active" "$actual" "Agent" "claude-code" "/tmp" "" "" "" "" "mvillmow" "member" "local")"
+    [[ "$result" == UPDATE:* ]]
+    [[ "$result" == *"tags"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Smoke: all three fields drifted simultaneously
+# ---------------------------------------------------------------------------
+
+@test "compute_drift smoke: UPDATE contains owner, role, and tags when all three change" {
+    actual="$(_make_full_actual "active" "Agent" "claude-code" "/tmp" "" "" '["old-tag"]' "" "alice" "member" "local")"
+    result="$(compute_drift "agent" "active" "$actual" "Agent" "claude-code" "/tmp" "" "" "new-tag" "" "bob" "admin" "local")"
+    [[ "$result" == UPDATE:* ]]
+    [[ "$result" == *"owner"* ]]
+    [[ "$result" == *"role"* ]]
+    [[ "$result" == *"tags"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Smoke: WAKE/HIBERNATE still take priority over field drift
+# ---------------------------------------------------------------------------
+
+@test "compute_drift smoke: WAKE takes priority over owner/role/tags drift" {
+    # Actual is offline; desired is active — should WAKE even though owner/role/tags also differ
+    actual="$(_make_full_actual "offline" "Agent" "claude-code" "/tmp" "" "" '["old"]' "" "alice" "member" "local")"
+    result="$(compute_drift "agent" "active" "$actual" "Agent" "claude-code" "/tmp" "" "" "new" "" "bob" "admin" "local")"
+    [[ "$result" == "WAKE" ]]
+}
+
+@test "compute_drift smoke: HIBERNATE takes priority over owner/role/tags drift" {
+    actual="$(_make_full_actual "online" "Agent" "claude-code" "/tmp" "" "" '["old"]' "" "alice" "member" "local")"
+    result="$(compute_drift "agent" "hibernated" "$actual" "Agent" "claude-code" "/tmp" "" "" "new" "" "bob" "admin" "local")"
+    [[ "$result" == "HIBERNATE" ]]
+}

--- a/tools/reconciler/tests/unit/test_export_default_owner.bats
+++ b/tools/reconciler/tests/unit/test_export_default_owner.bats
@@ -1,0 +1,291 @@
+#!/usr/bin/env bats
+# tests/unit/test_export_default_owner.bats — test MYRMIDONS_DEFAULT_OWNER resolution
+#
+# Issue #404: export.sh resolved $(whoami) once per agent in export_agent().
+# Fix: main() exports MYRMIDONS_DEFAULT_OWNER after resolving it, so subsequent
+# calls inside export_agent() find the variable already set.
+#
+# Tests:
+#   - whoami is called at most once when MYRMIDONS_DEFAULT_OWNER is unset (multi-agent)
+#   - whoami is never called when MYRMIDONS_DEFAULT_OWNER is pre-set
+#   - spec.owner in generated YAML uses the fallback when API returns null owner
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+HELPERS_DIR="${SCRIPT_DIR}/tests/helpers"
+
+MOCK_PORT=18087
+MOCK_PID_FILE=""
+TEMP_DIR=""
+
+# ── Mock server helpers ───────────────────────────────────────────────────────
+
+_start_mock_server() {
+    local http_status="${1:-200}"
+    local body="${2:-[]}"
+
+    MOCK_PID_FILE="${TEMP_DIR}/mock.pid"
+    MOCK_STATUS="$http_status" MOCK_BODY="$body" \
+        python3 "${HELPERS_DIR}/mock_server.py" "$MOCK_PORT" \
+        > /dev/null 2>&1 &
+    echo $! > "$MOCK_PID_FILE"
+    sleep 0.2
+}
+
+_stop_mock_server() {
+    if [[ -n "$MOCK_PID_FILE" && -f "$MOCK_PID_FILE" ]]; then
+        kill "$(cat "$MOCK_PID_FILE")" 2>/dev/null || true
+        rm -f "$MOCK_PID_FILE"
+    fi
+}
+
+# ── setup / teardown ─────────────────────────────────────────────────────────
+
+setup() {
+    TEMP_DIR="$(mktemp -d)"
+    export AGAMEMNON_URL="http://127.0.0.1:${MOCK_PORT}"
+    unset MYRMIDONS_DEFAULT_OWNER
+}
+
+teardown() {
+    _stop_mock_server
+    [[ -n "$TEMP_DIR" ]] && rm -rf "$TEMP_DIR"
+}
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+# Build a minimal agent JSON with null owner (to trigger the fallback path)
+_agent_json_null_owner() {
+    local name="${1:-agent}"
+    local label="${2:-Agent}"
+    jq -n \
+        --arg name  "$name" \
+        --arg lbl   "$label" \
+        '{
+            id: ("id-" + $name),
+            name: $name,
+            label: $lbl,
+            program: "claude-code",
+            status: "active",
+            workingDirectory: "/tmp",
+            programArgs: "",
+            taskDescription: "Test agent",
+            tags: [],
+            model: null,
+            owner: null,
+            role: "member",
+            deployment: {type: "local"}
+        }'
+}
+
+# Run export.sh with a mock `whoami` injected via PATH.
+# Sets WHOAMI_CALL_COUNT_FILE so tests can count invocations.
+_run_export_with_mock_whoami() {
+    local mock_body="$1"
+
+    # Create a mock whoami that records each call
+    mkdir -p "${TEMP_DIR}/mocks"
+    export WHOAMI_CALL_COUNT_FILE="${TEMP_DIR}/whoami_calls"
+    cat > "${TEMP_DIR}/mocks/whoami" <<'EOF'
+#!/usr/bin/env bash
+echo "1" >> "${WHOAMI_CALL_COUNT_FILE}"
+echo "mockuser"
+EOF
+    chmod +x "${TEMP_DIR}/mocks/whoami"
+    export PATH="${TEMP_DIR}/mocks:${PATH}"
+
+    _start_mock_server 200 "$mock_body"
+
+    local wrapper="${TEMP_DIR}/export_wrapper.sh"
+    cat > "$wrapper" <<WRAPPER
+#!/usr/bin/env bash
+set -euo pipefail
+export AGAMEMNON_URL="http://127.0.0.1:${MOCK_PORT}"
+export PATH="${TEMP_DIR}/mocks:\${PATH}"
+export WHOAMI_CALL_COUNT_FILE="${WHOAMI_CALL_COUNT_FILE}"
+
+SCRIPT_DIR_REAL="${SCRIPT_DIR}"
+TEMP_DIR_REAL="${TEMP_DIR}"
+
+HOST="hermes"
+OUTPUT_DIR="\${TEMP_DIR_REAL}/agents/\${HOST}"
+
+# shellcheck source=scripts/lib/log.sh
+source "\${SCRIPT_DIR_REAL}/scripts/lib/log.sh"
+# shellcheck source=scripts/lib/api.sh
+source "\${SCRIPT_DIR_REAL}/scripts/lib/api.sh"
+
+check_jq() { command -v jq &>/dev/null; }
+
+program_to_image() {
+    local prog="\$1"
+    case "\$prog" in
+        claude-code|claude) echo "achaean-claude:latest" ;;
+        *) echo "achaean-worker:latest" ;;
+    esac
+}
+
+label_to_stem() {
+    local lbl="\$1"
+    echo "\${lbl}" | tr '[:upper:]' '[:lower:]' | tr ' ' '-'
+}
+
+export_agent() {
+    local agent_json="\$1"
+    local name label program model workdir args desc owner role status deployment_type
+    name="\$(echo "\$agent_json" | jq -r '.name')"
+    label="\$(echo "\$agent_json" | jq -r '.label // .name')"
+    program="\$(echo "\$agent_json" | jq -r '.program // "claude-code"')"
+    model="\$(echo "\$agent_json" | jq -r '.model // "null"')"
+    workdir="\$(echo "\$agent_json" | jq -r '.workingDirectory // ""')"
+    args="\$(echo "\$agent_json" | jq -r '.programArgs // ""')"
+    desc="\$(echo "\$agent_json" | jq -r '.taskDescription // ""')"
+    owner="\$(echo "\$agent_json" | jq -r --arg default_owner "\${MYRMIDONS_DEFAULT_OWNER:-\$(whoami)}" '.owner // \$default_owner')"
+    role="\$(echo "\$agent_json" | jq -r '.role // "member"')"
+    status="\$(echo "\$agent_json" | jq -r '.status // "offline"')"
+    deployment_type="\$(echo "\$agent_json" | jq -r '.deployment.type // "local"')"
+
+    local desired_state="hibernated"
+    if [[ "\$status" == "active" || "\$status" == "online" ]]; then
+        desired_state="active"
+    fi
+
+    local tags_yaml
+    tags_yaml="\$(echo "\$agent_json" | jq -r '.tags // [] | if length == 0 then "  tags: []" else "  tags:\n" + (map("    - " + .) | join("\n")) end')"
+
+    local label_lower
+    label_lower="\$(label_to_stem "\$label")"
+    local outfile="\${OUTPUT_DIR}/\${label_lower}.yaml"
+
+    local model_yaml
+    if [[ "\$model" == "null" || -z "\$model" ]]; then
+        model_yaml="null"
+    else
+        model_yaml='"\$model"'
+    fi
+
+    local docker_image
+    docker_image="\$(program_to_image "\$program")"
+
+    local name_yaml label_yaml program_yaml workdir_yaml owner_yaml role_yaml
+    name_yaml="\$(echo "\$name" | jq -Rr '.')"
+    label_yaml="\$(echo "\$label" | jq -Rr '.')"
+    program_yaml="\$(echo "\$program" | jq -Rr '.')"
+    workdir_yaml="\$(echo "\$workdir" | jq -Rr '.')"
+    owner_yaml="\$(echo "\$owner" | jq -Rr '.')"
+    role_yaml="\$(echo "\$role" | jq -Rr '.')"
+
+    local args_escaped desc_escaped
+    args_escaped="\$(echo "\$args" | jq -Rr '.')"
+    desc_escaped="\$(echo "\$desc" | jq -Rr '.')"
+
+    cat > "\$outfile" <<YAML
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: \${name_yaml}
+  host: \${HOST}
+spec:
+  label: \${label_yaml}
+  program: \${program_yaml}
+  model: \${model_yaml}
+  workingDirectory: \${workdir_yaml}
+  programArgs: "\${args_escaped}"
+  taskDescription: "\${desc_escaped}"
+\${tags_yaml}
+  owner: \${owner_yaml}
+  role: \${role_yaml}
+  deployment:
+    type: \${deployment_type}
+    docker:
+      image: \${docker_image}
+      cpus: 2
+      memory: 4g
+  desiredState: \${desired_state}
+YAML
+}
+
+main() {
+    check_jq
+    agamemnon_check_connection
+    mkdir -p "\${OUTPUT_DIR}"
+
+    local effective_owner="\${MYRMIDONS_DEFAULT_OWNER:-\$(whoami)}"
+    export MYRMIDONS_DEFAULT_OWNER="\$effective_owner"
+
+    local agents_json
+    agents_json="\$(agamemnon_list_agents)"
+    local count
+    count="\$(echo "\$agents_json" | jq 'length')"
+    if [[ "\$count" -eq 0 ]]; then echo "No agents found."; exit 0; fi
+
+    echo "\$agents_json" | jq -c '.[]' | while IFS= read -r agent; do
+        export_agent "\$agent"
+    done
+}
+
+main "\$@"
+WRAPPER
+    chmod +x "$wrapper"
+    run "$wrapper"
+    _stop_mock_server
+}
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+@test "export.sh: whoami called at most once when MYRMIDONS_DEFAULT_OWNER unset and multiple agents exported" {
+    local agent1 agent2 agent3 mock_body
+    agent1="$(_agent_json_null_owner "agent-one" "AgentOne")"
+    agent2="$(_agent_json_null_owner "agent-two" "AgentTwo")"
+    agent3="$(_agent_json_null_owner "agent-three" "AgentThree")"
+    mock_body="$(echo "[$agent1,$agent2,$agent3]")"
+
+    unset MYRMIDONS_DEFAULT_OWNER
+    _run_export_with_mock_whoami "$mock_body"
+
+    [[ "$status" -eq 0 ]]
+
+    local call_count=0
+    if [[ -f "$WHOAMI_CALL_COUNT_FILE" ]]; then
+        call_count="$(wc -l < "$WHOAMI_CALL_COUNT_FILE")"
+    fi
+    # whoami should be called at most once (resolved once in main(), not per-agent)
+    [[ "$call_count" -le 1 ]]
+}
+
+@test "export.sh: whoami not called when MYRMIDONS_DEFAULT_OWNER is pre-set" {
+    local agent1 agent2 mock_body
+    agent1="$(_agent_json_null_owner "agent-alpha" "AgentAlpha")"
+    agent2="$(_agent_json_null_owner "agent-beta" "AgentBeta")"
+    mock_body="$(echo "[$agent1,$agent2]")"
+
+    export MYRMIDONS_DEFAULT_OWNER="presetuser"
+    _run_export_with_mock_whoami "$mock_body"
+
+    [[ "$status" -eq 0 ]]
+
+    local call_count=0
+    if [[ -f "$WHOAMI_CALL_COUNT_FILE" ]]; then
+        call_count="$(wc -l < "$WHOAMI_CALL_COUNT_FILE")"
+    fi
+    # whoami must not be called at all when the variable is already set
+    [[ "$call_count" -eq 0 ]]
+}
+
+@test "export.sh: fallback owner written to spec.owner when API returns null owner" {
+    local agent1 mock_body
+    agent1="$(_agent_json_null_owner "null-owner-agent" "NullOwnerAgent")"
+    mock_body="$(echo "[$agent1]")"
+
+    unset MYRMIDONS_DEFAULT_OWNER
+    _run_export_with_mock_whoami "$mock_body"
+
+    [[ "$status" -eq 0 ]]
+
+    local outfile="${TEMP_DIR}/agents/hermes/nullowneragent.yaml"
+    [[ -f "$outfile" ]]
+
+    local owner_val
+    owner_val="$(yq eval '.spec.owner' "$outfile")"
+    # The fallback should be "mockuser" (from our mock whoami)
+    [[ "$owner_val" == "mockuser" ]]
+}

--- a/tools/reconciler/tests/unit/test_export_no_env_leak.bats
+++ b/tools/reconciler/tests/unit/test_export_no_env_leak.bats
@@ -1,0 +1,115 @@
+#!/usr/bin/env bats
+# tests/unit/test_export_no_env_leak.bats — guard against MYRMIDONS_DEFAULT_OWNER
+# leaking into the parent shell environment after export.sh runs.
+#
+# Issue #526 (follow-up from #404): The previous fix added
+# `export MYRMIDONS_DEFAULT_OWNER=...` inside main(), which leaked the
+# variable into the parent shell's environment when export.sh was `source`d.
+# The fix scopes the value to a function-local shell variable — visible to
+# subshells of main() (the piped `while` loop), but invisible to the parent
+# shell after export.sh returns.
+#
+# Note: export.sh calls `exit 0` when the API returns zero agents, which
+# would terminate the sourcing shell normally. We use an `EXIT` trap so we
+# can still observe the post-source environment state.
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+HELPERS_DIR="${SCRIPT_DIR}/tests/helpers"
+
+MOCK_PORT=18091
+MOCK_PID_FILE=""
+TEMP_DIR=""
+
+_start_mock_server() {
+    local http_status="${1:-200}"
+    local body="${2:-[]}"
+
+    MOCK_PID_FILE="${TEMP_DIR}/mock.pid"
+    MOCK_STATUS="$http_status" MOCK_BODY="$body" \
+        python3 "${HELPERS_DIR}/mock_server.py" "$MOCK_PORT" \
+        > /dev/null 2>&1 &
+    echo $! > "$MOCK_PID_FILE"
+    sleep 0.2
+}
+
+_stop_mock_server() {
+    if [[ -n "$MOCK_PID_FILE" && -f "$MOCK_PID_FILE" ]]; then
+        kill "$(cat "$MOCK_PID_FILE")" 2>/dev/null || true
+        rm -f "$MOCK_PID_FILE"
+    fi
+}
+
+setup() {
+    TEMP_DIR="$(mktemp -d)"
+    unset MYRMIDONS_DEFAULT_OWNER
+}
+
+teardown() {
+    _stop_mock_server
+    [[ -n "$TEMP_DIR" ]] && rm -rf "$TEMP_DIR"
+}
+
+_make_mock_whoami() {
+    mkdir -p "${TEMP_DIR}/mocks"
+    cat > "${TEMP_DIR}/mocks/whoami" <<'EOF'
+#!/usr/bin/env bash
+echo "mockuser"
+EOF
+    chmod +x "${TEMP_DIR}/mocks/whoami"
+}
+
+@test "export.sh: MYRMIDONS_DEFAULT_OWNER does not leak into parent shell after sourcing" {
+    _make_mock_whoami
+    _start_mock_server 200 "[]"
+
+    local result_file="${TEMP_DIR}/result"
+    local probe="${TEMP_DIR}/probe.sh"
+    cat > "$probe" <<PROBE
+#!/usr/bin/env bash
+unset MYRMIDONS_DEFAULT_OWNER
+trap '
+if [[ -n \${MYRMIDONS_DEFAULT_OWNER+set} ]]; then
+    echo "LEAK:\${MYRMIDONS_DEFAULT_OWNER}" > "${result_file}"
+else
+    echo OK > "${result_file}"
+fi
+' EXIT
+source "${SCRIPT_DIR}/scripts/export.sh" hermes >/dev/null 2>&1
+PROBE
+    chmod +x "$probe"
+
+    PATH="${TEMP_DIR}/mocks:${PATH}" AGAMEMNON_URL="http://127.0.0.1:${MOCK_PORT}" \
+        bash "$probe" || true
+    _stop_mock_server
+
+    local result=""
+    [[ -f "$result_file" ]] && result="$(cat "$result_file")"
+    echo "result=$result"
+    [[ "$result" == "OK" ]]
+}
+
+@test "export.sh: parent's pre-set MYRMIDONS_DEFAULT_OWNER is preserved after sourcing" {
+    _make_mock_whoami
+    _start_mock_server 200 "[]"
+
+    local result_file="${TEMP_DIR}/result"
+    local probe="${TEMP_DIR}/probe.sh"
+    cat > "$probe" <<PROBE
+#!/usr/bin/env bash
+export MYRMIDONS_DEFAULT_OWNER="caller-owner"
+trap '
+echo "AFTER:\${MYRMIDONS_DEFAULT_OWNER:-unset}" > "${result_file}"
+' EXIT
+source "${SCRIPT_DIR}/scripts/export.sh" hermes >/dev/null 2>&1
+PROBE
+    chmod +x "$probe"
+
+    PATH="${TEMP_DIR}/mocks:${PATH}" AGAMEMNON_URL="http://127.0.0.1:${MOCK_PORT}" \
+        bash "$probe" || true
+    _stop_mock_server
+
+    local result=""
+    [[ -f "$result_file" ]] && result="$(cat "$result_file")"
+    echo "result=$result"
+    [[ "$result" == "AFTER:caller-owner" ]]
+}

--- a/tools/reconciler/tests/unit/test_export_status.bats
+++ b/tools/reconciler/tests/unit/test_export_status.bats
@@ -1,0 +1,671 @@
+#!/usr/bin/env bats
+# tests/unit/test_export_status.bats — test coverage for export.sh and status.sh
+#
+# Issue #191: Add bats tests for export.sh (YAML generation) and status.sh (table output).
+#
+# export.sh tests:
+#   - Given a mock Agamemnon response, verify YAML files are written with the
+#     correct structure (apiVersion, metadata.name, spec.label, etc.)
+#   - Verify filename is derived from label (lowercased)
+#   - Verify desiredState mapping: active/online → active, else → hibernated
+#   - Verify model null handling
+#   - Verify empty agent list produces no files
+#
+# status.sh tests:
+#   - Header row is printed for text output
+#   - Agent appearing in table with correct DESIRED/ACTUAL columns
+#   - MISSING agent shown when not in Agamemnon
+#   - Drift detected and displayed in table
+#   - --output json produces valid JSON
+#
+# Uses mock_server.py for HTTP and temporary agents directory.
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+HELPERS_DIR="${SCRIPT_DIR}/tests/helpers"
+
+MOCK_PORT=18083
+MOCK_PID_FILE=""
+TEMP_DIR=""
+
+# ── Mock server helpers ───────────────────────────────────────────────────────
+
+_start_mock_server() {
+    local http_status="${1:-200}"
+    local body="${2}"
+    [[ -z "$body" ]] && body='[]'
+
+    MOCK_PID_FILE="${TEMP_DIR}/mock.pid"
+    MOCK_STATUS="$http_status" MOCK_BODY="$body" \
+        python3 "${HELPERS_DIR}/mock_server.py" "$MOCK_PORT" \
+        > /dev/null 2>&1 &
+    echo $! > "$MOCK_PID_FILE"
+    sleep 0.2
+}
+
+_stop_mock_server() {
+    if [[ -n "$MOCK_PID_FILE" && -f "$MOCK_PID_FILE" ]]; then
+        kill "$(cat "$MOCK_PID_FILE")" 2>/dev/null || true
+        rm -f "$MOCK_PID_FILE"
+    fi
+}
+
+# ── setup / teardown ─────────────────────────────────────────────────────────
+
+setup() {
+    TEMP_DIR="$(mktemp -d)"
+    export AGAMEMNON_URL="http://127.0.0.1:${MOCK_PORT}"
+}
+
+teardown() {
+    _stop_mock_server
+    [[ -n "$TEMP_DIR" ]] && rm -rf "$TEMP_DIR"
+}
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+# Build a minimal agent JSON for use with the mock server
+_agent_json() {
+    local name="${1:-myagent}"
+    local label="${2:-MyAgent}"
+    local program="${3:-claude-code}"
+    local status="${4:-active}"
+    local workdir="${5:-/tmp}"
+    local owner="${6:-mvillmow}"
+    local role="${7:-member}"
+    jq -n \
+        --arg id     "id-${name}" \
+        --arg name   "$name" \
+        --arg lbl    "$label" \
+        --arg prog   "$program" \
+        --arg status "$status" \
+        --arg wd     "$workdir" \
+        --arg owner  "$owner" \
+        --arg role   "$role" \
+        '{
+            id: $id,
+            name: $name,
+            label: $lbl,
+            program: $prog,
+            status: $status,
+            workingDirectory: $wd,
+            programArgs: "",
+            taskDescription: "Test agent",
+            tags: [],
+            model: null,
+            owner: $owner,
+            role: $role,
+            deployment: {type: "local"}
+        }'
+}
+
+# Create a minimal agent YAML file in TEMP_DIR/agents/<host>/
+_make_agent_yaml() {
+    local host="${1:-hermes}"
+    local name="${2:-test-status-agent}"
+    local label="${3:-TestStatus}"
+    local desired="${4:-active}"
+    local program="${5:-claude-code}"
+    local workdir="${6:-/tmp}"
+    local owner="${7:-mvillmow}"
+    local role="${8:-member}"
+
+    mkdir -p "${TEMP_DIR}/agents/${host}"
+    local filename
+    filename="$(echo "$label" | tr '[:upper:]' '[:lower:]' | tr ' ' '-').yaml"
+    cat > "${TEMP_DIR}/agents/${host}/${filename}" <<YAML
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: ${name}
+  host: ${host}
+spec:
+  label: ${label}
+  program: ${program}
+  workingDirectory: ${workdir}
+  programArgs: ""
+  taskDescription: "Test agent"
+  tags: []
+  owner: ${owner}
+  role: ${role}
+  deployment:
+    type: local
+  desiredState: ${desired}
+YAML
+    echo "${TEMP_DIR}/agents/${host}/${filename}"
+}
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# export.sh tests
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Helper: run export.sh with a mock Agamemnon response and a given host,
+# writing output into TEMP_DIR. Returns the output dir.
+_run_export() {
+    local host="${1:-hermes}"
+    local mock_body="$2"
+
+    _start_mock_server 200 "$mock_body"
+
+    # export.sh writes to REPO_ROOT/agents/<host>/, which is determined at
+    # runtime via BASH_SOURCE. We wrap it by running export.sh with a
+    # custom REPO_ROOT baked via a wrapper script.
+    local wrapper="${TEMP_DIR}/export_wrapper.sh"
+    cat > "$wrapper" <<WRAPPER
+#!/usr/bin/env bash
+set -euo pipefail
+export AGAMEMNON_URL="http://127.0.0.1:${MOCK_PORT}"
+
+SCRIPT_DIR_REAL="${SCRIPT_DIR}"
+TEMP_DIR_REAL="${TEMP_DIR}"
+HOST_ARG="${host}"
+
+source "\${SCRIPT_DIR_REAL}/scripts/lib/log.sh"
+source "\${SCRIPT_DIR_REAL}/scripts/lib/api.sh"
+
+HOST="\${HOST_ARG}"
+OUTPUT_DIR="\${TEMP_DIR_REAL}/agents/\${HOST}"
+
+check_jq() {
+    command -v jq &>/dev/null
+}
+
+program_to_image() {
+    local prog="\$1"
+    case "\$prog" in
+        claude-code|claude) echo "achaean-claude:latest" ;;
+        aider)              echo "achaean-aider:latest" ;;
+        *)                  echo "achaean-worker:latest" ;;
+    esac
+}
+
+agent_filename() {
+    local name="\$1"
+    echo "\${name}" | tr '[:upper:]' '[:lower:]' | tr ' ' '-'
+}
+
+export_agent() {
+    local agent_json="\$1"
+    local name label program model workdir args desc owner role status deployment_type
+    name="\$(echo "\$agent_json" | jq -r '.name')"
+    label="\$(echo "\$agent_json" | jq -r '.label // .name')"
+    program="\$(echo "\$agent_json" | jq -r '.program // "claude-code"')"
+    model="\$(echo "\$agent_json" | jq -r '.model // "null"')"
+    workdir="\$(echo "\$agent_json" | jq -r '.workingDirectory // ""')"
+    args="\$(echo "\$agent_json" | jq -r '.programArgs // ""')"
+    desc="\$(echo "\$agent_json" | jq -r '.taskDescription // ""')"
+    owner="\$(echo "\$agent_json" | jq -r '.owner // "mvillmow"')"
+    role="\$(echo "\$agent_json" | jq -r '.role // "member"')"
+    status="\$(echo "\$agent_json" | jq -r '.status // "offline"')"
+    deployment_type="\$(echo "\$agent_json" | jq -r '.deployment.type // "local"')"
+
+    local desired_state="hibernated"
+    if [[ "\$status" == "active" || "\$status" == "online" ]]; then
+        desired_state="active"
+    fi
+
+    local tags_yaml
+    tags_yaml="\$(echo "\$agent_json" | jq -r '.tags // [] | if length == 0 then "  tags: []" else "  tags:\n" + (map("    - " + .) | join("\n")) end')"
+
+    local label_lower
+    label_lower="\$(echo "\$label" | tr '[:upper:]' '[:lower:]' | tr ' ' '-')"
+    local outfile="\${OUTPUT_DIR}/\${label_lower}.yaml"
+
+    local model_yaml
+    if [[ "\$model" == "null" || -z "\$model" ]]; then
+        model_yaml="null"
+    else
+        model_yaml='"\$model"'
+    fi
+
+    local docker_image
+    docker_image="\$(program_to_image "\$program")"
+
+    local name_yaml label_yaml program_yaml workdir_yaml owner_yaml role_yaml
+    name_yaml="\$(echo "\$name" | jq -Rr '.')"
+    label_yaml="\$(echo "\$label" | jq -Rr '.')"
+    program_yaml="\$(echo "\$program" | jq -Rr '.')"
+    workdir_yaml="\$(echo "\$workdir" | jq -Rr '.')"
+    owner_yaml="\$(echo "\$owner" | jq -Rr '.')"
+    role_yaml="\$(echo "\$role" | jq -Rr '.')"
+
+    local args_escaped desc_escaped
+    args_escaped="\$(echo "\$args" | jq -Rr '.')"
+    desc_escaped="\$(echo "\$desc" | jq -Rr '.')"
+
+    cat > "\$outfile" <<YAML
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: \${name_yaml}
+  host: \${HOST}
+spec:
+  label: \${label_yaml}
+  program: \${program_yaml}
+  model: \${model_yaml}
+  workingDirectory: \${workdir_yaml}
+  programArgs: "\${args_escaped}"
+  taskDescription: "\${desc_escaped}"
+\${tags_yaml}
+  owner: \${owner_yaml}
+  role: \${role_yaml}
+  deployment:
+    type: \${deployment_type}
+    docker:
+      image: \${docker_image}
+      cpus: 2
+      memory: 4g
+  desiredState: \${desired_state}
+YAML
+    echo "  \${outfile}"
+}
+
+main() {
+    check_jq
+    agamemnon_check_connection
+    mkdir -p "\${OUTPUT_DIR}"
+
+    local agents_json
+    agents_json="\$(agamemnon_list_agents)"
+    local count
+    count="\$(echo "\$agents_json" | jq 'length')"
+    if [[ "\$count" -eq 0 ]]; then echo "No agents found."; exit 0; fi
+
+    echo "\$agents_json" | jq -c '.[]' | while IFS= read -r agent; do
+        export_agent "\$agent"
+    done
+}
+
+main "\$@"
+WRAPPER
+    chmod +x "$wrapper"
+    run "$wrapper"
+    _stop_mock_server
+}
+
+# ── export.sh: empty list ─────────────────────────────────────────────────────
+
+@test "export.sh: exits 0 when Agamemnon returns empty agent list" {
+    _run_export hermes '[]'
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"No agents found"* ]]
+}
+
+@test "export.sh: produces no YAML files when agent list is empty" {
+    _run_export hermes '[]'
+    local count
+    count="$(find "${TEMP_DIR}/agents" -name "*.yaml" 2>/dev/null | wc -l)"
+    [[ "$count" -eq 0 ]]
+}
+
+# ── export.sh: YAML content ───────────────────────────────────────────────────
+
+@test "export.sh: creates YAML file with correct apiVersion" {
+    local mock_body
+    mock_body="$(_agent_json "my-agent" "MyAgent" "claude-code" "active" "/tmp" "mvillmow" "member" | jq -c '[.]')"
+    _run_export hermes "$mock_body"
+    [[ "$status" -eq 0 ]]
+
+    local outfile="${TEMP_DIR}/agents/hermes/myagent.yaml"
+    [[ -f "$outfile" ]]
+    grep -q "apiVersion: myrmidons/v1" "$outfile"
+}
+
+@test "export.sh: filename is derived from label (lowercased)" {
+    local mock_body
+    mock_body="$(_agent_json "backend-worker" "BackendWorker" "claude-code" "active" "/tmp" "mvillmow" "member" | jq -c '[.]')"
+    _run_export hermes "$mock_body"
+
+    # Filename should be backendworker.yaml (label lowercased, no space)
+    [[ -f "${TEMP_DIR}/agents/hermes/backendworker.yaml" ]]
+}
+
+@test "export.sh: metadata.name matches agent name from API" {
+    local mock_body
+    mock_body="$(_agent_json "odyssey-analysis" "Odyssey" "claude-code" "active" "/tmp" "mvillmow" "member" | jq -c '[.]')"
+    _run_export hermes "$mock_body"
+
+    local outfile="${TEMP_DIR}/agents/hermes/odyssey.yaml"
+    [[ -f "$outfile" ]]
+    local name_val
+    name_val="$(yq eval '.metadata.name' "$outfile")"
+    [[ "$name_val" == "odyssey-analysis" ]]
+}
+
+@test "export.sh: desiredState=active when status=active" {
+    local mock_body
+    mock_body="$(_agent_json "active-agent" "ActiveAgent" "claude-code" "active" "/tmp" "mvillmow" "member" | jq -c '[.]')"
+    _run_export hermes "$mock_body"
+
+    local outfile="${TEMP_DIR}/agents/hermes/activeagent.yaml"
+    [[ -f "$outfile" ]]
+    local ds
+    ds="$(yq eval '.spec.desiredState' "$outfile")"
+    [[ "$ds" == "active" ]]
+}
+
+@test "export.sh: desiredState=active when status=online" {
+    local mock_body
+    mock_body="$(_agent_json "online-agent" "OnlineAgent" "claude-code" "online" "/tmp" "mvillmow" "member" | jq -c '[.]')"
+    _run_export hermes "$mock_body"
+
+    local outfile="${TEMP_DIR}/agents/hermes/onlineagent.yaml"
+    [[ -f "$outfile" ]]
+    local ds
+    ds="$(yq eval '.spec.desiredState' "$outfile")"
+    [[ "$ds" == "active" ]]
+}
+
+@test "export.sh: desiredState=hibernated when status=offline" {
+    local mock_body
+    mock_body="$(_agent_json "sleeping-agent" "SleepingAgent" "claude-code" "offline" "/tmp" "mvillmow" "member" | jq -c '[.]')"
+    _run_export hermes "$mock_body"
+
+    local outfile="${TEMP_DIR}/agents/hermes/sleepingagent.yaml"
+    [[ -f "$outfile" ]]
+    local ds
+    ds="$(yq eval '.spec.desiredState' "$outfile")"
+    [[ "$ds" == "hibernated" ]]
+}
+
+@test "export.sh: model: null written when API returns null model" {
+    local mock_body
+    mock_body="$(_agent_json "null-model-agent" "NullModelAgent" "claude-code" "active" "/tmp" "mvillmow" "member" | jq -c '[.]')"
+    _run_export hermes "$mock_body"
+
+    local outfile="${TEMP_DIR}/agents/hermes/nullmodelagent.yaml"
+    [[ -f "$outfile" ]]
+    local model_val
+    model_val="$(yq eval '.spec.model' "$outfile")"
+    [[ "$model_val" == "null" ]]
+}
+
+@test "export.sh: spec.program is written correctly" {
+    local mock_body
+    mock_body="$(_agent_json "aider-agent" "AiderAgent" "aider" "active" "/home/user/proj" "mvillmow" "member" | jq -c '[.]')"
+    _run_export hermes "$mock_body"
+
+    local outfile="${TEMP_DIR}/agents/hermes/aideragent.yaml"
+    [[ -f "$outfile" ]]
+    local prog
+    prog="$(yq eval '.spec.program' "$outfile")"
+    [[ "$prog" == "aider" ]]
+}
+
+@test "export.sh: spec.workingDirectory is written correctly" {
+    local mock_body
+    mock_body="$(_agent_json "workdir-agent" "WorkdirAgent" "claude-code" "active" "/home/mvillmow/MyProject" "mvillmow" "member" | jq -c '[.]')"
+    _run_export hermes "$mock_body"
+
+    local outfile="${TEMP_DIR}/agents/hermes/workdiragent.yaml"
+    [[ -f "$outfile" ]]
+    local wd
+    wd="$(yq eval '.spec.workingDirectory' "$outfile")"
+    [[ "$wd" == "/home/mvillmow/MyProject" ]]
+}
+
+@test "export.sh: spec.owner and spec.role are written correctly" {
+    local mock_body
+    mock_body="$(_agent_json "owner-agent" "OwnerAgent" "claude-code" "active" "/tmp" "alice" "admin" | jq -c '[.]')"
+    _run_export hermes "$mock_body"
+
+    local outfile="${TEMP_DIR}/agents/hermes/owneragent.yaml"
+    [[ -f "$outfile" ]]
+    local owner role
+    owner="$(yq eval '.spec.owner' "$outfile")"
+    role="$(yq eval '.spec.role' "$outfile")"
+    [[ "$owner" == "alice" ]]
+    [[ "$role" == "admin" ]]
+}
+
+@test "export.sh: produces valid YAML (parseable by yq)" {
+    local mock_body
+    mock_body="$(_agent_json "valid-yaml-agent" "ValidYamlAgent" "claude-code" "active" "/tmp" "mvillmow" "member" | jq -c '[.]')"
+    _run_export hermes "$mock_body"
+
+    local outfile="${TEMP_DIR}/agents/hermes/validmlagent.yaml"
+    # Even if name doesn't match exactly, some yaml file should exist
+    local found_yaml
+    found_yaml="$(find "${TEMP_DIR}/agents/hermes" -name "*.yaml" 2>/dev/null | head -1)"
+    [[ -n "$found_yaml" ]]
+    # Should parse without error
+    yq eval '.' "$found_yaml" > /dev/null
+}
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# status.sh tests
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Helper: run a wrapper that mimics status.sh's core logic against our temp agents dir
+_run_status() {
+    local mock_body="$1"
+    local extra_args="${2:-}"
+
+    _start_mock_server 200 "$mock_body"
+
+    local wrapper="${TEMP_DIR}/status_wrapper.sh"
+    cat > "$wrapper" <<WRAPPER
+#!/usr/bin/env bash
+set -euo pipefail
+export AGAMEMNON_URL="http://127.0.0.1:${MOCK_PORT}"
+
+SCRIPT_DIR_REAL="${SCRIPT_DIR}"
+TEMP_DIR_REAL="${TEMP_DIR}"
+
+source "\${SCRIPT_DIR_REAL}/scripts/lib/log.sh"
+source "\${SCRIPT_DIR_REAL}/scripts/lib/api.sh"
+source "\${SCRIPT_DIR_REAL}/scripts/lib/reconcile.sh"
+source "\${SCRIPT_DIR_REAL}/scripts/lib/report.sh"
+
+# Override get_agent_files to use our temp agents dir
+get_agent_files() {
+    find "\${TEMP_DIR_REAL}/agents" -name "*.yaml" 2>/dev/null || true
+}
+
+HOST=""
+OUTPUT_FORMAT="text"
+
+parse_args() {
+    while [[ \$# -gt 0 ]]; do
+        case "\$1" in
+            --output) OUTPUT_FORMAT="\$2"; shift 2 ;;
+            -h|--help) exit 0 ;;
+            *) HOST="\$1"; shift ;;
+        esac
+    done
+}
+
+status_agent() {
+    local yaml_file="\$1"
+    local agents_json="\$2"
+
+    local name host desired_state label program workdir args desc tags owner role deploy_type
+    name="\$(yq eval '.metadata.name' "\$yaml_file")"
+    host="\$(yq eval '.metadata.host // "hermes"' "\$yaml_file")"
+    desired_state="\$(yq eval '.spec.desiredState // "active"' "\$yaml_file")"
+    label="\$(yq eval '.spec.label // ""' "\$yaml_file")"
+    program="\$(yq eval '.spec.program // ""' "\$yaml_file")"
+    workdir="\$(yq eval '.spec.workingDirectory // ""' "\$yaml_file")"
+    args="\$(yq eval '.spec.programArgs // ""' "\$yaml_file")"
+    desc="\$(yq eval '.spec.taskDescription // ""' "\$yaml_file")"
+    tags="\$(yq eval '.spec.tags // [] | join(",")' "\$yaml_file")"
+    owner="\$(yq eval '.spec.owner // ""' "\$yaml_file")"
+    role="\$(yq eval '.spec.role // "member"' "\$yaml_file")"
+    deploy_type="\$(yq eval '.spec.deployment.type // "local"' "\$yaml_file")"
+
+    local actual_json
+    actual_json="\$(echo "\$agents_json" | jq -r --arg n "\$name" '.[] | select(.name == \$n)')"
+
+    if [[ -z "\$actual_json" ]]; then
+        printf "%-22s %-10s %-12s %-12s %s\n" \\
+            "\${name:0:21}" "\${host:0:9}" "\$desired_state" "MISSING" "NEEDS CREATE"
+        return
+    fi
+
+    local actual_status
+    actual_status="\$(echo "\$actual_json" | jq -r '.status // "unknown"')"
+
+    local drift
+    drift="\$(compute_drift "\$name" "\$desired_state" "\$actual_json" \\
+        "\$label" "\$program" "\$workdir" "\$args" "\$desc" "\$tags" "" "\$owner" "\$role" "\$deploy_type")"
+
+    local drift_display
+    case "\$drift" in
+        UNCHANGED)  drift_display="ok" ;;
+        WAKE)       drift_display="NEEDS WAKE" ;;
+        HIBERNATE)  drift_display="NEEDS HIBERNATE" ;;
+        UPDATE:*)   drift_display="drifted: \${drift#UPDATE:}" ;;
+        *)          drift_display="\$drift" ;;
+    esac
+
+    printf "%-22s %-10s %-12s %-12s %s\n" \\
+        "\${name:0:21}" "\${host:0:9}" "\$desired_state" "\$actual_status" "\$drift_display"
+}
+
+main() {
+    parse_args \$extra_args "\$@"
+    agamemnon_check_connection
+
+    local agents_json
+    agents_json="\$(agamemnon_list_agents)"
+    local yaml_files
+    mapfile -t yaml_files < <(get_agent_files)
+
+    if [[ "\$OUTPUT_FORMAT" != "json" ]]; then
+        printf "%-22s %-10s %-12s %-12s %s\n" "AGENT" "HOST" "DESIRED" "ACTUAL" "DRIFT"
+        printf "%-22s %-10s %-12s %-12s %s\n" "-----" "----" "-------" "------" "-----"
+    fi
+
+    if [[ "\${#yaml_files[@]}" -gt 0 ]]; then
+        for yaml_file in "\${yaml_files[@]}"; do
+            status_agent "\$yaml_file" "\$agents_json"
+        done
+    fi
+}
+
+extra_args="${extra_args}"
+main
+WRAPPER
+    chmod +x "$wrapper"
+    run "$wrapper"
+    _stop_mock_server
+}
+
+# ── status.sh: table header ───────────────────────────────────────────────────
+
+@test "status.sh: prints header row with AGENT, HOST, DESIRED, ACTUAL, DRIFT" {
+    _run_status '[]'
+    [[ "$output" == *"AGENT"* ]]
+    [[ "$output" == *"HOST"* ]]
+    [[ "$output" == *"DESIRED"* ]]
+    [[ "$output" == *"ACTUAL"* ]]
+    [[ "$output" == *"DRIFT"* ]]
+}
+
+# ── status.sh: agent present and UNCHANGED ────────────────────────────────────
+
+@test "status.sh: shows 'ok' drift for UNCHANGED agent" {
+    _make_agent_yaml hermes "status-agent" "StatusAgent" active claude-code /tmp mvillmow member
+
+    # owner/role in actual must match the YAML values so compute_drift returns UNCHANGED.
+    local mock_body
+    mock_body='[{"id":"id-001","name":"status-agent","status":"active","label":"StatusAgent","program":"claude-code","workingDirectory":"/tmp","programArgs":"","taskDescription":"Test agent","tags":[],"owner":"mvillmow","role":"member"}]'
+    _run_status "$mock_body"
+
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"ok"* ]]
+}
+
+@test "status.sh: shows agent name in table output" {
+    _make_agent_yaml hermes "my-status-agent" "MyStatusAgent" active claude-code /tmp mvillmow member
+
+    local mock_body
+    mock_body='[{"id":"id-001","name":"my-status-agent","status":"active","label":"MyStatusAgent","program":"claude-code","workingDirectory":"/tmp","programArgs":"","taskDescription":"Test agent","tags":[],"owner":"mvillmow","role":"member"}]'
+    _run_status "$mock_body"
+
+    [[ "$output" == *"my-status-agent"* ]]
+}
+
+@test "status.sh: shows desired state in table output" {
+    _make_agent_yaml hermes "ds-agent" "DsAgent" hibernated claude-code /tmp mvillmow member
+
+    local mock_body
+    mock_body='[{"id":"id-001","name":"ds-agent","status":"offline","label":"DsAgent","program":"claude-code","workingDirectory":"/tmp","programArgs":"","taskDescription":"Test agent","tags":[],"owner":"mvillmow","role":"member"}]'
+    _run_status "$mock_body"
+
+    [[ "$output" == *"hibernated"* ]]
+}
+
+@test "status.sh: shows actual status in table output" {
+    _make_agent_yaml hermes "actual-agent" "ActualAgent" active claude-code /tmp mvillmow member
+
+    local mock_body
+    mock_body='[{"id":"id-001","name":"actual-agent","status":"online","label":"ActualAgent","program":"claude-code","workingDirectory":"/tmp","programArgs":"","taskDescription":"Test agent","tags":[],"owner":"mvillmow","role":"member"}]'
+    _run_status "$mock_body"
+
+    [[ "$output" == *"online"* ]]
+}
+
+# ── status.sh: MISSING agent ──────────────────────────────────────────────────
+
+@test "status.sh: shows MISSING and NEEDS CREATE when agent not in Agamemnon" {
+    _make_agent_yaml hermes "ghost-agent" "GhostAgent" active claude-code /tmp mvillmow member
+
+    # Agamemnon returns empty list → agent is missing
+    _run_status '[]'
+
+    [[ "$output" == *"MISSING"* ]]
+    [[ "$output" == *"NEEDS CREATE"* ]]
+}
+
+# ── status.sh: drift detection ────────────────────────────────────────────────
+
+@test "status.sh: shows 'NEEDS WAKE' when desired=active but agent is offline" {
+    _make_agent_yaml hermes "wake-agent" "WakeAgent" active claude-code /tmp mvillmow member
+
+    local mock_body
+    mock_body='[{"id":"id-001","name":"wake-agent","status":"offline","label":"WakeAgent","program":"claude-code","workingDirectory":"/tmp","programArgs":"","taskDescription":"Test agent","tags":[],"owner":"mvillmow","role":"member"}]'
+    _run_status "$mock_body"
+
+    [[ "$output" == *"NEEDS WAKE"* ]]
+}
+
+@test "status.sh: shows 'NEEDS HIBERNATE' when desired=hibernated but agent is active" {
+    _make_agent_yaml hermes "hibernate-agent" "HibernateAgent" hibernated claude-code /tmp mvillmow member
+
+    local mock_body
+    mock_body='[{"id":"id-001","name":"hibernate-agent","status":"active","label":"HibernateAgent","program":"claude-code","workingDirectory":"/tmp","programArgs":"","taskDescription":"Test agent","tags":[],"owner":"mvillmow","role":"member"}]'
+    _run_status "$mock_body"
+
+    [[ "$output" == *"NEEDS HIBERNATE"* ]]
+}
+
+@test "status.sh: shows 'drifted:' when field-level drift detected" {
+    _make_agent_yaml hermes "drift-agent" "DriftAgent" active aider /tmp mvillmow member
+
+    # Actual has claude-code but desired is aider
+    local mock_body
+    mock_body='[{"id":"id-001","name":"drift-agent","status":"active","label":"DriftAgent","program":"claude-code","workingDirectory":"/tmp","programArgs":"","taskDescription":"Test agent","tags":[],"owner":"mvillmow","role":"member"}]'
+    _run_status "$mock_body"
+
+    [[ "$output" == *"drifted:"* ]]
+    [[ "$output" == *"program"* ]]
+}
+
+# ── status.sh: no YAML files ──────────────────────────────────────────────────
+
+@test "status.sh: exits 0 with just header when no agent YAML files exist" {
+    # No YAML files created — only header should appear
+    _run_status '[]'
+
+    [[ "$status" -eq 0 ]]
+    # Header must be present
+    [[ "$output" == *"AGENT"* ]]
+}
+
+# ── status.sh: unreachable server ────────────────────────────────────────────
+
+@test "status.sh: exits non-zero when Agamemnon is unreachable" {
+    export AGAMEMNON_URL="http://127.0.0.1:19996"  # nothing listening
+    run "${SCRIPT_DIR}/scripts/status.sh"
+    [[ "$status" -ne 0 ]]
+}

--- a/tools/reconciler/tests/unit/test_failed_agent_arrays.bats
+++ b/tools/reconciler/tests/unit/test_failed_agent_arrays.bats
@@ -1,0 +1,290 @@
+#!/usr/bin/env bats
+# tests/unit/test_failed_agent_arrays.bats — unit tests for unified FAILED_AGENT_NAMES array
+#
+# Verifies that record_failure(), print_error_summary(), and _write_failed_agents_file()
+# all draw from the same FAILED_AGENT_NAMES / FAILED_AGENT_STATUSES / FAILED_AGENT_MESSAGES
+# parallel arrays, so that agents appearing in the summary are also in the retry file.
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+APPLY_SH="${SCRIPT_DIR}/scripts/apply.sh"
+
+# ---------------------------------------------------------------------------
+# Build a minimal harness that sources just the functions under test.
+# ---------------------------------------------------------------------------
+
+_build_harness() {
+    local harness="${BATS_TMPDIR}/fa_harness_$$.sh"
+    cat > "$harness" << 'HARNESS'
+#!/usr/bin/env bash
+set -uo pipefail
+
+ERRORS=0
+FAILED_AGENT_NAMES=()
+FAILED_AGENT_STATUSES=()
+FAILED_AGENT_MESSAGES=()
+RETRY_FILE=""
+FAILED_AGENTS_FILE="/dev/null"
+OUTPUT_FORMAT="text"
+
+log_warn() { echo "WARN: $*" >&2; }
+
+record_failure() {
+    local agent_name="$1"
+    local http_status="$2"
+    local error_message="$3"
+    ERRORS=$((ERRORS + 1))
+    FAILED_AGENT_NAMES+=("$agent_name")
+    FAILED_AGENT_STATUSES+=("$http_status")
+    FAILED_AGENT_MESSAGES+=("$error_message")
+}
+
+print_error_summary() {
+    echo ""
+    echo "================================================"
+    echo "FAILED AGENTS (${ERRORS}):"
+    echo ""
+    local i
+    for i in "${!FAILED_AGENT_NAMES[@]}"; do
+        local agent_name="${FAILED_AGENT_NAMES[$i]}"
+        local http_status="${FAILED_AGENT_STATUSES[$i]}"
+        local error_msg="${FAILED_AGENT_MESSAGES[$i]}"
+        echo "  [FAIL] ${agent_name}"
+        if [[ -n "$http_status" ]]; then
+            echo "         HTTP status: ${http_status}"
+        fi
+        if [[ -n "$error_msg" ]]; then
+            echo "         Error: ${error_msg}"
+        fi
+    done
+    echo ""
+    echo "Failed agents written to: ${FAILED_AGENTS_FILE}"
+}
+
+_write_failed_agents_file() {
+    local failed_file="${RETRY_FILE:-failed-agents.txt}"
+    if [[ ${#FAILED_AGENT_NAMES[@]} -gt 0 ]]; then
+        : > "$failed_file"
+        for agent_name in "${FAILED_AGENT_NAMES[@]}"; do
+            echo "$agent_name" >> "$failed_file"
+        done
+        log_warn "Wrote ${#FAILED_AGENT_NAMES[@]} failed agent(s) to ${failed_file}"
+    fi
+}
+HARNESS
+    echo "$harness"
+}
+
+# ---------------------------------------------------------------------------
+# Tests: record_failure populates all three parallel arrays
+# ---------------------------------------------------------------------------
+
+@test "record_failure: populates FAILED_AGENT_NAMES" {
+    local harness
+    harness="$(_build_harness)"
+
+    run bash -c "
+        source '${harness}'
+        record_failure 'agent-alpha' '500' 'internal error'
+        echo \"\${FAILED_AGENT_NAMES[0]}\"
+    "
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == "agent-alpha" ]]
+    rm -f "$harness"
+}
+
+@test "record_failure: populates FAILED_AGENT_STATUSES" {
+    local harness
+    harness="$(_build_harness)"
+
+    run bash -c "
+        source '${harness}'
+        record_failure 'agent-alpha' '500' 'internal error'
+        echo \"\${FAILED_AGENT_STATUSES[0]}\"
+    "
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == "500" ]]
+    rm -f "$harness"
+}
+
+@test "record_failure: populates FAILED_AGENT_MESSAGES" {
+    local harness
+    harness="$(_build_harness)"
+
+    run bash -c "
+        source '${harness}'
+        record_failure 'agent-alpha' '500' 'internal error'
+        echo \"\${FAILED_AGENT_MESSAGES[0]}\"
+    "
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == "internal error" ]]
+    rm -f "$harness"
+}
+
+@test "record_failure: increments ERRORS counter" {
+    local harness
+    harness="$(_build_harness)"
+
+    run bash -c "
+        source '${harness}'
+        record_failure 'a' '404' 'not found'
+        record_failure 'b' '503' 'unavailable'
+        echo \"\$ERRORS\"
+    "
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == "2" ]]
+    rm -f "$harness"
+}
+
+@test "record_failure: multiple calls append to arrays in order" {
+    local harness
+    harness="$(_build_harness)"
+
+    run bash -c "
+        source '${harness}'
+        record_failure 'agent-one' '500' 'err-one'
+        record_failure 'agent-two' '503' 'err-two'
+        echo \"\${FAILED_AGENT_NAMES[0]} \${FAILED_AGENT_NAMES[1]}\"
+    "
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == "agent-one agent-two" ]]
+    rm -f "$harness"
+}
+
+# ---------------------------------------------------------------------------
+# Tests: _write_failed_agents_file uses FAILED_AGENT_NAMES
+# ---------------------------------------------------------------------------
+
+@test "_write_failed_agents_file: writes each name from FAILED_AGENT_NAMES" {
+    local harness
+    harness="$(_build_harness)"
+    local out_file="${BATS_TMPDIR}/retry_$$.txt"
+
+    run bash -c "
+        source '${harness}'
+        record_failure 'alpha' '500' 'err'
+        record_failure 'beta'  '503' 'err'
+        RETRY_FILE='${out_file}'
+        _write_failed_agents_file
+        cat '${out_file}'
+    "
+    [[ "$status" -eq 0 ]]
+    grep -q "alpha" <(echo "$output")
+    grep -q "beta"  <(echo "$output")
+    rm -f "$harness" "$out_file"
+}
+
+@test "_write_failed_agents_file: writes exactly the names in FAILED_AGENT_NAMES (no extras)" {
+    local harness
+    harness="$(_build_harness)"
+    local out_file="${BATS_TMPDIR}/retry_exact_$$.txt"
+
+    run bash -c "
+        source '${harness}'
+        record_failure 'only-agent' '400' 'bad request'
+        RETRY_FILE='${out_file}'
+        _write_failed_agents_file 2>/dev/null
+        wc -l < '${out_file}'
+    "
+    [[ "$status" -eq 0 ]]
+    [[ "${output// /}" -eq 1 ]]
+    rm -f "$harness" "$out_file"
+}
+
+@test "_write_failed_agents_file: does not write file when no failures" {
+    local harness
+    harness="$(_build_harness)"
+    local out_file="${BATS_TMPDIR}/retry_empty_$$.txt"
+
+    run bash -c "
+        source '${harness}'
+        RETRY_FILE='${out_file}'
+        _write_failed_agents_file
+        [[ ! -f '${out_file}' ]] && echo 'not created' || echo 'created'
+    "
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == "not created" ]]
+    rm -f "$harness" "$out_file"
+}
+
+# ---------------------------------------------------------------------------
+# Tests: summary and retry file are in sync (no divergence)
+# ---------------------------------------------------------------------------
+
+@test "summary and retry file contain the same agent names" {
+    local harness
+    harness="$(_build_harness)"
+    local out_file="${BATS_TMPDIR}/retry_sync_$$.txt"
+
+    run bash -c "
+        source '${harness}'
+        record_failure 'gamma' '500' 'err-gamma'
+        record_failure 'delta' '502' 'err-delta'
+
+        RETRY_FILE='${out_file}'
+        _write_failed_agents_file 2>/dev/null
+
+        # Extract names from print_error_summary output
+        summary_names=\$(print_error_summary | grep '^\s*\[FAIL\]' | awk '{print \$2}')
+        retry_names=\$(cat '${out_file}')
+
+        # Both sets must be identical (same elements, same order)
+        [[ \"\$summary_names\" == \"\$retry_names\" ]] && echo 'in_sync' || echo 'diverged'
+    "
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == "in_sync" ]]
+    rm -f "$harness" "$out_file"
+}
+
+@test "agent in print_error_summary output also appears in retry file" {
+    local harness
+    harness="$(_build_harness)"
+    local out_file="${BATS_TMPDIR}/retry_present_$$.txt"
+
+    run bash -c "
+        source '${harness}'
+        record_failure 'target-agent' '503' 'timeout'
+
+        RETRY_FILE='${out_file}'
+        _write_failed_agents_file 2>/dev/null
+
+        # Confirm the agent appears in the summary
+        print_error_summary | grep -q 'target-agent' || { echo 'missing_from_summary'; exit 1; }
+
+        # Confirm the agent appears in the retry file
+        grep -q 'target-agent' '${out_file}' || { echo 'missing_from_retry'; exit 1; }
+
+        echo 'both_present'
+    "
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == "both_present" ]]
+    rm -f "$harness" "$out_file"
+}
+
+# ---------------------------------------------------------------------------
+# Static check: FAILED_AGENTS bare array is gone from apply.sh
+# ---------------------------------------------------------------------------
+
+@test "apply.sh: FAILED_AGENTS bare array declaration is absent" {
+    local count
+    count=$(grep -cE '^FAILED_AGENTS=\(\)' "$APPLY_SH" || true)
+    [[ "$count" -eq 0 ]]
+}
+
+@test "apply.sh: no direct FAILED_AGENTS+= appends exist" {
+    local count
+    count=$(grep -cE 'FAILED_AGENTS\+=\(' "$APPLY_SH" || true)
+    [[ "$count" -eq 0 ]]
+}
+
+@test "apply.sh: _write_failed_agents_file iterates FAILED_AGENT_NAMES not FAILED_AGENTS" {
+    # The function body must reference FAILED_AGENT_NAMES, not bare FAILED_AGENTS.
+    # Extract lines inside _write_failed_agents_file and check.
+    local uses_names
+    uses_names=$(grep -c 'FAILED_AGENT_NAMES' "$APPLY_SH" || true)
+    [[ "$uses_names" -gt 0 ]]
+
+    # Bare FAILED_AGENTS (not followed by _) should not appear
+    local bare_count
+    bare_count=$(grep -cE 'FAILED_AGENTS[^_]' "$APPLY_SH" || true)
+    [[ "$bare_count" -eq 0 ]]
+}

--- a/tools/reconciler/tests/unit/test_fleet.bats
+++ b/tools/reconciler/tests/unit/test_fleet.bats
@@ -1,0 +1,321 @@
+#!/usr/bin/env bats
+bats_require_minimum_version 1.5.0
+# tests/unit/test_fleet.bats — unit tests for fleet resolution (scripts/lib/reconcile.sh)
+#
+# Tests cover:
+# - find_fleet_file() for locating fleet YAML files
+# - resolve_fleet_files() for resolving refs and creating inline agent temp files
+# - cleanup_fleet_tmpdir() for temporary file cleanup
+#
+# Issue #208: Add bats tests for resolve_fleet() and fleet resolution logic
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+REPO_ROOT="${SCRIPT_DIR}"
+
+# Source reconcile.sh before each test
+setup() {
+    export AGAMEMNON_URL="http://localhost:19999"
+    # shellcheck source=/dev/null
+    source "${SCRIPT_DIR}/scripts/lib/reconcile.sh"
+}
+
+# Teardown: clean up any FLEET_TMPDIR created during tests
+teardown() {
+    cleanup_fleet_tmpdir
+}
+
+# ---------------------------------------------------------------------------
+# find_fleet_file
+# ---------------------------------------------------------------------------
+
+@test "find_fleet_file: locates production fleet by name" {
+    result="$(find_fleet_file "production")"
+    [[ -f "$result" ]]
+    [[ "$result" == *"production.yaml" ]]
+}
+
+@test "find_fleet_file: locates dev-mesh fleet by name" {
+    result="$(find_fleet_file "dev-mesh")"
+    [[ -f "$result" ]]
+    [[ "$result" == *"dev-mesh.yaml" ]]
+}
+
+@test "find_fleet_file: exits 1 for nonexistent fleet" {
+    ! find_fleet_file "nonexistent-fleet-xyz" 2>/dev/null
+}
+
+@test "find_fleet_file: outputs error message for missing fleet" {
+    result="$(find_fleet_file "nonexistent-fleet-xyz" 2>&1 || true)"
+    [[ "$result" == *"not found"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# resolve_fleet_files: ref resolution
+# ---------------------------------------------------------------------------
+
+@test "resolve_fleet_files: resolves production fleet refs to correct file paths" {
+    fleet_file="${REPO_ROOT}/fleets/production.yaml"
+    result="$(resolve_fleet_files "$fleet_file")"
+
+    # Should output 5 lines (5 refs in production.yaml)
+    line_count="$(echo "$result" | wc -l | tr -d ' ')"
+    [[ "$line_count" == "5" ]]
+
+    # Each output path should exist
+    while IFS= read -r f; do
+        [[ -f "$f" ]]
+    done <<< "$result"
+}
+
+@test "resolve_fleet_files: resolves ref paths to agents/<host>/<name>.yaml format" {
+    fleet_file="${REPO_ROOT}/fleets/production.yaml"
+    result="$(resolve_fleet_files "$fleet_file")"
+
+    # Check that resolved paths contain the expected agent names and agents directory
+    echo "$result" | grep -q "agents/hermes/aindrea.yaml"
+    echo "$result" | grep -q "agents/hermes/raiden.yaml"
+    echo "$result" | grep -q "agents/hermes/baird.yaml"
+    echo "$result" | grep -q "agents/hermes/vegai.yaml"
+    echo "$result" | grep -q "agents/hermes/julia.yaml"
+}
+
+@test "resolve_fleet_files: bad ref path exits 1 with error" {
+    # Create a temp fleet with a bad ref
+    local tmp_fleet
+    tmp_fleet="$(mktemp)"
+    cat > "$tmp_fleet" <<'EOF'
+apiVersion: myrmidons/v1
+kind: Fleet
+metadata:
+  name: bad-refs
+  host: hermes
+spec:
+  agents:
+    - ref: hermes/nonexistent-agent-xyz
+EOF
+
+    result="$(resolve_fleet_files "$tmp_fleet" 2>&1 || true)"
+    run ! resolve_fleet_files "$tmp_fleet" 2>/dev/null
+    [[ "$result" == *"not found"* ]]
+    rm -f "$tmp_fleet"
+}
+
+@test "resolve_fleet_files: missing fleet file produces error" {
+    result=$(resolve_fleet_files "/nonexistent/fleet.yaml" 2>&1 || true)
+    # Should produce an error message about the file not being found
+    [[ "$result" == *"no such file"* ]] || [[ "$result" == *"Error"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# resolve_fleet_files: inline agent handling
+# ---------------------------------------------------------------------------
+
+@test "resolve_fleet_files: creates FLEET_TMPDIR and temp files for inline agents" {
+    fleet_file="${REPO_ROOT}/fleets/dev-mesh.yaml"
+
+    result="$(resolve_fleet_files "$fleet_file")"
+
+    # dev-mesh has 3 refs + 1 inline agent = 4 lines
+    line_count="$(echo "$result" | wc -l | tr -d ' ')"
+    [[ "$line_count" == "4" ]]
+
+    # Find the inline temp file in the result
+    ci_worker_file="$(echo "$result" | grep "ci-worker.yaml")"
+    [[ -f "$ci_worker_file" ]]
+
+    # Verify temp dir exists
+    ci_worker_tmpdir="$(dirname "$ci_worker_file")"
+    [[ -d "$ci_worker_tmpdir" ]]
+}
+
+@test "resolve_fleet_files: inline agent written to FLEET_TMPDIR with correct name" {
+    fleet_file="${REPO_ROOT}/fleets/dev-mesh.yaml"
+    unset FLEET_TMPDIR
+
+    result="$(resolve_fleet_files "$fleet_file")"
+
+    # Find the ci-worker temp file
+    ci_worker_file="$(echo "$result" | grep "ci-worker.yaml")"
+    [[ -f "$ci_worker_file" ]]
+    [[ "$ci_worker_file" == *"ci-worker.yaml" ]]
+}
+
+@test "resolve_fleet_files: inline agent has kind Agent" {
+    fleet_file="${REPO_ROOT}/fleets/dev-mesh.yaml"
+    unset FLEET_TMPDIR
+
+    result="$(resolve_fleet_files "$fleet_file")"
+    ci_worker_file="$(echo "$result" | grep "ci-worker.yaml")"
+
+    kind="$(yq eval '.kind' "$ci_worker_file" 2>/dev/null)"
+    [[ "$kind" == "Agent" ]]
+}
+
+@test "resolve_fleet_files: inline agent has correct metadata.name" {
+    fleet_file="${REPO_ROOT}/fleets/dev-mesh.yaml"
+    unset FLEET_TMPDIR
+
+    result="$(resolve_fleet_files "$fleet_file")"
+    ci_worker_file="$(echo "$result" | grep "ci-worker.yaml")"
+
+    name="$(yq eval '.metadata.name' "$ci_worker_file" 2>/dev/null)"
+    [[ "$name" == "ci-worker" ]]
+}
+
+@test "resolve_fleet_files: inline agent inherits fleet host in metadata" {
+    fleet_file="${REPO_ROOT}/fleets/dev-mesh.yaml"
+    unset FLEET_TMPDIR
+
+    result="$(resolve_fleet_files "$fleet_file")"
+    ci_worker_file="$(echo "$result" | grep "ci-worker.yaml")"
+
+    host="$(yq eval '.metadata.host' "$ci_worker_file" 2>/dev/null)"
+    [[ "$host" == "hermes" ]]
+}
+
+@test "resolve_fleet_files: inline agent has correct spec.program" {
+    fleet_file="${REPO_ROOT}/fleets/dev-mesh.yaml"
+    unset FLEET_TMPDIR
+
+    result="$(resolve_fleet_files "$fleet_file")"
+    ci_worker_file="$(echo "$result" | grep "ci-worker.yaml")"
+
+    program="$(yq eval '.spec.program' "$ci_worker_file" 2>/dev/null)"
+    [[ "$program" == "none" ]]
+}
+
+@test "resolve_fleet_files: inline agent has correct spec.workingDirectory" {
+    fleet_file="${REPO_ROOT}/fleets/dev-mesh.yaml"
+    unset FLEET_TMPDIR
+
+    result="$(resolve_fleet_files "$fleet_file")"
+    ci_worker_file="$(echo "$result" | grep "ci-worker.yaml")"
+
+    workdir="$(yq eval '.spec.workingDirectory' "$ci_worker_file" 2>/dev/null)"
+    [[ "$workdir" == "/tmp/ci" ]]
+}
+
+@test "resolve_fleet_files: inline agent has correct spec.taskDescription" {
+    fleet_file="${REPO_ROOT}/fleets/dev-mesh.yaml"
+    unset FLEET_TMPDIR
+
+    result="$(resolve_fleet_files "$fleet_file")"
+    ci_worker_file="$(echo "$result" | grep "ci-worker.yaml")"
+
+    taskdesc="$(yq eval '.spec.taskDescription' "$ci_worker_file" 2>/dev/null)"
+    [[ "$taskdesc" == "CI shell worker for local dev tasks" ]]
+}
+
+@test "resolve_fleet_files: inline agent has correct spec.deployment.type" {
+    fleet_file="${REPO_ROOT}/fleets/dev-mesh.yaml"
+    unset FLEET_TMPDIR
+
+    result="$(resolve_fleet_files "$fleet_file")"
+    ci_worker_file="$(echo "$result" | grep "ci-worker.yaml")"
+
+    deploy_type="$(yq eval '.spec.deployment.type' "$ci_worker_file" 2>/dev/null)"
+    [[ "$deploy_type" == "docker" ]]
+}
+
+@test "resolve_fleet_files: inline agent preserves docker image config" {
+    fleet_file="${REPO_ROOT}/fleets/dev-mesh.yaml"
+    unset FLEET_TMPDIR
+
+    result="$(resolve_fleet_files "$fleet_file")"
+    ci_worker_file="$(echo "$result" | grep "ci-worker.yaml")"
+
+    image="$(yq eval '.spec.deployment.docker.image' "$ci_worker_file" 2>/dev/null)"
+    [[ "$image" == "achaean-worker:latest" ]]
+}
+
+@test "resolve_fleet_files: inline agent has correct spec.desiredState" {
+    fleet_file="${REPO_ROOT}/fleets/dev-mesh.yaml"
+    unset FLEET_TMPDIR
+
+    result="$(resolve_fleet_files "$fleet_file")"
+    ci_worker_file="$(echo "$result" | grep "ci-worker.yaml")"
+
+    state="$(yq eval '.spec.desiredState' "$ci_worker_file" 2>/dev/null)"
+    [[ "$state" == "active" ]]
+}
+
+# ---------------------------------------------------------------------------
+# cleanup_fleet_tmpdir
+# ---------------------------------------------------------------------------
+
+@test "cleanup_fleet_tmpdir: removes FLEET_TMPDIR when set" {
+    fleet_file="${REPO_ROOT}/fleets/dev-mesh.yaml"
+    unset FLEET_TMPDIR
+
+    # Resolve to create temp dir
+    resolve_fleet_files "$fleet_file" > /dev/null
+
+    # FLEET_TMPDIR should be set
+    [[ -n "${FLEET_TMPDIR:-}" ]]
+    tmp_dir="${FLEET_TMPDIR}"
+    [[ -d "$tmp_dir" ]]
+
+    # Clean up
+    cleanup_fleet_tmpdir
+
+    # Directory should be gone
+    [[ ! -d "$tmp_dir" ]]
+    [[ -z "${FLEET_TMPDIR:-}" ]]
+}
+
+@test "cleanup_fleet_tmpdir: does nothing when FLEET_TMPDIR is unset" {
+    unset FLEET_TMPDIR
+    # Should not error
+    cleanup_fleet_tmpdir
+}
+
+# ---------------------------------------------------------------------------
+# Integration: inline agent without name errors
+# ---------------------------------------------------------------------------
+
+@test "resolve_fleet_files: inline agent without name exits 1 with error" {
+    local tmp_fleet
+    tmp_fleet="$(mktemp)"
+    cat > "$tmp_fleet" <<'EOF'
+apiVersion: myrmidons/v1
+kind: Fleet
+metadata:
+  name: bad-inline
+  host: hermes
+spec:
+  agents:
+    - program: claude-code
+      workingDirectory: /tmp/test
+EOF
+
+    unset FLEET_TMPDIR
+    result="$(resolve_fleet_files "$tmp_fleet" 2>&1 || true)"
+    run ! resolve_fleet_files "$tmp_fleet" 2>/dev/null
+    [[ "$result" == *"no name"* ]]
+    rm -f "$tmp_fleet"
+}
+
+# ---------------------------------------------------------------------------
+# Integration: mixed refs and inline agents
+# ---------------------------------------------------------------------------
+
+@test "resolve_fleet_files: dev-mesh resolves both refs and inline agents correctly" {
+    fleet_file="${REPO_ROOT}/fleets/dev-mesh.yaml"
+
+    result="$(resolve_fleet_files "$fleet_file")"
+
+    # Should have 4 entries (3 refs + 1 inline)
+    line_count="$(echo "$result" | wc -l | tr -d ' ')"
+    [[ "$line_count" == "4" ]]
+
+    # Should contain both ref-resolved files and inline temp files
+    echo "$result" | grep -q "agents/hermes/aindrea.yaml"
+    echo "$result" | grep -q "agents/hermes/baird.yaml"
+    echo "$result" | grep -q "agents/hermes/vegai.yaml"
+    echo "$result" | grep -q "ci-worker.yaml"
+
+    # All files should exist
+    while IFS= read -r f; do
+        [[ -f "$f" ]]
+    done <<< "$result"
+}

--- a/tools/reconciler/tests/unit/test_install_hooks_legacy.bats
+++ b/tools/reconciler/tests/unit/test_install_hooks_legacy.bats
@@ -1,0 +1,78 @@
+#!/usr/bin/env bats
+# tests/unit/test_install_hooks_legacy.bats
+#
+# Issue #421: test coverage for the install-hooks-legacy justfile recipe.
+#
+# Verifies that install-hooks-legacy copies hooks/pre-commit to .git/hooks/pre-commit
+# without invoking `pixi run pre-commit install`.
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+
+TMP_REPO=""
+PIXI_STUB=""
+
+setup() {
+    TMP_REPO="${SCRIPT_DIR}/_install_hooks_legacy_test_$$_${RANDOM}"
+    mkdir -p "$TMP_REPO"
+
+    git -C "$TMP_REPO" init -q
+    git -C "$TMP_REPO" config user.email "test@example.com"
+    git -C "$TMP_REPO" config user.name "Test"
+    git -C "$TMP_REPO" config commit.gpgsign false
+
+    mkdir -p "${TMP_REPO}/hooks"
+    mkdir -p "${TMP_REPO}/.git/hooks"
+    cp "${SCRIPT_DIR}/hooks/pre-commit" "${TMP_REPO}/hooks/pre-commit"
+
+    touch "${TMP_REPO}/.gitkeep"
+    git -C "$TMP_REPO" add .gitkeep
+    git -C "$TMP_REPO" commit -q --no-verify -m "init"
+
+    # Stub that records any invocation of pixi
+    PIXI_STUB="$(mktemp -d)"
+    cat > "${PIXI_STUB}/pixi" <<'SH'
+#!/usr/bin/env bash
+echo "called" >> "${0%/*}/pixi.log"
+exit 0
+SH
+    chmod +x "${PIXI_STUB}/pixi"
+}
+
+teardown() {
+    [[ -n "$TMP_REPO" && -d "$TMP_REPO" ]] && rm -rf "$TMP_REPO"
+    [[ -n "$PIXI_STUB" && -d "$PIXI_STUB" ]] && rm -rf "$PIXI_STUB"
+}
+
+@test "install-hooks-legacy: copies pre-commit hook to .git/hooks/pre-commit" {
+    run just --justfile "${SCRIPT_DIR}/justfile" \
+        --working-directory "${TMP_REPO}" \
+        install-hooks-legacy
+    [ "$status" -eq 0 ]
+    [ -f "${TMP_REPO}/.git/hooks/pre-commit" ]
+}
+
+@test "install-hooks-legacy: installed hook is executable" {
+    run just --justfile "${SCRIPT_DIR}/justfile" \
+        --working-directory "${TMP_REPO}" \
+        install-hooks-legacy
+    [ "$status" -eq 0 ]
+    [ -x "${TMP_REPO}/.git/hooks/pre-commit" ]
+}
+
+@test "install-hooks-legacy: installed hook content matches hooks/pre-commit" {
+    run just --justfile "${SCRIPT_DIR}/justfile" \
+        --working-directory "${TMP_REPO}" \
+        install-hooks-legacy
+    [ "$status" -eq 0 ]
+    run diff "${TMP_REPO}/hooks/pre-commit" "${TMP_REPO}/.git/hooks/pre-commit"
+    [ "$status" -eq 0 ]
+}
+
+@test "install-hooks-legacy: does not invoke pixi run pre-commit install" {
+    run env PATH="${PIXI_STUB}:${PATH}" \
+        just --justfile "${SCRIPT_DIR}/justfile" \
+        --working-directory "${TMP_REPO}" \
+        install-hooks-legacy
+    [ "$status" -eq 0 ]
+    [ ! -f "${PIXI_STUB}/pixi.log" ]
+}

--- a/tools/reconciler/tests/unit/test_lint_agents_md.bats
+++ b/tools/reconciler/tests/unit/test_lint_agents_md.bats
@@ -1,0 +1,245 @@
+#!/usr/bin/env bats
+# tests/unit/test_lint_agents_md.bats
+#
+# Unit tests for scripts/lint-agents-md.sh
+#
+# Verifies that the script passes when all six required sections are present,
+# fails with a clear error message when any section is missing, and handles
+# edge cases (missing file, partial matches, stdin, env var).
+
+bats_require_minimum_version 1.5.0
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+LINT_SCRIPT="${SCRIPT_DIR}/scripts/lint-agents-md.sh"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Write a complete AGENTS.md with all required sections to a temp file.
+_write_complete_agents_md() {
+    local path="$1"
+    cat > "$path" <<'EOF'
+# AGENTS.md — Agent Safety Boundaries
+
+## Scope
+
+In scope content here.
+
+## Permitted Actions
+
+Permitted content here.
+
+## Prohibited Actions
+
+Prohibited content here.
+
+## `--dangerously-skip-permissions` Policy
+
+Policy content here.
+
+## Fleet Coordination
+
+Coordination content here.
+
+## Escalation — Human Review Required
+
+Escalation content here.
+EOF
+}
+
+setup() {
+    TMP_DIR="$(mktemp -d)"
+}
+
+teardown() {
+    rm -rf "$TMP_DIR"
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: complete AGENTS.md exits 0
+# ---------------------------------------------------------------------------
+
+@test "lint-agents-md: complete AGENTS.md exits 0" {
+    _write_complete_agents_md "${TMP_DIR}/AGENTS.md"
+    run bash "$LINT_SCRIPT" "${TMP_DIR}/AGENTS.md"
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 2: real AGENTS.md in repo passes
+# ---------------------------------------------------------------------------
+
+@test "lint-agents-md: real repo AGENTS.md passes" {
+    run bash "$LINT_SCRIPT" "${SCRIPT_DIR}/AGENTS.md"
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Tests 3–8: each required section missing → exit 1 with helpful message
+# ---------------------------------------------------------------------------
+
+@test "lint-agents-md: missing '## Scope' exits 1" {
+    _write_complete_agents_md "${TMP_DIR}/AGENTS.md"
+    grep -v "^## Scope" "${TMP_DIR}/AGENTS.md" > "${TMP_DIR}/AGENTS-broken.md"
+    run bash "$LINT_SCRIPT" "${TMP_DIR}/AGENTS-broken.md"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"## Scope"* ]]
+}
+
+@test "lint-agents-md: missing '## Permitted Actions' exits 1" {
+    _write_complete_agents_md "${TMP_DIR}/AGENTS.md"
+    grep -v "^## Permitted Actions" "${TMP_DIR}/AGENTS.md" > "${TMP_DIR}/AGENTS-broken.md"
+    run bash "$LINT_SCRIPT" "${TMP_DIR}/AGENTS-broken.md"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"## Permitted Actions"* ]]
+}
+
+@test "lint-agents-md: missing '## Prohibited Actions' exits 1" {
+    _write_complete_agents_md "${TMP_DIR}/AGENTS.md"
+    grep -v "^## Prohibited Actions" "${TMP_DIR}/AGENTS.md" > "${TMP_DIR}/AGENTS-broken.md"
+    run bash "$LINT_SCRIPT" "${TMP_DIR}/AGENTS-broken.md"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"## Prohibited Actions"* ]]
+}
+
+@test "lint-agents-md: missing '--dangerously-skip-permissions Policy' exits 1" {
+    _write_complete_agents_md "${TMP_DIR}/AGENTS.md"
+    grep -v "dangerously-skip-permissions" "${TMP_DIR}/AGENTS.md" > "${TMP_DIR}/AGENTS-broken.md"
+    run bash "$LINT_SCRIPT" "${TMP_DIR}/AGENTS-broken.md"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"dangerously-skip-permissions"* ]]
+}
+
+@test "lint-agents-md: missing '## Fleet Coordination' exits 1" {
+    _write_complete_agents_md "${TMP_DIR}/AGENTS.md"
+    grep -v "^## Fleet Coordination" "${TMP_DIR}/AGENTS.md" > "${TMP_DIR}/AGENTS-broken.md"
+    run bash "$LINT_SCRIPT" "${TMP_DIR}/AGENTS-broken.md"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"## Fleet Coordination"* ]]
+}
+
+@test "lint-agents-md: missing '## Escalation' exits 1" {
+    _write_complete_agents_md "${TMP_DIR}/AGENTS.md"
+    grep -v "^## Escalation" "${TMP_DIR}/AGENTS.md" > "${TMP_DIR}/AGENTS-broken.md"
+    run bash "$LINT_SCRIPT" "${TMP_DIR}/AGENTS-broken.md"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Escalation"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 9: multiple missing sections → reports all of them
+# ---------------------------------------------------------------------------
+
+@test "lint-agents-md: multiple missing sections reports count" {
+    cat > "${TMP_DIR}/AGENTS-empty.md" <<'EOF'
+# AGENTS.md — Agent Safety Boundaries
+
+Some content but no required sections.
+EOF
+    run bash "$LINT_SCRIPT" "${TMP_DIR}/AGENTS-empty.md"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"missing"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 10: file not found → exit 1 with clear error
+# ---------------------------------------------------------------------------
+
+@test "lint-agents-md: missing file exits 1 with error" {
+    run bash "$LINT_SCRIPT" "${TMP_DIR}/does-not-exist.md"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"file not found"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 11: partial heading match does not satisfy requirement
+# ---------------------------------------------------------------------------
+
+@test "lint-agents-md: partial heading 'Scope' without ## prefix does not satisfy requirement" {
+    cat > "${TMP_DIR}/AGENTS-partial.md" <<'EOF'
+# AGENTS.md — Agent Safety Boundaries
+
+Scope is mentioned here in prose but not as a heading.
+
+## Permitted Actions
+
+## Prohibited Actions
+
+## `--dangerously-skip-permissions` Policy
+
+## Fleet Coordination
+
+## Escalation — Human Review Required
+EOF
+    run bash "$LINT_SCRIPT" "${TMP_DIR}/AGENTS-partial.md"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"## Scope"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 12: no arguments → defaults to repo AGENTS.md and passes
+# ---------------------------------------------------------------------------
+
+@test "lint-agents-md: no arguments defaults to repo AGENTS.md" {
+    # Run from repo root so the default path resolves correctly
+    run bash -c "cd '${SCRIPT_DIR}' && bash scripts/lint-agents-md.sh"
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Tests 13–18: stdin input modes
+# ---------------------------------------------------------------------------
+
+@test "lint-agents-md: stdin via '-' arg with complete content exits 0" {
+    _write_complete_agents_md "${TMP_DIR}/AGENTS.md"
+    run bash -c "bash '$LINT_SCRIPT' - < '${TMP_DIR}/AGENTS.md'"
+    [ "$status" -eq 0 ]
+}
+
+@test "lint-agents-md: stdin via '-' arg with missing section exits 1" {
+    _write_complete_agents_md "${TMP_DIR}/AGENTS.md"
+    grep -v "^## Scope" "${TMP_DIR}/AGENTS.md" > "${TMP_DIR}/AGENTS-broken.md"
+    run bash -c "bash '$LINT_SCRIPT' - < '${TMP_DIR}/AGENTS-broken.md'"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"## Scope"* ]]
+    [[ "$output" == *"<stdin>"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Tests: LINT_AGENTS_MD_FILE environment variable
+# ---------------------------------------------------------------------------
+
+@test "lint-agents-md: LINT_AGENTS_MD_FILE env var with complete file exits 0" {
+    _write_complete_agents_md "${TMP_DIR}/AGENTS.md"
+    LINT_AGENTS_MD_FILE="${TMP_DIR}/AGENTS.md" run bash "$LINT_SCRIPT"
+    [ "$status" -eq 0 ]
+}
+
+@test "lint-agents-md: LINT_AGENTS_MD_FILE env var with missing section exits 1" {
+    _write_complete_agents_md "${TMP_DIR}/AGENTS.md"
+    grep -v "^## Permitted Actions" "${TMP_DIR}/AGENTS.md" > "${TMP_DIR}/AGENTS-broken.md"
+    LINT_AGENTS_MD_FILE="${TMP_DIR}/AGENTS-broken.md" run bash "$LINT_SCRIPT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"## Permitted Actions"* ]]
+}
+
+@test "lint-agents-md: LINT_AGENTS_MD_FILE='-' reads stdin" {
+    _write_complete_agents_md "${TMP_DIR}/AGENTS.md"
+    run bash -c "LINT_AGENTS_MD_FILE=- bash '$LINT_SCRIPT' < '${TMP_DIR}/AGENTS.md'"
+    [ "$status" -eq 0 ]
+}
+
+@test "lint-agents-md: positional arg takes precedence over LINT_AGENTS_MD_FILE" {
+    _write_complete_agents_md "${TMP_DIR}/AGENTS.md"
+    grep -v "^## Scope" "${TMP_DIR}/AGENTS.md" > "${TMP_DIR}/AGENTS-broken.md"
+    # env var points at broken file, but positional arg should win
+    LINT_AGENTS_MD_FILE="${TMP_DIR}/AGENTS-broken.md" run bash "$LINT_SCRIPT" "${TMP_DIR}/AGENTS.md"
+    [ "$status" -eq 0 ]
+}
+
+@test "lint-agents-md: LINT_AGENTS_MD_FILE pointing to missing file exits 1" {
+    LINT_AGENTS_MD_FILE="${TMP_DIR}/does-not-exist.md" run bash "$LINT_SCRIPT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"file not found"* ]]
+}

--- a/tools/reconciler/tests/unit/test_log.bats
+++ b/tools/reconciler/tests/unit/test_log.bats
@@ -1,0 +1,180 @@
+#!/usr/bin/env bats
+# tests/unit/test_log.bats — unit tests for scripts/lib/log.sh
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+
+setup() {
+    # shellcheck source=/dev/null
+    source "${SCRIPT_DIR}/scripts/lib/log.sh"
+    # Unset log-related env vars for clean test state
+    unset LOG_LEVEL LOG_FORMAT
+}
+
+# ---------------------------------------------------------------------------
+# LOG_LEVEL filtering: DEBUG
+# ---------------------------------------------------------------------------
+
+@test "log_debug: emitted when LOG_LEVEL=DEBUG" {
+    export LOG_LEVEL=DEBUG
+    run log_debug "test debug message"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"DEBUG"* ]]
+    [[ "$output" == *"test debug message"* ]]
+}
+
+@test "log_debug: suppressed when LOG_LEVEL=INFO" {
+    export LOG_LEVEL=INFO
+    run log_debug "test debug message"
+    [[ "$status" -eq 0 ]]
+    [[ -z "$output" ]]
+}
+
+# ---------------------------------------------------------------------------
+# LOG_LEVEL filtering: INFO
+# ---------------------------------------------------------------------------
+
+@test "log_info: emitted when LOG_LEVEL=INFO (default)" {
+    run log_info "test info message"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"INFO"* ]]
+    [[ "$output" == *"test info message"* ]]
+}
+
+@test "log_info: emitted when LOG_LEVEL=DEBUG" {
+    export LOG_LEVEL=DEBUG
+    run log_info "test info message"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"INFO"* ]]
+}
+
+@test "log_info: suppressed when LOG_LEVEL=WARN" {
+    export LOG_LEVEL=WARN
+    run log_info "test info message"
+    [[ "$status" -eq 0 ]]
+    [[ -z "$output" ]]
+}
+
+# ---------------------------------------------------------------------------
+# LOG_LEVEL filtering: WARN
+# ---------------------------------------------------------------------------
+
+@test "log_warn: emitted when LOG_LEVEL=WARN" {
+    export LOG_LEVEL=WARN
+    run log_warn "test warn message"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"WARN"* ]]
+    [[ "$output" == *"test warn message"* ]]
+}
+
+@test "log_warn: suppressed when LOG_LEVEL=ERROR" {
+    export LOG_LEVEL=ERROR
+    run log_warn "test warn message"
+    [[ "$status" -eq 0 ]]
+    [[ -z "$output" ]]
+}
+
+# ---------------------------------------------------------------------------
+# LOG_LEVEL filtering: ERROR
+# ---------------------------------------------------------------------------
+
+@test "log_error: always emitted regardless of LOG_LEVEL" {
+    export LOG_LEVEL=ERROR
+    run log_error "test error message"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"ERROR"* ]]
+    [[ "$output" == *"test error message"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# JSON format output
+# ---------------------------------------------------------------------------
+
+@test "LOG_FORMAT=json: output is valid JSON" {
+    export LOG_FORMAT=json
+    run log_info "test message"
+    [[ "$status" -eq 0 ]]
+    # Verify output contains JSON object structure
+    [[ "$output" == *"\"level\":"* ]]
+    [[ "$output" == *"\"message\":"* ]]
+    [[ "$output" == *"\"script\":"* ]]
+    [[ "$output" == *"\"timestamp\":"* ]]
+}
+
+@test "LOG_FORMAT=json: contains expected fields" {
+    export LOG_FORMAT=json
+    run log_info "test message"
+    [[ "$status" -eq 0 ]]
+    # Check for required fields in JSON output
+    [[ "$output" == *"\"level\":\"INFO\""* ]]
+    [[ "$output" == *"\"message\":test message"* ]]
+    [[ "$output" == *"\"script\":"* ]]
+    [[ "$output" =~ \"timestamp\":\"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z\" ]]
+}
+
+# ---------------------------------------------------------------------------
+# stderr vs stdout routing
+# ---------------------------------------------------------------------------
+
+@test "log_error: goes to stderr (fd 2)" {
+    export LOG_FORMAT=text
+    run log_error "error to stderr" 2>&1
+    [[ "$status" -eq 0 ]]
+    # The output should contain the error (captured via 2>&1 redirection above)
+    [[ "$output" == *"ERROR"* ]]
+    [[ "$output" == *"error to stderr"* ]]
+}
+
+@test "log_info: goes to stdout (fd 1)" {
+    export LOG_FORMAT=text
+    run log_info "info to stdout"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"INFO"* ]]
+    [[ "$output" == *"info to stdout"* ]]
+}
+
+@test "log_warn: goes to stdout (fd 1)" {
+    export LOG_FORMAT=text
+    run log_warn "warn to stdout"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"WARN"* ]]
+    [[ "$output" == *"warn to stdout"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Color codes
+# ---------------------------------------------------------------------------
+
+@test "text format: no ANSI color codes when output is not a TTY" {
+    export LOG_FORMAT=text
+    run log_info "test message"
+    [[ "$status" -eq 0 ]]
+    # Should not contain ANSI escape sequences
+    [[ "$output" != *$'\033['* ]]
+}
+
+@test "JSON format: never includes ANSI color codes" {
+    export LOG_FORMAT=json
+    run log_info "test message"
+    [[ "$status" -eq 0 ]]
+    # JSON output should never contain ANSI codes
+    [[ "$output" != *$'\033['* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Message content preservation
+# ---------------------------------------------------------------------------
+
+@test "log functions: preserve special characters in message" {
+    export LOG_FORMAT=text
+    run log_info 'test with $special "chars" and newline'
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *'test with $special "chars" and newline'* ]]
+}
+
+@test "LOG_FORMAT=json: properly handles special characters in message" {
+    export LOG_FORMAT=json
+    run log_info 'test with special chars'
+    [[ "$status" -eq 0 ]]
+    # Verify message field is present in JSON output
+    [[ "$output" == *"\"message\":test with special chars"* ]]
+}

--- a/tools/reconciler/tests/unit/test_mock_server_routes.bats
+++ b/tools/reconciler/tests/unit/test_mock_server_routes.bats
@@ -1,0 +1,285 @@
+#!/usr/bin/env bats
+# tests/unit/test_mock_server_routes.bats
+#
+# Tests for mock_server.py per-route response feature (issue #192).
+# Verifies that a single mock server instance can serve different responses
+# for different method+path combinations, enabling multi-step workflow tests.
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+HELPERS_DIR="${SCRIPT_DIR}/tests/helpers"
+
+MOCK_PORT=18085
+MOCK_PID_FILE="/tmp/bats-mock-routes-$$.pid"
+ROUTES_FILE="/tmp/bats-mock-routes-$$.json"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_start_mock_with_routes() {
+    local routes_json="$1"
+    printf '%s' "$routes_json" > "$ROUTES_FILE"
+    python3 "${HELPERS_DIR}/mock_server.py" "$MOCK_PORT" --routes "$ROUTES_FILE" \
+        > /dev/null 2>&1 &
+    echo $! > "$MOCK_PID_FILE"
+    sleep 0.2
+}
+
+_stop_mock_server() {
+    if [[ -f "$MOCK_PID_FILE" ]]; then
+        kill "$(cat "$MOCK_PID_FILE")" 2>/dev/null || true
+        rm -f "$MOCK_PID_FILE"
+    fi
+    rm -f "$ROUTES_FILE"
+}
+
+_curl_get() {
+    # -s: silent, no -f so that 4xx/5xx responses still print the status code
+    curl -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:${MOCK_PORT}${1}"
+}
+
+_curl_get_body() {
+    curl -sf "http://127.0.0.1:${MOCK_PORT}${1}"
+}
+
+_curl_post_code() {
+    curl -s -o /dev/null -w "%{http_code}" -X POST \
+        -H "Content-Type: application/json" -d '{}' \
+        "http://127.0.0.1:${MOCK_PORT}${1}"
+}
+
+teardown() {
+    _stop_mock_server
+}
+
+# ---------------------------------------------------------------------------
+# Flat-array JSON format (issue #192 spec)
+# ---------------------------------------------------------------------------
+
+@test "mock_server: per-route flat-array — GET /api/v1/agents returns 200 with agent list" {
+    _start_mock_with_routes '[
+        {"method":"GET","path":"/api/v1/agents","status":200,"body":[{"id":"a1","name":"agent-one","status":"active"}]},
+        {"method":"POST","path":"/api/v1/agents","status":201,"body":{"id":"a2","name":"agent-two","status":"offline"}}
+    ]'
+    code="$(_curl_get /api/v1/agents)"
+    [[ "$code" == "200" ]]
+}
+
+@test "mock_server: per-route flat-array — GET body contains expected agent data" {
+    _start_mock_with_routes '[
+        {"method":"GET","path":"/api/v1/agents","status":200,"body":[{"id":"a1","name":"agent-one","status":"active"}]}
+    ]'
+    body="$(_curl_get_body /api/v1/agents)"
+    name="$(echo "$body" | jq -r '.[0].name')"
+    [[ "$name" == "agent-one" ]]
+}
+
+@test "mock_server: per-route flat-array — POST /api/v1/agents returns 201" {
+    _start_mock_with_routes '[
+        {"method":"GET","path":"/api/v1/agents","status":200,"body":[]},
+        {"method":"POST","path":"/api/v1/agents","status":201,"body":{"id":"new1","name":"new-agent"}}
+    ]'
+    code="$(_curl_post_code /api/v1/agents)"
+    [[ "$code" == "201" ]]
+}
+
+@test "mock_server: per-route — different paths return different responses" {
+    _start_mock_with_routes '[
+        {"method":"GET","path":"/api/v1/agents","status":200,"body":{"route":"list"}},
+        {"method":"GET","path":"/api/v1/status","status":200,"body":{"route":"status"}}
+    ]'
+    body_agents="$(_curl_get_body /api/v1/agents)"
+    body_status="$(_curl_get_body /api/v1/status)"
+    route_agents="$(echo "$body_agents" | jq -r '.route')"
+    route_status="$(echo "$body_status" | jq -r '.route')"
+    [[ "$route_agents" == "list" ]]
+    [[ "$route_status" == "status" ]]
+}
+
+# ---------------------------------------------------------------------------
+# Wildcard path matching
+# ---------------------------------------------------------------------------
+
+@test "mock_server: wildcard path — GET /api/v1/agents/* matches specific agent ID" {
+    _start_mock_with_routes '[
+        {"method":"GET","path":"/api/v1/agents/*","status":200,"body":{"id":"abc123","name":"my-agent"}}
+    ]'
+    body="$(_curl_get_body /api/v1/agents/abc123)"
+    id="$(echo "$body" | jq -r '.id')"
+    [[ "$id" == "abc123" ]]
+}
+
+@test "mock_server: wildcard path — exact match takes priority over wildcard (first match wins)" {
+    _start_mock_with_routes '[
+        {"method":"GET","path":"/api/v1/agents/special","status":200,"body":{"route":"exact"}},
+        {"method":"GET","path":"/api/v1/agents/*","status":200,"body":{"route":"wildcard"}}
+    ]'
+    body_exact="$(_curl_get_body /api/v1/agents/special)"
+    body_wild="$(_curl_get_body /api/v1/agents/other)"
+    route_exact="$(echo "$body_exact" | jq -r '.route')"
+    route_wild="$(echo "$body_wild" | jq -r '.route')"
+    [[ "$route_exact" == "exact" ]]
+    [[ "$route_wild" == "wildcard" ]]
+}
+
+# ---------------------------------------------------------------------------
+# Fallback behaviour
+# ---------------------------------------------------------------------------
+
+@test "mock_server: per-route — unmatched path falls back to default_status/default_body" {
+    _start_mock_with_routes '{
+        "routes":[{"method":"GET","path":"/api/v1/agents","status":200,"body":[]}],
+        "default_status":404,
+        "default_body":{"error":"not found"}
+    }'
+    code="$(_curl_get /api/v1/unknown)"
+    [[ "$code" == "404" ]]
+}
+
+@test "mock_server: per-route — unmatched method falls back to default even if path matches" {
+    _start_mock_with_routes '{
+        "routes":[{"method":"GET","path":"/api/v1/agents","status":200,"body":[]}],
+        "default_status":405,
+        "default_body":{"error":"method not allowed"}
+    }'
+    code="$(_curl_post_code /api/v1/agents)"
+    [[ "$code" == "405" ]]
+}
+
+@test "mock_server: per-route — fallback to MOCK_STATUS env var when no default in config" {
+    _start_mock_with_routes '[
+        {"method":"GET","path":"/api/v1/agents","status":200,"body":[]}
+    ]'
+    # No MOCK_STATUS set → defaults to 200 for unmatched routes
+    code="$(_curl_get /api/v1/unmatched)"
+    [[ "$code" == "200" ]]
+}
+
+# ---------------------------------------------------------------------------
+# Object-wrapper format (legacy / alternative)
+# ---------------------------------------------------------------------------
+
+@test "mock_server: object-format routes config — routes key works correctly" {
+    _start_mock_with_routes '{
+        "routes":[
+            {"method":"GET","path":"/health","status":200,"body":{"healthy":true}}
+        ],
+        "default_status":503,
+        "default_body":{"healthy":false}
+    }'
+    body="$(_curl_get_body /health)"
+    healthy="$(echo "$body" | jq -r '.healthy')"
+    [[ "$healthy" == "true" ]]
+}
+
+# ---------------------------------------------------------------------------
+# Multi-step workflow test (the core use-case from issue #192)
+# ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# Use-once route support (issue #433)
+# ---------------------------------------------------------------------------
+
+@test "mock_server: once route — first GET returns once-route body, second falls through to default_body" {
+    _start_mock_with_routes '{
+        "routes":[
+            {"method":"GET","path":"/api/v1/agents","status":200,"body":[{"status":"offline"}],"once":true}
+        ],
+        "default_status":200,
+        "default_body":[{"status":"active"}]
+    }'
+    body1="$(_curl_get_body /api/v1/agents)"
+    status1="$(echo "$body1" | jq -r '.[0].status')"
+    body2="$(_curl_get_body /api/v1/agents)"
+    status2="$(echo "$body2" | jq -r '.[0].status')"
+    [[ "$status1" == "offline" ]]
+    [[ "$status2" == "active" ]]
+}
+
+@test "mock_server: once route — once consumed, next explicit route matches on second call" {
+    _start_mock_with_routes '[
+        {"method":"GET","path":"/api/v1/agents","status":200,"body":{"hit":"first"},"once":true},
+        {"method":"GET","path":"/api/v1/agents","status":200,"body":{"hit":"second"}}
+    ]'
+    body1="$(_curl_get_body /api/v1/agents)"
+    hit1="$(echo "$body1" | jq -r '.hit')"
+    body2="$(_curl_get_body /api/v1/agents)"
+    hit2="$(echo "$body2" | jq -r '.hit')"
+    body3="$(_curl_get_body /api/v1/agents)"
+    hit3="$(echo "$body3" | jq -r '.hit')"
+    [[ "$hit1" == "first" ]]
+    [[ "$hit2" == "second" ]]
+    # third call still matches the non-once second route
+    [[ "$hit3" == "second" ]]
+}
+
+@test "mock_server: non-once route — served on every call (regression guard)" {
+    _start_mock_with_routes '[
+        {"method":"GET","path":"/api/v1/agents","status":200,"body":{"stable":true}}
+    ]'
+    for _ in 1 2 3; do
+        body="$(_curl_get_body /api/v1/agents)"
+        val="$(echo "$body" | jq -r '.stable')"
+        [[ "$val" == "true" ]]
+    done
+}
+
+@test "mock_server: once route — works on POST method, not just GET" {
+    _start_mock_with_routes '{
+        "routes":[
+            {"method":"POST","path":"/api/v1/agents","status":201,"body":{"created":true},"once":true}
+        ],
+        "default_status":200,
+        "default_body":{"created":false}
+    }'
+    body1="$(curl -sf -X POST -H "Content-Type: application/json" -d '{}' \
+        "http://127.0.0.1:${MOCK_PORT}/api/v1/agents")"
+    created1="$(echo "$body1" | jq -r '.created')"
+    body2="$(curl -sf -X POST -H "Content-Type: application/json" -d '{}' \
+        "http://127.0.0.1:${MOCK_PORT}/api/v1/agents")"
+    created2="$(echo "$body2" | jq -r '.created')"
+    [[ "$created1" == "true" ]]
+    [[ "$created2" == "false" ]]
+}
+
+@test "mock_server: multiple once routes — each consumed in order" {
+    _start_mock_with_routes '{
+        "routes":[
+            {"method":"GET","path":"/api/v1/agents","status":200,"body":[{"seq":1}],"once":true},
+            {"method":"GET","path":"/api/v1/agents","status":200,"body":[{"seq":2}],"once":true}
+        ],
+        "default_status":200,
+        "default_body":[{"seq":3}]
+    }'
+    seq1="$(_curl_get_body /api/v1/agents | jq -r '.[0].seq')"
+    seq2="$(_curl_get_body /api/v1/agents | jq -r '.[0].seq')"
+    seq3="$(_curl_get_body /api/v1/agents | jq -r '.[0].seq')"
+    [[ "$seq1" == "1" ]]
+    [[ "$seq2" == "2" ]]
+    [[ "$seq3" == "3" ]]
+}
+
+@test "mock_server: multi-step workflow — list then get then update use single server" {
+    # Simulates a workflow that: lists agents, fetches one by ID, then patches it.
+    _start_mock_with_routes '[
+        {"method":"GET","path":"/api/v1/agents","status":200,"body":[{"id":"wf1","name":"workflow-agent","status":"offline"}]},
+        {"method":"GET","path":"/api/v1/agents/*","status":200,"body":{"id":"wf1","name":"workflow-agent","status":"offline"}},
+        {"method":"PATCH","path":"/api/v1/agents/*","status":200,"body":{"id":"wf1","name":"workflow-agent","status":"active"}}
+    ]'
+
+    # Step 1: list
+    list_body="$(_curl_get_body /api/v1/agents)"
+    agent_id="$(echo "$list_body" | jq -r '.[0].id')"
+    [[ "$agent_id" == "wf1" ]]
+
+    # Step 2: get by ID
+    get_body="$(_curl_get_body "/api/v1/agents/${agent_id}")"
+    get_status="$(echo "$get_body" | jq -r '.status')"
+    [[ "$get_status" == "offline" ]]
+
+    # Step 3: patch (wake)
+    patch_body="$(curl -sf -X PATCH -H "Content-Type: application/json" -d '{"status":"active"}' \
+        "http://127.0.0.1:${MOCK_PORT}/api/v1/agents/${agent_id}")"
+    patch_status="$(echo "$patch_body" | jq -r '.status')"
+    [[ "$patch_status" == "active" ]]
+}

--- a/tools/reconciler/tests/unit/test_precommit_dangerous_flags.bats
+++ b/tools/reconciler/tests/unit/test_precommit_dangerous_flags.bats
@@ -1,0 +1,267 @@
+#!/usr/bin/env bats
+# tests/unit/test_precommit_dangerous_flags.bats
+#
+# Issue #147: test coverage for the pre-commit hook's dangerous-flags integration.
+#
+# The pre-commit hook (hooks/pre-commit) calls scripts/check-dangerous-flags.sh
+# on staged agent and fleet YAML files.  These tests set up a temporary git
+# repository, stage agent YAMLs containing (or not) --dangerously-skip-permissions,
+# and verify the hook exits with the correct status.
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+
+HOOK_SCRIPT="${SCRIPT_DIR}/hooks/pre-commit"
+DANGEROUS_FLAGS_SCRIPT="${SCRIPT_DIR}/scripts/check-dangerous-flags.sh"
+
+# Temporary git repo used by the tests — created under SCRIPT_DIR so it stays
+# within the worktree and is removed cleanly by teardown.
+TMP_REPO=""
+
+setup() {
+    # Create a temp directory inside the worktree to avoid safety-net restrictions
+    TMP_REPO="${SCRIPT_DIR}/_precommit_test_$$_${RANDOM}"
+    mkdir -p "$TMP_REPO"
+
+    # Initialise git repo (without gpg signing to avoid prompts)
+    git -C "$TMP_REPO" init -q
+    git -C "$TMP_REPO" config user.email "test@example.com"
+    git -C "$TMP_REPO" config user.name "Test"
+    git -C "$TMP_REPO" config commit.gpgsign false
+
+    # Copy the hook and scripts into the temp repo
+    mkdir -p "${TMP_REPO}/scripts"
+    mkdir -p "${TMP_REPO}/hooks"
+    mkdir -p "${TMP_REPO}/.git/hooks"
+    cp "$HOOK_SCRIPT" "${TMP_REPO}/hooks/pre-commit"
+    cp "$DANGEROUS_FLAGS_SCRIPT" "${TMP_REPO}/scripts/check-dangerous-flags.sh"
+    chmod +x "${TMP_REPO}/hooks/pre-commit"
+    chmod +x "${TMP_REPO}/scripts/check-dangerous-flags.sh"
+
+    # Install the hook
+    cp "${TMP_REPO}/hooks/pre-commit" "${TMP_REPO}/.git/hooks/pre-commit"
+    chmod +x "${TMP_REPO}/.git/hooks/pre-commit"
+
+    # Create the agents directory
+    mkdir -p "${TMP_REPO}/agents/hermes"
+
+    # Create an initial commit so the repo is in a valid state
+    touch "${TMP_REPO}/.gitkeep"
+    git -C "$TMP_REPO" add .gitkeep
+    git -C "$TMP_REPO" commit -q --no-verify -m "init"
+}
+
+teardown() {
+    if [[ -n "$TMP_REPO" && -d "$TMP_REPO" ]]; then
+        rm -rf "$TMP_REPO"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Helper: stage a file and run the hook directly.
+# The hook is run with the mikefarah yq (from pixi) in PATH if available,
+# since the hook uses `yq eval` syntax (yq v4).
+# ---------------------------------------------------------------------------
+
+_stage_and_run_hook() {
+    local file_path="$1"   # absolute path under TMP_REPO
+    local rel_path="${file_path#"${TMP_REPO}/"}"
+
+    git -C "$TMP_REPO" add "$rel_path"
+
+    # Prefer pixi yq (v4/mikefarah) over system yq (may be Python-based v3)
+    local pixi_yq_dir="${SCRIPT_DIR}/.pixi/envs/lint/bin"
+    local run_path="$PATH"
+    if [[ -x "${pixi_yq_dir}/yq" ]]; then
+        run_path="${pixi_yq_dir}:${PATH}"
+    fi
+
+    # Run the pre-commit hook from the repo root
+    # SKIP_TESTS=1: TMP_REPO has no Justfile/pixi.toml, so skip the test-suite step
+    (cd "$TMP_REPO" && SKIP_TESTS=1 PATH="$run_path" bash ".git/hooks/pre-commit") 2>&1
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: Bare --dangerously-skip-permissions without suppression → hook rejects
+# ---------------------------------------------------------------------------
+
+@test "pre-commit hook: rejects agent YAML with bare --dangerously-skip-permissions" {
+    local agent_file="${TMP_REPO}/agents/hermes/danger.yaml"
+    cat > "$agent_file" <<'YAML'
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: danger-agent
+  host: hermes
+spec:
+  label: DangerAgent
+  program: claude-code
+  workingDirectory: /tmp/danger
+  programArgs: "--dangerously-skip-permissions"
+  desiredState: active
+YAML
+
+    run _stage_and_run_hook "$agent_file"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"dangerously-skip-permissions"* || "$output" == *"dangerous"* || "$output" == *"violation"* || "$output" == *"lint"* || "$output" == *"failed"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 2: --dangerously-skip-permissions with suppression annotation → hook accepts
+# ---------------------------------------------------------------------------
+
+@test "pre-commit hook: accepts agent YAML with suppressed --dangerously-skip-permissions" {
+    local agent_file="${TMP_REPO}/agents/hermes/suppressed.yaml"
+    cat > "$agent_file" <<'YAML'
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: suppressed-agent
+  host: hermes
+spec:
+  label: SuppressedAgent
+  program: claude-code
+  workingDirectory: /tmp/suppressed
+  programArgs: "--dangerously-skip-permissions" # skip-permissions-lint: ephemeral container with read-only mount and 30m timeout
+  desiredState: active
+YAML
+
+    run _stage_and_run_hook "$agent_file"
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 3: Agent YAML with no dangerous flags → hook accepts
+# ---------------------------------------------------------------------------
+
+@test "pre-commit hook: accepts agent YAML without --dangerously-skip-permissions" {
+    local agent_file="${TMP_REPO}/agents/hermes/safe.yaml"
+    cat > "$agent_file" <<'YAML'
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: safe-agent
+  host: hermes
+spec:
+  label: SafeAgent
+  program: claude-code
+  workingDirectory: /tmp/safe
+  programArgs: "--model claude-sonnet-4-6"
+  desiredState: active
+YAML
+
+    run _stage_and_run_hook "$agent_file"
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 4: Fleet YAML with bare --dangerously-skip-permissions → hook rejects
+# ---------------------------------------------------------------------------
+
+@test "pre-commit hook: rejects fleet YAML with bare --dangerously-skip-permissions" {
+    mkdir -p "${TMP_REPO}/fleets"
+    local fleet_file="${TMP_REPO}/fleets/danger-fleet.yaml"
+    cat > "$fleet_file" <<'YAML'
+apiVersion: myrmidons/v1
+kind: Fleet
+metadata:
+  name: danger-fleet
+spec:
+  agents:
+    - name: danger-inline
+      program: claude-code
+      workingDirectory: /tmp/danger
+      programArgs: "--dangerously-skip-permissions"
+      desiredState: active
+YAML
+
+    run _stage_and_run_hook "$fleet_file"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"dangerously-skip-permissions"* || "$output" == *"dangerous"* || "$output" == *"violation"* || "$output" == *"lint"* || "$output" == *"failed"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 5: Fleet YAML with suppressed --dangerously-skip-permissions → hook accepts
+# ---------------------------------------------------------------------------
+
+@test "pre-commit hook: accepts fleet YAML with suppressed --dangerously-skip-permissions" {
+    mkdir -p "${TMP_REPO}/fleets"
+    local fleet_file="${TMP_REPO}/fleets/suppressed-fleet.yaml"
+    cat > "$fleet_file" <<'YAML'
+apiVersion: myrmidons/v1
+kind: Fleet
+metadata:
+  name: suppressed-fleet
+spec:
+  agents:
+    - name: suppressed-inline
+      program: claude-code
+      workingDirectory: /tmp/suppressed
+      programArgs: "--dangerously-skip-permissions" # skip-permissions-lint: isolated docker container with no network
+      desiredState: active
+YAML
+
+    run _stage_and_run_hook "$fleet_file"
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 6: Combined flags with bare dangerous flag → hook rejects
+# ---------------------------------------------------------------------------
+
+@test "pre-commit hook: rejects when --dangerously-skip-permissions combined with other flags" {
+    local agent_file="${TMP_REPO}/agents/hermes/combined.yaml"
+    cat > "$agent_file" <<'YAML'
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: combined-agent
+  host: hermes
+spec:
+  label: CombinedAgent
+  program: claude-code
+  workingDirectory: /tmp/combined
+  programArgs: "--dangerously-skip-permissions --model claude-sonnet-4-6"
+  desiredState: active
+YAML
+
+    run _stage_and_run_hook "$agent_file"
+    [ "$status" -ne 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 7: check-dangerous-flags.sh directly — bare flag exits 1
+# ---------------------------------------------------------------------------
+
+@test "check-dangerous-flags.sh: bare flag in file exits 1" {
+    local tmpfile="${TMP_REPO}/direct_test.yaml"
+    cat > "$tmpfile" <<'YAML'
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: direct-test
+  host: hermes
+spec:
+  programArgs: "--dangerously-skip-permissions"
+YAML
+    run bash "$DANGEROUS_FLAGS_SCRIPT" "$tmpfile"
+    [ "$status" -eq 1 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 8: check-dangerous-flags.sh directly — suppressed flag exits 0
+# ---------------------------------------------------------------------------
+
+@test "check-dangerous-flags.sh: suppressed flag in file exits 0" {
+    local tmpfile="${TMP_REPO}/direct_suppressed.yaml"
+    cat > "$tmpfile" <<'YAML'
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: direct-suppressed
+  host: hermes
+spec:
+  programArgs: "--dangerously-skip-permissions" # skip-permissions-lint: test justification
+YAML
+    run bash "$DANGEROUS_FLAGS_SCRIPT" "$tmpfile"
+    [ "$status" -eq 0 ]
+}

--- a/tools/reconciler/tests/unit/test_precommit_staged.bats
+++ b/tools/reconciler/tests/unit/test_precommit_staged.bats
@@ -1,0 +1,254 @@
+#!/usr/bin/env bats
+# tests/unit/test_precommit_staged.bats — shell-based tests for the pre-commit hook
+# staged-vs-working-tree behavior (#108)
+#
+# The pre-commit hook (hooks/pre-commit) reads staged YAML content via
+# `git diff --cached --name-only` and then reads the file from the working tree.
+# These tests use a temporary git repo with staged and unstaged changes to verify
+# that the hook validates what is staged, not what is on disk after staging.
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+HOOK="${SCRIPT_DIR}/hooks/pre-commit"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Create a minimal temporary git repo, initialise it, and configure a test user.
+# Sets REPO_DIR so teardown can clean it up.
+_init_test_repo() {
+    REPO_DIR="$(mktemp -d)"
+    git -C "$REPO_DIR" init -q
+    git -C "$REPO_DIR" config user.email "test@example.com"
+    git -C "$REPO_DIR" config user.name "Test User"
+    # Create the agents directory tree
+    mkdir -p "$REPO_DIR/agents/hermes"
+}
+
+# Write a valid agent YAML to a path (relative to REPO_DIR).
+_write_valid_agent() {
+    local rel_path="$1"
+    local name="${2:-valid-agent}"
+    cat > "$REPO_DIR/$rel_path" <<EOF
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: ${name}
+  host: hermes
+spec:
+  label: ValidAgent
+  program: claude-code
+  workingDirectory: /tmp/valid
+  deployment:
+    type: local
+  desiredState: active
+EOF
+}
+
+# Write an invalid agent YAML (missing metadata.name).
+_write_invalid_agent() {
+    local rel_path="$1"
+    cat > "$REPO_DIR/$rel_path" <<'EOF'
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  host: hermes
+spec:
+  label: NoName
+  program: claude-code
+  workingDirectory: /tmp/noname
+  deployment:
+    type: local
+  desiredState: active
+EOF
+}
+
+setup() {
+    _init_test_repo
+}
+
+teardown() {
+    [[ -d "${REPO_DIR:-}" ]] && rm -rf "$REPO_DIR"
+}
+
+# ---------------------------------------------------------------------------
+# Baseline: no staged YAML files → hook exits 0 immediately
+# ---------------------------------------------------------------------------
+
+@test "pre-commit hook: exits 0 when no YAML files are staged" {
+    # Nothing staged at all
+    run bash -c "cd '$REPO_DIR' && SKIP_TESTS=1 bash '$HOOK'"
+    [[ "$status" -eq 0 ]]
+}
+
+# ---------------------------------------------------------------------------
+# Valid staged file → hook exits 0
+# ---------------------------------------------------------------------------
+
+@test "pre-commit hook: exits 0 when staged agent YAML is valid" {
+    _write_valid_agent "agents/hermes/myagent.yaml"
+    git -C "$REPO_DIR" add "agents/hermes/myagent.yaml"
+    run git -C "$REPO_DIR" -c core.hooksPath="${SCRIPT_DIR}/hooks" diff --cached --name-only
+    # Run hook inside the test repo so git commands see the index
+    run bash -c "cd '$REPO_DIR' && SKIP_TESTS=1 bash '$HOOK'"
+    [[ "$status" -eq 0 ]]
+}
+
+# ---------------------------------------------------------------------------
+# Invalid staged file → hook exits non-zero
+# ---------------------------------------------------------------------------
+
+@test "pre-commit hook: exits non-zero when staged agent YAML is missing metadata.name" {
+    _write_invalid_agent "agents/hermes/noname.yaml"
+    git -C "$REPO_DIR" add "agents/hermes/noname.yaml"
+    run bash -c "cd '$REPO_DIR' && SKIP_TESTS=1 bash '$HOOK'"
+    [[ "$status" -ne 0 ]]
+}
+
+# ---------------------------------------------------------------------------
+# Staged-vs-working-tree: hook reads staged content
+#
+# The key behavior: if a file is staged in a valid state but then the
+# working-tree copy is overwritten with an invalid version BEFORE the hook
+# runs (which is the pre-commit scenario when the file is edited after
+# `git add`), the hook reads the working-tree file (not the index blob).
+# Conversely, if the working-tree file is valid but the staged version is
+# invalid, only the staged version matters — but the hook reads the path
+# from disk, which in the typical flow IS the staged content.
+#
+# The hook uses `git diff --cached --name-only` to discover which files to
+# check, then reads those files directly from the working tree via yq.
+# These tests verify that only staged files are checked (not unstaged ones).
+# ---------------------------------------------------------------------------
+
+@test "pre-commit hook: only checks staged files, ignores unstaged-only changes" {
+    # Place an invalid YAML file but do NOT stage it
+    _write_invalid_agent "agents/hermes/unstaged-invalid.yaml"
+    # Stage a valid file instead
+    _write_valid_agent "agents/hermes/staged-valid.yaml"
+    git -C "$REPO_DIR" add "agents/hermes/staged-valid.yaml"
+    # Run hook — it should only see staged-valid.yaml and pass
+    run bash -c "cd '$REPO_DIR' && SKIP_TESTS=1 bash '$HOOK'"
+    [[ "$status" -eq 0 ]]
+}
+
+@test "pre-commit hook: checks all staged files, not just the first" {
+    # Stage two valid files; both should be validated
+    _write_valid_agent "agents/hermes/agent-one.yaml" "agent-one"
+    _write_valid_agent "agents/hermes/agent-two.yaml" "agent-two"
+    git -C "$REPO_DIR" add "agents/hermes/agent-one.yaml" "agents/hermes/agent-two.yaml"
+    run bash -c "cd '$REPO_DIR' && SKIP_TESTS=1 bash '$HOOK'"
+    [[ "$status" -eq 0 ]]
+    # Output should mention both files
+    [[ "$output" == *"agent-one.yaml"* ]]
+    [[ "$output" == *"agent-two.yaml"* ]]
+}
+
+@test "pre-commit hook: fails when one of two staged files is invalid" {
+    _write_valid_agent "agents/hermes/good.yaml" "good-agent"
+    _write_invalid_agent "agents/hermes/bad.yaml"
+    git -C "$REPO_DIR" add "agents/hermes/good.yaml" "agents/hermes/bad.yaml"
+    run bash -c "cd '$REPO_DIR' && SKIP_TESTS=1 bash '$HOOK'"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"bad.yaml"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Staged file deletion (D filter) is excluded from check
+# ---------------------------------------------------------------------------
+
+@test "pre-commit hook: exits 0 when only a deletion is staged (no YAML to validate)" {
+    # Create and commit a valid file, then stage its deletion
+    _write_valid_agent "agents/hermes/todelete.yaml" "todelete-agent"
+    git -C "$REPO_DIR" add "agents/hermes/todelete.yaml"
+    git -C "$REPO_DIR" commit -q -m "initial"
+    git -C "$REPO_DIR" rm -q "agents/hermes/todelete.yaml"
+    # The diff-filter=ACM used by the hook excludes D (deleted), so nothing to check
+    run bash -c "cd '$REPO_DIR' && SKIP_TESTS=1 bash '$HOOK'"
+    [[ "$status" -eq 0 ]]
+}
+
+# ---------------------------------------------------------------------------
+# YAML outside agents/ and fleets/ is not checked
+# ---------------------------------------------------------------------------
+
+@test "pre-commit hook: exits 0 when only non-agent YAML is staged" {
+    # Stage a YAML file outside agents/ and fleets/ — hook should ignore it
+    mkdir -p "$REPO_DIR/config"
+    cat > "$REPO_DIR/config/settings.yaml" <<'EOF'
+key: value
+EOF
+    git -C "$REPO_DIR" add "config/settings.yaml"
+    run bash -c "cd '$REPO_DIR' && SKIP_TESTS=1 bash '$HOOK'"
+    [[ "$status" -eq 0 ]]
+}
+
+# ---------------------------------------------------------------------------
+# apiVersion validation is checked against staged file content
+# ---------------------------------------------------------------------------
+
+@test "pre-commit hook: rejects staged file with wrong apiVersion" {
+    cat > "$REPO_DIR/agents/hermes/wrongver.yaml" <<'EOF'
+apiVersion: wrong/v2
+kind: Agent
+metadata:
+  name: wrong-version-agent
+  host: hermes
+spec:
+  program: claude-code
+  workingDirectory: /tmp/test
+  deployment:
+    type: local
+EOF
+    git -C "$REPO_DIR" add "agents/hermes/wrongver.yaml"
+    run bash -c "cd '$REPO_DIR' && SKIP_TESTS=1 bash '$HOOK'"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"apiVersion"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# desiredState validation
+# ---------------------------------------------------------------------------
+
+@test "pre-commit hook: rejects staged file with invalid desiredState" {
+    cat > "$REPO_DIR/agents/hermes/badstate.yaml" <<'EOF'
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: bad-state-agent
+  host: hermes
+spec:
+  label: BadState
+  program: claude-code
+  workingDirectory: /tmp/test
+  deployment:
+    type: local
+  desiredState: running
+EOF
+    git -C "$REPO_DIR" add "agents/hermes/badstate.yaml"
+    run bash -c "cd '$REPO_DIR' && SKIP_TESTS=1 bash '$HOOK'"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"desiredState"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Fleet YAML is validated as kind=Fleet (not as Agent)
+# ---------------------------------------------------------------------------
+
+@test "pre-commit hook: exits 0 when valid Fleet YAML is staged" {
+    mkdir -p "$REPO_DIR/fleets"
+    cat > "$REPO_DIR/fleets/myfleet.yaml" <<'EOF'
+apiVersion: myrmidons/v1
+kind: Fleet
+metadata:
+  name: myfleet
+  host: hermes
+spec:
+  agents:
+    - ref: hermes/someagent
+EOF
+    git -C "$REPO_DIR" add "fleets/myfleet.yaml"
+    run bash -c "cd '$REPO_DIR' && SKIP_TESTS=1 bash '$HOOK'"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"Fleet"* ]]
+}

--- a/tools/reconciler/tests/unit/test_prompt.bats
+++ b/tools/reconciler/tests/unit/test_prompt.bats
@@ -1,0 +1,173 @@
+#!/usr/bin/env bats
+# tests/unit/test_prompt.bats — unit tests for scripts/lib/prompt.sh
+#
+# Tests confirm_with_timeout() behavior across:
+#   - TTY mode: yes reply, no reply, timeout
+#   - Non-TTY mode: piped y, piped n, no stdin (default n), no stdin (default y)
+
+SCRIPT_DIR=""
+PROMPT_LIB=""
+
+setup() {
+    SCRIPT_DIR="$(cd "$(dirname "${BATS_TEST_FILENAME}")/../.." && pwd)/scripts"
+    PROMPT_LIB="${SCRIPT_DIR}/lib/prompt.sh"
+}
+
+# ---------------------------------------------------------------------------
+# Non-TTY stdin tests (stdin is a pipe — always non-interactive in BATS)
+# ---------------------------------------------------------------------------
+
+@test "confirm_with_timeout: piped 'y' returns 0 (yes)" {
+    run bash -c "
+        source '${PROMPT_LIB}'
+        echo y | confirm_with_timeout 'Proceed? [y/N]'
+    "
+    [[ "$status" -eq 0 ]]
+}
+
+@test "confirm_with_timeout: piped 'Y' returns 0 (yes)" {
+    run bash -c "
+        source '${PROMPT_LIB}'
+        echo Y | confirm_with_timeout 'Proceed? [y/N]'
+    "
+    [[ "$status" -eq 0 ]]
+}
+
+@test "confirm_with_timeout: piped 'yes' returns 0 (yes)" {
+    run bash -c "
+        source '${PROMPT_LIB}'
+        echo yes | confirm_with_timeout 'Proceed? [y/N]'
+    "
+    [[ "$status" -eq 0 ]]
+}
+
+@test "confirm_with_timeout: piped 'YES' returns 0 (yes)" {
+    run bash -c "
+        source '${PROMPT_LIB}'
+        echo YES | confirm_with_timeout 'Proceed? [y/N]'
+    "
+    [[ "$status" -eq 0 ]]
+}
+
+@test "confirm_with_timeout: piped 'n' returns 1 (no)" {
+    run bash -c "
+        source '${PROMPT_LIB}'
+        echo n | confirm_with_timeout 'Proceed? [y/N]'
+    "
+    [[ "$status" -eq 1 ]]
+}
+
+@test "confirm_with_timeout: piped 'N' returns 1 (no)" {
+    run bash -c "
+        source '${PROMPT_LIB}'
+        echo N | confirm_with_timeout 'Proceed? [y/N]'
+    "
+    [[ "$status" -eq 1 ]]
+}
+
+@test "confirm_with_timeout: piped 'no' returns 1 (no)" {
+    run bash -c "
+        source '${PROMPT_LIB}'
+        echo no | confirm_with_timeout 'Proceed? [y/N]'
+    "
+    [[ "$status" -eq 1 ]]
+}
+
+@test "confirm_with_timeout: empty piped input returns 1 (default n)" {
+    run bash -c "
+        source '${PROMPT_LIB}'
+        echo '' | confirm_with_timeout 'Proceed? [y/N]'
+    "
+    [[ "$status" -eq 1 ]]
+}
+
+# ---------------------------------------------------------------------------
+# Non-TTY no-stdin tests (default fallback)
+# ---------------------------------------------------------------------------
+
+@test "confirm_with_timeout: no stdin, default n returns 1" {
+    run bash -c "
+        source '${PROMPT_LIB}'
+        confirm_with_timeout 'Proceed? [y/N]' 1 n < /dev/null
+    "
+    [[ "$status" -eq 1 ]]
+}
+
+@test "confirm_with_timeout: no stdin, default y returns 0" {
+    run bash -c "
+        source '${PROMPT_LIB}'
+        confirm_with_timeout 'Proceed? [y/N]' 1 y < /dev/null
+    "
+    [[ "$status" -eq 0 ]]
+}
+
+@test "confirm_with_timeout: default timeout is 30 (parameter default)" {
+    # Verify the function accepts calls without explicit timeout/default args
+    run bash -c "
+        source '${PROMPT_LIB}'
+        confirm_with_timeout 'Proceed?' 1 n < /dev/null
+    "
+    [[ "$status" -eq 1 ]]
+}
+
+@test "confirm_with_timeout: no-arg call uses built-in defaults" {
+    run bash -c "
+        source '${PROMPT_LIB}'
+        confirm_with_timeout < /dev/null
+    "
+    [[ "$status" -eq 1 ]]
+}
+
+# ---------------------------------------------------------------------------
+# Prompt text output tests
+# ---------------------------------------------------------------------------
+
+@test "confirm_with_timeout: prompt is written to stderr not stdout" {
+    # Capture only stdout; stderr (prompt text) should not appear there
+    run bash -c "
+        source '${PROMPT_LIB}'
+        confirm_with_timeout 'Do it? [y/N]' 1 n < /dev/null 2>/dev/null
+        true
+    "
+    # stdout should be empty — prompt goes to stderr only
+    [[ -z "$output" ]]
+}
+
+@test "confirm_with_timeout: timeout message is written to stderr" {
+    run bash -c "
+        source '${PROMPT_LIB}'
+        confirm_with_timeout 'Go? [y/N]' 1 n < /dev/null 2>&1
+    " 2>&1
+    # With /dev/null stdin, either the 1-second non-TTY branch fires or
+    # the timeout branch fires; either way status is 1
+    [[ "$status" -eq 1 ]]
+}
+
+# ---------------------------------------------------------------------------
+# Case-insensitivity tests
+# ---------------------------------------------------------------------------
+
+@test "confirm_with_timeout: 'yEs' is accepted as yes" {
+    run bash -c "
+        source '${PROMPT_LIB}'
+        echo yEs | confirm_with_timeout 'Proceed? [y/N]'
+    "
+    [[ "$status" -eq 0 ]]
+}
+
+@test "confirm_with_timeout: 'yup' is NOT accepted (only y* where first char is y)" {
+    run bash -c "
+        source '${PROMPT_LIB}'
+        echo yup | confirm_with_timeout 'Proceed? [y/N]'
+    "
+    # 'yup' starts with y → matches y* → returns 0
+    [[ "$status" -eq 0 ]]
+}
+
+@test "confirm_with_timeout: 'nope' returns 1" {
+    run bash -c "
+        source '${PROMPT_LIB}'
+        echo nope | confirm_with_timeout 'Proceed? [y/N]'
+    "
+    [[ "$status" -eq 1 ]]
+}

--- a/tools/reconciler/tests/unit/test_reconcile.bats
+++ b/tools/reconciler/tests/unit/test_reconcile.bats
@@ -1,0 +1,267 @@
+#!/usr/bin/env bats
+# tests/unit/test_reconcile.bats — unit tests for scripts/lib/reconcile.sh
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+FIXTURES_DIR="${SCRIPT_DIR}/tests/fixtures"
+
+# Source reconcile.sh before each test (without api.sh dependency)
+setup() {
+    # Stub out api.sh sourcing to avoid connection errors
+    export AGAMEMNON_URL="http://localhost:19999"
+    # shellcheck source=/dev/null
+    source "${SCRIPT_DIR}/scripts/lib/reconcile.sh"
+}
+
+# ---------------------------------------------------------------------------
+# normalize_path
+# ---------------------------------------------------------------------------
+
+@test "normalize_path: expands tilde to HOME" {
+    # shellcheck disable=SC2088
+    result="$(normalize_path '~/Projects/foo')"
+    [[ "$result" == "${HOME}/Projects/foo" ]]
+}
+
+@test "normalize_path: leaves absolute path unchanged" {
+    result="$(normalize_path "/absolute/path")"
+    [[ "$result" == "/absolute/path" ]]
+}
+
+@test "normalize_path: leaves empty string as empty" {
+    result="$(normalize_path "")"
+    [[ "$result" == "" ]]
+}
+
+@test "normalize_path: does not expand tilde in the middle of path" {
+    result="$(normalize_path "/home/user/~/foo")"
+    [[ "$result" == "/home/user/~/foo" ]]
+}
+
+# ---------------------------------------------------------------------------
+# parse_agent_yaml
+# ---------------------------------------------------------------------------
+
+@test "parse_agent_yaml: parses all fields from valid agent YAML" {
+    output="$(parse_agent_yaml "${FIXTURES_DIR}/agent-valid.yaml")"
+    [[ "$output" == *"name=test-agent"* ]]
+    [[ "$output" == *"host=hermes"* ]]
+    [[ "$output" == *"label=Test Agent"* ]]
+    [[ "$output" == *"program=claude-code"* ]]
+    [[ "$output" == *"workingDirectory=/home/mvillmow/TestProject"* ]]
+    [[ "$output" == *"programArgs=--verbose"* ]]
+    [[ "$output" == *"desiredState=active"* ]]
+    [[ "$output" == *"deploymentType=local"* ]]
+}
+
+@test "parse_agent_yaml: parses tags as comma-separated string" {
+    output="$(parse_agent_yaml "${FIXTURES_DIR}/agent-valid.yaml")"
+    # tags should be joined with commas
+    [[ "$output" == *"tags="* ]]
+    tags_line="$(echo "$output" | grep '^tags=')"
+    [[ "$tags_line" == *"testing"* ]]
+    [[ "$tags_line" == *"ci"* ]]
+}
+
+@test "parse_agent_yaml: handles missing optional fields with defaults" {
+    output="$(parse_agent_yaml "${FIXTURES_DIR}/agent-minimal.yaml")"
+    [[ "$output" == *"name=minimal-agent"* ]]
+    [[ "$output" == *"desiredState=active"* ]]
+    [[ "$output" == *"deploymentType=local"* ]]
+    [[ "$output" == *"role=member"* ]]
+}
+
+@test "parse_agent_yaml: parses hibernated desiredState" {
+    output="$(parse_agent_yaml "${FIXTURES_DIR}/agent-hibernated.yaml")"
+    [[ "$output" == *"desiredState=hibernated"* ]]
+}
+
+@test "parse_agent_yaml: parses docker deployment fields" {
+    output="$(parse_agent_yaml "${FIXTURES_DIR}/agent-docker.yaml")"
+    [[ "$output" == *"deploymentType=docker"* ]]
+    [[ "$output" == *"dockerImage=my-claude:latest"* ]]
+    [[ "$output" == *"dockerCpus=2"* ]]
+    [[ "$output" == *"dockerMemory=4g"* ]]
+}
+
+@test "parse_agent_yaml: empty tags field when no tags defined" {
+    output="$(parse_agent_yaml "${FIXTURES_DIR}/agent-no-tags.yaml")"
+    tags_line="$(echo "$output" | grep '^tags=')"
+    # Should be tags= with empty value
+    [[ "$tags_line" == "tags=" ]]
+}
+
+# ---------------------------------------------------------------------------
+# build_create_json
+# ---------------------------------------------------------------------------
+
+@test "build_create_json: produces valid JSON" {
+    result="$(build_create_json "my-agent" "My Agent" "claude-code" "/home/user/proj" "" "Does stuff" "ai,ops" "mvillmow" "member")"
+    echo "$result" | jq . > /dev/null  # fails if invalid JSON
+}
+
+@test "build_create_json: sets name field correctly" {
+    result="$(build_create_json "my-agent" "My Agent" "claude-code" "/home/user/proj" "" "Does stuff" "" "mvillmow" "member")"
+    name="$(echo "$result" | jq -r '.name')"
+    [[ "$name" == "my-agent" ]]
+}
+
+@test "build_create_json: sets program field correctly" {
+    result="$(build_create_json "agent" "Agent" "aider" "/tmp" "" "" "" "user" "member")"
+    prog="$(echo "$result" | jq -r '.program')"
+    [[ "$prog" == "aider" ]]
+}
+
+@test "build_create_json: converts CSV tags to JSON array" {
+    result="$(build_create_json "agent" "Agent" "prog" "/tmp" "" "" "tag1,tag2,tag3" "user" "member")"
+    tags="$(echo "$result" | jq -r '.tags | length')"
+    [[ "$tags" == "3" ]]
+    [[ "$(echo "$result" | jq -r '.tags[0]')" == "tag1" ]]
+    [[ "$(echo "$result" | jq -r '.tags[1]')" == "tag2" ]]
+    [[ "$(echo "$result" | jq -r '.tags[2]')" == "tag3" ]]
+}
+
+@test "build_create_json: produces empty array for empty tags" {
+    result="$(build_create_json "agent" "Agent" "prog" "/tmp" "" "" "" "user" "member")"
+    tags="$(echo "$result" | jq -r '.tags | length')"
+    [[ "$tags" == "0" ]]
+}
+
+@test "build_create_json: handles programArgs with special characters" {
+    result="$(build_create_json "agent" "Agent" "prog" "/tmp" "--flag value" "" "" "user" "member")"
+    args="$(echo "$result" | jq -r '.programArgs')"
+    [[ "$args" == "--flag value" ]]
+}
+
+@test "build_create_json: sets workingDirectory" {
+    result="$(build_create_json "agent" "Agent" "prog" "/home/user/myproject" "" "" "" "user" "member")"
+    workdir="$(echo "$result" | jq -r '.workingDirectory')"
+    [[ "$workdir" == "/home/user/myproject" ]]
+}
+
+@test "build_create_json: sets owner and role" {
+    result="$(build_create_json "agent" "Agent" "prog" "/tmp" "" "" "" "alice" "admin")"
+    owner="$(echo "$result" | jq -r '.owner')"
+    role="$(echo "$result" | jq -r '.role')"
+    [[ "$owner" == "alice" ]]
+    [[ "$role" == "admin" ]]
+}
+
+# ---------------------------------------------------------------------------
+# compute_drift
+# ---------------------------------------------------------------------------
+
+# Helper to build a minimal actual_json
+_make_actual() {
+    # Note: $label is a reserved keyword in jq 1.6; use $lbl to avoid parser conflict.
+    # Use explicit positional args to avoid bash ${:-} collapsing empty strings to defaults.
+    jq -n \
+        --arg status "$1" \
+        --arg lbl "$2" \
+        --arg program "$3" \
+        --arg workingDirectory "$4" \
+        --arg programArgs "$5" \
+        --arg taskDescription "$6" \
+        --argjson tags "$7" \
+        '{status: $status, label: $lbl, program: $program,
+          workingDirectory: $workingDirectory, programArgs: $programArgs,
+          taskDescription: $taskDescription, tags: $tags}'
+}
+
+@test "compute_drift: UNCHANGED when all fields match and agent is active" {
+    actual="$(_make_actual "active" "Test Agent" "claude-code" "/home/mvillmow/TestProject" "" "A test agent" '["ci","testing"]')"
+    result="$(compute_drift "test-agent" "active" "$actual" "Test Agent" "claude-code" "/home/mvillmow/TestProject" "" "A test agent" "ci,testing" "" "" "" "local")"
+    [[ "$result" == "UNCHANGED" ]]
+}
+
+@test "compute_drift: UNCHANGED when hibernated agent matches hibernated desired state" {
+    actual="$(_make_actual "offline" "Sleeping" "aider" "/tmp/proj" "" "" '[]')"
+    result="$(compute_drift "sleep-agent" "hibernated" "$actual" "Sleeping" "aider" "/tmp/proj" "" "" "" "" "" "" "local")"
+    [[ "$result" == "UNCHANGED" ]]
+}
+
+@test "compute_drift: WAKE when desired=active and actual status=offline" {
+    actual="$(_make_actual "offline" "Agent" "claude-code" "/tmp" "" "" '[]')"
+    result="$(compute_drift "agent" "active" "$actual" "Agent" "claude-code" "/tmp" "" "" "" "" "" "" "local")"
+    [[ "$result" == "WAKE" ]]
+}
+
+@test "compute_drift: HIBERNATE when desired=hibernated and actual status=active" {
+    actual="$(_make_actual "active" "Agent" "claude-code" "/tmp" "" "" '[]')"
+    result="$(compute_drift "agent" "hibernated" "$actual" "Agent" "claude-code" "/tmp" "" "" "" "" "" "" "local")"
+    [[ "$result" == "HIBERNATE" ]]
+}
+
+@test "compute_drift: HIBERNATE when desired=hibernated and actual status=online" {
+    actual="$(_make_actual "online" "Agent" "claude-code" "/tmp" "" "" '[]')"
+    result="$(compute_drift "agent" "hibernated" "$actual" "Agent" "claude-code" "/tmp" "" "" "" "" "" "" "local")"
+    [[ "$result" == "HIBERNATE" ]]
+}
+
+@test "compute_drift: UPDATE when label differs" {
+    actual="$(_make_actual "active" "Old Label" "claude-code" "/tmp" "" "" '[]')"
+    result="$(compute_drift "agent" "active" "$actual" "New Label" "claude-code" "/tmp" "" "" "" "" "" "" "local")"
+    [[ "$result" == UPDATE:* ]]
+    [[ "$result" == *"label"* ]]
+}
+
+@test "compute_drift: UPDATE when program differs" {
+    actual="$(_make_actual "active" "Agent" "claude-code" "/tmp" "" "" '[]')"
+    result="$(compute_drift "agent" "active" "$actual" "Agent" "aider" "/tmp" "" "" "" "" "" "" "local")"
+    [[ "$result" == UPDATE:* ]]
+    [[ "$result" == *"program"* ]]
+}
+
+@test "compute_drift: UPDATE when workingDirectory differs" {
+    actual="$(_make_actual "active" "Agent" "claude-code" "/old/path" "" "" '[]')"
+    result="$(compute_drift "agent" "active" "$actual" "Agent" "claude-code" "/new/path" "" "" "" "" "" "" "local")"
+    [[ "$result" == UPDATE:* ]]
+    [[ "$result" == *"workingDirectory"* ]]
+}
+
+@test "compute_drift: UPDATE when programArgs differs" {
+    actual="$(_make_actual "active" "Agent" "claude-code" "/tmp" "--old" "" '[]')"
+    result="$(compute_drift "agent" "active" "$actual" "Agent" "claude-code" "/tmp" "--new" "" "" "" "" "" "local")"
+    [[ "$result" == UPDATE:* ]]
+    [[ "$result" == *"programArgs"* ]]
+}
+
+@test "compute_drift: UPDATE when taskDescription differs" {
+    actual="$(_make_actual "active" "Agent" "claude-code" "/tmp" "" "Old description" '[]')"
+    result="$(compute_drift "agent" "active" "$actual" "Agent" "claude-code" "/tmp" "" "New description" "" "" "" "" "local")"
+    [[ "$result" == UPDATE:* ]]
+    [[ "$result" == *"taskDescription"* ]]
+}
+
+@test "compute_drift: UPDATE when tags differ" {
+    actual="$(_make_actual "active" "Agent" "claude-code" "/tmp" "" "" '["tag1"]')"
+    result="$(compute_drift "agent" "active" "$actual" "Agent" "claude-code" "/tmp" "" "" "tag1,tag2" "" "" "" "local")"
+    [[ "$result" == UPDATE:* ]]
+    [[ "$result" == *"tags"* ]]
+}
+
+@test "compute_drift: UPDATE lists all drifted fields" {
+    actual="$(_make_actual "active" "Old Label" "old-prog" "/tmp" "" "" '[]')"
+    result="$(compute_drift "agent" "active" "$actual" "New Label" "new-prog" "/tmp" "" "" "" "" "" "" "local")"
+    [[ "$result" == UPDATE:* ]]
+    [[ "$result" == *"label"* ]]
+    [[ "$result" == *"program"* ]]
+}
+
+@test "compute_drift: UNCHANGED when tags are in different order (sorted comparison)" {
+    actual="$(_make_actual "active" "Agent" "claude-code" "/tmp" "" "" '["beta","alpha"]')"
+    result="$(compute_drift "agent" "active" "$actual" "Agent" "claude-code" "/tmp" "" "" "alpha,beta" "" "" "" "local")"
+    [[ "$result" == "UNCHANGED" ]]
+}
+
+@test "compute_drift: UNCHANGED when workingDirectory uses tilde and actual uses full path" {
+    actual="$(_make_actual "active" "Agent" "claude-code" "${HOME}/Projects" "" "" '[]')"
+    # shellcheck disable=SC2088
+    result="$(compute_drift "agent" "active" "$actual" "Agent" "claude-code" '~/Projects' "" "" "" "" "" "" "local")"
+    [[ "$result" == "UNCHANGED" ]]
+}
+
+@test "compute_drift: UNCHANGED when both tags are empty" {
+    actual="$(_make_actual "active" "Agent" "claude-code" "/tmp" "" "" '[]')"
+    result="$(compute_drift "agent" "active" "$actual" "Agent" "claude-code" "/tmp" "" "" "" "" "" "" "local")"
+    [[ "$result" == "UNCHANGED" ]]
+}

--- a/tools/reconciler/tests/unit/test_record_failure.bats
+++ b/tools/reconciler/tests/unit/test_record_failure.bats
@@ -1,0 +1,177 @@
+#!/usr/bin/env bats
+# tests/unit/test_record_failure.bats — unit tests for record_failure() and print_error_summary()
+#
+# Tests verify the FAILED_AGENTS_INFO structured-string approach introduced in #394:
+# - record_failure() appends "name\x01http_status\x01message" entries
+# - print_error_summary() parses and formats those entries correctly
+
+# ---------------------------------------------------------------------------
+# Helper: source record_failure and print_error_summary from apply.sh
+# We extract only the two functions plus the required globals to avoid
+# sourcing the entire script (which has side effects).
+# ---------------------------------------------------------------------------
+
+_load_functions() {
+    # Variables that apply.sh expects to exist
+    ERRORS=0
+    FAILED_AGENTS_INFO=()
+    # shellcheck disable=SC2034
+    FAILED_AGENTS_FILE="/tmp/failed-agents.txt"
+
+    # Source only the two functions via eval (extract between markers)
+    # shellcheck disable=SC1090
+    eval "$(sed -n '/^record_failure()/,/^}/p' "${BATS_TEST_DIRNAME}/../../scripts/apply.sh")"
+    # shellcheck disable=SC1090
+    eval "$(sed -n '/^print_error_summary()/,/^}/p' "${BATS_TEST_DIRNAME}/../../scripts/apply.sh")"
+}
+
+setup() {
+    _load_functions
+}
+
+# ---------------------------------------------------------------------------
+# record_failure — array population
+# ---------------------------------------------------------------------------
+
+@test "record_failure: FAILED_AGENTS_INFO starts empty" {
+    [[ "${#FAILED_AGENTS_INFO[@]}" -eq 0 ]]
+}
+
+@test "record_failure: increments ERRORS" {
+    record_failure "agent-a" "404" "not found"
+    [[ "$ERRORS" -eq 1 ]]
+}
+
+@test "record_failure: appends one entry to FAILED_AGENTS_INFO" {
+    record_failure "agent-a" "404" "not found"
+    [[ "${#FAILED_AGENTS_INFO[@]}" -eq 1 ]]
+}
+
+@test "record_failure: entry contains name, status, and message" {
+    record_failure "agent-a" "404" "not found"
+    local entry="${FAILED_AGENTS_INFO[0]}"
+    local sep=$'\x01'
+    IFS="$sep" read -r name status msg <<< "$entry"
+    [[ "$name"   == "agent-a"   ]]
+    [[ "$status" == "404"       ]]
+    [[ "$msg"    == "not found" ]]
+}
+
+@test "record_failure: multiple calls produce multiple entries in order" {
+    record_failure "agent-a" "404" "not found"
+    record_failure "agent-b" "500" "server error"
+    [[ "${#FAILED_AGENTS_INFO[@]}" -eq 2 ]]
+    local sep=$'\x01'
+    IFS="$sep" read -r n1 s1 m1 <<< "${FAILED_AGENTS_INFO[0]}"
+    IFS="$sep" read -r n2 s2 m2 <<< "${FAILED_AGENTS_INFO[1]}"
+    [[ "$n1" == "agent-a" ]] && [[ "$s1" == "404" ]] && [[ "$m1" == "not found" ]]
+    [[ "$n2" == "agent-b" ]] && [[ "$s2" == "500" ]] && [[ "$m2" == "server error" ]]
+}
+
+@test "record_failure: ERRORS accumulates across multiple calls" {
+    record_failure "agent-a" "404" "not found"
+    record_failure "agent-b" "500" "server error"
+    record_failure "agent-c" "503" "unavailable"
+    [[ "$ERRORS" -eq 3 ]]
+}
+
+@test "record_failure: empty http_status stored and retrievable" {
+    record_failure "agent-b" "" "timeout"
+    local sep=$'\x01'
+    IFS="$sep" read -r name status msg <<< "${FAILED_AGENTS_INFO[0]}"
+    [[ "$name"   == "agent-b" ]]
+    [[ "$status" == ""        ]]
+    [[ "$msg"    == "timeout" ]]
+}
+
+@test "record_failure: empty error_message stored and retrievable" {
+    record_failure "agent-c" "500" ""
+    local sep=$'\x01'
+    IFS="$sep" read -r name status msg <<< "${FAILED_AGENTS_INFO[0]}"
+    [[ "$name"   == "agent-c" ]]
+    [[ "$status" == "500"     ]]
+    [[ "$msg"    == ""        ]]
+}
+
+@test "record_failure: message with pipe character is stored safely" {
+    record_failure "agent-d" "500" "Failed to update fields [label|program]"
+    local sep=$'\x01'
+    IFS="$sep" read -r name status msg <<< "${FAILED_AGENTS_INFO[0]}"
+    [[ "$name"   == "agent-d"                                    ]]
+    [[ "$status" == "500"                                        ]]
+    [[ "$msg"    == "Failed to update fields [label|program]"    ]]
+}
+
+# ---------------------------------------------------------------------------
+# print_error_summary — output formatting
+# ---------------------------------------------------------------------------
+
+@test "print_error_summary: prints FAIL tag for single failure" {
+    record_failure "agent-a" "404" "not found"
+    ERRORS=1
+    run print_error_summary
+    [[ "${output}" == *"[FAIL] agent-a"* ]]
+}
+
+@test "print_error_summary: includes HTTP status line when present" {
+    record_failure "agent-a" "404" "not found"
+    ERRORS=1
+    run print_error_summary
+    [[ "${output}" == *"HTTP status: 404"* ]]
+}
+
+@test "print_error_summary: includes error message line when present" {
+    record_failure "agent-a" "404" "not found"
+    ERRORS=1
+    run print_error_summary
+    [[ "${output}" == *"Error: not found"* ]]
+}
+
+@test "print_error_summary: omits HTTP status line when empty" {
+    record_failure "agent-b" "" "timeout"
+    ERRORS=1
+    run print_error_summary
+    [[ "${output}" != *"HTTP status:"* ]]
+}
+
+@test "print_error_summary: omits error line when message is empty" {
+    record_failure "agent-c" "500" ""
+    ERRORS=1
+    run print_error_summary
+    [[ "${output}" != *"Error:"* ]]
+}
+
+@test "print_error_summary: prints all failures for multiple entries" {
+    record_failure "agent-a" "404" "not found"
+    record_failure "agent-b" "500" "server error"
+    ERRORS=2
+    run print_error_summary
+    [[ "${output}" == *"[FAIL] agent-a"* ]]
+    [[ "${output}" == *"[FAIL] agent-b"* ]]
+}
+
+@test "print_error_summary: prints failures in insertion order" {
+    record_failure "first-agent"  "400" "bad request"
+    record_failure "second-agent" "500" "server error"
+    ERRORS=2
+    run print_error_summary
+    local first_pos second_pos
+    first_pos=$(echo "$output" | grep -n "first-agent"  | head -1 | cut -d: -f1)
+    second_pos=$(echo "$output" | grep -n "second-agent" | head -1 | cut -d: -f1)
+    [[ "$first_pos" -lt "$second_pos" ]]
+}
+
+@test "print_error_summary: FAILED AGENTS count matches ERRORS" {
+    record_failure "agent-a" "404" "not found"
+    record_failure "agent-b" "500" "server error"
+    ERRORS=2
+    run print_error_summary
+    [[ "${output}" == *"FAILED AGENTS (2)"* ]]
+}
+
+@test "print_error_summary: message with pipe character renders correctly" {
+    record_failure "agent-d" "500" "Failed to update fields [label|program]"
+    ERRORS=1
+    run print_error_summary
+    [[ "${output}" == *"Error: Failed to update fields [label|program]"* ]]
+}

--- a/tools/reconciler/tests/unit/test_snapshot_dir_guard.bats
+++ b/tools/reconciler/tests/unit/test_snapshot_dir_guard.bats
@@ -1,0 +1,150 @@
+#!/usr/bin/env bats
+# tests/unit/test_snapshot_dir_guard.bats — unit tests for _guard_snapshot_dir()
+#
+# Issue #391: guard snapshot dir against root-filesystem writes at runtime.
+# Tests cover all four conditions:
+#   1. Normal derived path inside repo  → passes
+#   2. Derived path resolves to /.myrmidons/snapshots (REPO_ROOT empty) → aborts
+#   3. Derived path is outside repo tree for another reason → aborts
+#   4. SNAPSHOT_DIR explicitly set to a path outside repo → passes (user override)
+
+# shellcheck disable=SC2034
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+
+# ---------------------------------------------------------------------------
+# Helper: run _guard_snapshot_dir in an isolated subshell.
+#
+# Usage: _run_guard <dir> <explicitly_set> [REPO_ROOT_OVERRIDE]
+#   <dir>             the effective_snapshot_dir value to test
+#   <explicitly_set>  "set" or "" to simulate ${SNAPSHOT_DIR:+set}
+#   REPO_ROOT_OVERRIDE (optional) value for REPO_ROOT inside the subshell
+# ---------------------------------------------------------------------------
+_run_guard() {
+    local dir="$1"
+    local explicitly_set="$2"
+    local repo_root="${3:-/home/user/myrepo}"
+
+    bash -c "
+        REPO_ROOT='${repo_root}'
+        $(declare -f _guard_snapshot_dir 2>/dev/null || true)
+
+        # Inline the function definition so we don't need to source apply.sh
+        _guard_snapshot_dir() {
+            local dir=\"\$1\"
+            local explicitly_set=\"\${2:-}\"
+
+            if [[ \"\$dir\" == '/.myrmidons/snapshots' ]]; then
+                echo \"ERROR: snapshot dir resolved to '/.myrmidons/snapshots'.\" >&2
+                echo \"  This usually means REPO_ROOT is empty or unset.\" >&2
+                echo \"  Set SNAPSHOT_DIR explicitly or ensure REPO_ROOT is defined.\" >&2
+                exit 1
+            fi
+
+            local repo_root_stripped=\"\${REPO_ROOT%/}\"
+            if [[ -z \"\$explicitly_set\" && \"\$dir\" != \"\${repo_root_stripped}\"/* ]]; then
+                echo \"ERROR: snapshot dir '\${dir}' is outside the repo tree '\${REPO_ROOT}'.\" >&2
+                echo \"  REPO_ROOT may be empty or unset. Set SNAPSHOT_DIR explicitly to override.\" >&2
+                exit 1
+            fi
+        }
+
+        _guard_snapshot_dir '${dir}' '${explicitly_set}'
+    " 2>&1
+}
+
+# ---------------------------------------------------------------------------
+# Case 1: Normal derived path inside repo — must pass silently
+# ---------------------------------------------------------------------------
+
+@test "_guard_snapshot_dir: derived path inside repo passes" {
+    run _run_guard "/home/user/myrepo/.myrmidons/snapshots" "" "/home/user/myrepo"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "_guard_snapshot_dir: derived path in a subdirectory of repo passes" {
+    run _run_guard "/home/user/myrepo/reports/snapshots" "" "/home/user/myrepo"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+# ---------------------------------------------------------------------------
+# Case 2: REPO_ROOT empty → resolves to /.myrmidons/snapshots — must abort
+# ---------------------------------------------------------------------------
+
+@test "_guard_snapshot_dir: /.myrmidons/snapshots always rejected (REPO_ROOT empty)" {
+    run _run_guard "/.myrmidons/snapshots" "" ""
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"/.myrmidons/snapshots"* ]]
+}
+
+@test "_guard_snapshot_dir: /.myrmidons/snapshots rejected even when explicitly set" {
+    # This path is never safe, regardless of how it was derived.
+    run _run_guard "/.myrmidons/snapshots" "set" ""
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"/.myrmidons/snapshots"* ]]
+}
+
+@test "_guard_snapshot_dir: error message mentions REPO_ROOT for /.myrmidons/snapshots" {
+    run _run_guard "/.myrmidons/snapshots" "" ""
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"REPO_ROOT"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Case 3: Derived path outside repo for another reason — must abort
+# ---------------------------------------------------------------------------
+
+@test "_guard_snapshot_dir: derived path outside repo tree is rejected" {
+    run _run_guard "/tmp/snapshots" "" "/home/user/myrepo"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"outside the repo tree"* ]]
+}
+
+@test "_guard_snapshot_dir: derived /var/tmp path is rejected" {
+    run _run_guard "/var/tmp/.myrmidons/snapshots" "" "/home/user/myrepo"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"outside the repo tree"* ]]
+}
+
+@test "_guard_snapshot_dir: error message includes the bad dir and REPO_ROOT" {
+    run _run_guard "/tmp/snapshots" "" "/home/user/myrepo"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"/tmp/snapshots"* ]]
+    [[ "$output" == *"/home/user/myrepo"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Case 4: SNAPSHOT_DIR explicitly set to outside repo — must pass (user override)
+# ---------------------------------------------------------------------------
+
+@test "_guard_snapshot_dir: explicit SNAPSHOT_DIR outside repo is allowed" {
+    run _run_guard "/mnt/backup/snapshots" "set" "/home/user/myrepo"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "_guard_snapshot_dir: explicit SNAPSHOT_DIR in /tmp is allowed" {
+    run _run_guard "/tmp/my-snapshots" "set" "/home/user/myrepo"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+# ---------------------------------------------------------------------------
+# Case 5 (#487): REPO_ROOT with trailing slash must still match in-repo paths
+# ---------------------------------------------------------------------------
+
+@test "_guard_snapshot_dir: REPO_ROOT with trailing slash accepts in-repo path" {
+    # Without the ${REPO_ROOT%/} strip, the glob "/home/user/myrepo//*" would not
+    # match "/home/user/myrepo/.myrmidons/snapshots" and the guard would falsely
+    # report an out-of-repo path.
+    run _run_guard "/home/user/myrepo/.myrmidons/snapshots" "" "/home/user/myrepo/"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "_guard_snapshot_dir: REPO_ROOT with trailing slash still rejects out-of-repo path" {
+    run _run_guard "/tmp/snapshots" "" "/home/user/myrepo/"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"outside the repo tree"* ]]
+}

--- a/tools/reconciler/tests/unit/test_snapshot_dir_resolution.bats
+++ b/tools/reconciler/tests/unit/test_snapshot_dir_resolution.bats
@@ -1,0 +1,96 @@
+#!/usr/bin/env bats
+bats_require_minimum_version 1.5.0
+# tests/unit/test_snapshot_dir_resolution.bats
+#
+# Runtime regression test for issue #390: effective_snapshot_dir resolves to
+# ${REPO_ROOT}/.myrmidons/snapshots when SNAPSHOT_DIR is unset.
+#
+# The static grep check in test_default_snapshot_dir_uses_repo_root verifies
+# source text; these tests exercise the actual runtime resolution path and
+# catch regressions such as variable name typos or logic errors.
+
+# shellcheck disable=SC2034
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+
+setup() {
+    # Controlled REPO_ROOT — never touch the real repo root
+    REPO_ROOT="$(mktemp -d)"
+    export REPO_ROOT
+
+    # File where mock snapshot_write records the snapshot_dir argument it received
+    MOCK_CAPTURE="${BATS_TMPDIR}/captured_snapshot_dir_$$"
+    export MOCK_CAPTURE
+
+    # Ensure SNAPSHOT_DIR is NOT inherited from the caller's environment
+    unset SNAPSHOT_DIR
+}
+
+teardown() {
+    rm -rf "${REPO_ROOT:-}"
+    rm -f "${MOCK_CAPTURE:-}"
+}
+
+# ---------------------------------------------------------------------------
+# Helper: resolve effective_snapshot_dir using the same expression as apply.sh
+# line 507, then invoke the mock snapshot_write with it.
+# ---------------------------------------------------------------------------
+
+_run_resolution() {
+    # shellcheck disable=SC2034
+    local snapshot_write
+    snapshot_write() {
+        local _agents_json="$1"
+        local snapshot_dir="$2"
+        echo "$snapshot_dir" > "${MOCK_CAPTURE}"
+    }
+
+    local effective_snapshot_dir="${SNAPSHOT_DIR:-${REPO_ROOT}/.myrmidons/snapshots}"
+    snapshot_write '[]' "$effective_snapshot_dir" "all"
+}
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+@test "effective_snapshot_dir resolves to REPO_ROOT/.myrmidons/snapshots when SNAPSHOT_DIR unset" {
+    unset SNAPSHOT_DIR
+
+    _run_resolution
+
+    run cat "${MOCK_CAPTURE}"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == "${REPO_ROOT}/.myrmidons/snapshots" ]]
+}
+
+@test "effective_snapshot_dir resolves to REPO_ROOT/.myrmidons/snapshots when SNAPSHOT_DIR is empty string" {
+    export SNAPSHOT_DIR=""
+
+    _run_resolution
+
+    run cat "${MOCK_CAPTURE}"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == "${REPO_ROOT}/.myrmidons/snapshots" ]]
+}
+
+@test "effective_snapshot_dir uses SNAPSHOT_DIR override when set" {
+    local custom_dir="${BATS_TMPDIR}/custom-snapshots-$$"
+    export SNAPSHOT_DIR="$custom_dir"
+
+    _run_resolution
+
+    run cat "${MOCK_CAPTURE}"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == "$custom_dir" ]]
+}
+
+@test "effective_snapshot_dir does not use REPO_ROOT when SNAPSHOT_DIR is set" {
+    local custom_dir="${BATS_TMPDIR}/override-snapshots-$$"
+    export SNAPSHOT_DIR="$custom_dir"
+
+    _run_resolution
+
+    run cat "${MOCK_CAPTURE}"
+    [[ "$status" -eq 0 ]]
+    # Must NOT fall back to REPO_ROOT path
+    [[ "$output" != "${REPO_ROOT}/.myrmidons/snapshots" ]]
+}

--- a/tools/reconciler/tests/unit/test_tls.bats
+++ b/tools/reconciler/tests/unit/test_tls.bats
@@ -1,0 +1,121 @@
+#!/usr/bin/env bats
+# tests/unit/test_tls.bats — unit tests for TLS flag wiring in scripts/lib/api.sh
+#
+# Tests the _agamemnon_build_tls_flags() function and its integration with curl.
+# Covers edge cases: no TLS vars, TLS_VERIFY=false warning, all vars set,
+# and asymmetric cert/key configuration.
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+
+setup() {
+    # Unset all TLS-related variables before each test
+    unset AGAMEMNON_TLS_VERIFY
+    unset AGAMEMNON_CA_CERT
+    unset AGAMEMNON_CLIENT_CERT
+    unset AGAMEMNON_CLIENT_KEY
+    unset AGAMEMNON_API_KEY
+
+    # Set a default URL for testing
+    export AGAMEMNON_URL="http://127.0.0.1:18080"
+
+    # shellcheck source=/dev/null
+    source "${SCRIPT_DIR}/scripts/lib/api.sh"
+}
+
+teardown() {
+    unset AGAMEMNON_TLS_VERIFY
+    unset AGAMEMNON_CA_CERT
+    unset AGAMEMNON_CLIENT_CERT
+    unset AGAMEMNON_CLIENT_KEY
+    unset AGAMEMNON_API_KEY
+}
+
+# ---------------------------------------------------------------------------
+# _agamemnon_build_tls_flags tests
+# ---------------------------------------------------------------------------
+
+@test "_agamemnon_build_tls_flags: produces empty array when no TLS vars are set" {
+    _agamemnon_build_tls_flags
+    # Array should be empty; length via ${#array[@]} should be 0
+    [[ ${#_AGAMEMNON_TLS_FLAGS[@]} -eq 0 ]]
+}
+
+@test "_agamemnon_build_tls_flags: adds --insecure when AGAMEMNON_TLS_VERIFY=false" {
+    export AGAMEMNON_TLS_VERIFY="false"
+    _agamemnon_build_tls_flags
+    # Check that --insecure is in the array
+    [[ " ${_AGAMEMNON_TLS_FLAGS[*]} " == *" --insecure "* ]]
+}
+
+@test "_agamemnon_build_tls_flags: emits warning to stderr when AGAMEMNON_TLS_VERIFY=false" {
+    export AGAMEMNON_TLS_VERIFY="false"
+    # Capture stderr during test setup
+    run bash -c "source ${SCRIPT_DIR}/scripts/lib/api.sh 2>&1"
+    [[ "$output" == *"WARNING"* ]]
+    [[ "$output" == *"TLS verification is DISABLED"* ]]
+}
+
+@test "_agamemnon_build_tls_flags: adds --insecure when AGAMEMNON_TLS_VERIFY=0" {
+    export AGAMEMNON_TLS_VERIFY="0"
+    _agamemnon_build_tls_flags
+    [[ " ${_AGAMEMNON_TLS_FLAGS[*]} " == *" --insecure "* ]]
+}
+
+@test "_agamemnon_build_tls_flags: adds --cacert when AGAMEMNON_CA_CERT is set" {
+    export AGAMEMNON_CA_CERT="/path/to/ca-bundle.pem"
+    _agamemnon_build_tls_flags
+    # Check for both --cacert and the path
+    [[ " ${_AGAMEMNON_TLS_FLAGS[*]} " == *" --cacert "* ]]
+    [[ " ${_AGAMEMNON_TLS_FLAGS[*]} " == *"/path/to/ca-bundle.pem"* ]]
+}
+
+@test "_agamemnon_build_tls_flags: adds --cert when AGAMEMNON_CLIENT_CERT is set" {
+    export AGAMEMNON_CLIENT_CERT="/path/to/client-cert.pem"
+    _agamemnon_build_tls_flags
+    [[ " ${_AGAMEMNON_TLS_FLAGS[*]} " == *" --cert "* ]]
+    [[ " ${_AGAMEMNON_TLS_FLAGS[*]} " == *"/path/to/client-cert.pem"* ]]
+}
+
+@test "_agamemnon_build_tls_flags: adds --key when AGAMEMNON_CLIENT_KEY is set" {
+    export AGAMEMNON_CLIENT_KEY="/path/to/client-key.pem"
+    _agamemnon_build_tls_flags
+    [[ " ${_AGAMEMNON_TLS_FLAGS[*]} " == *" --key "* ]]
+    [[ " ${_AGAMEMNON_TLS_FLAGS[*]} " == *"/path/to/client-key.pem"* ]]
+}
+
+@test "_agamemnon_build_tls_flags: includes all four flags when all TLS vars are set" {
+    export AGAMEMNON_TLS_VERIFY="false"
+    export AGAMEMNON_CA_CERT="/path/to/ca-bundle.pem"
+    export AGAMEMNON_CLIENT_CERT="/path/to/client-cert.pem"
+    export AGAMEMNON_CLIENT_KEY="/path/to/client-key.pem"
+    _agamemnon_build_tls_flags
+    # Verify all four flags are present
+    [[ " ${_AGAMEMNON_TLS_FLAGS[*]} " == *" --insecure "* ]]
+    [[ " ${_AGAMEMNON_TLS_FLAGS[*]} " == *" --cacert "* ]]
+    [[ " ${_AGAMEMNON_TLS_FLAGS[*]} " == *" --cert "* ]]
+    [[ " ${_AGAMEMNON_TLS_FLAGS[*]} " == *" --key "* ]]
+    # Also check that the paths are preserved
+    [[ " ${_AGAMEMNON_TLS_FLAGS[*]} " == *"/path/to/ca-bundle.pem"* ]]
+    [[ " ${_AGAMEMNON_TLS_FLAGS[*]} " == *"/path/to/client-cert.pem"* ]]
+    [[ " ${_AGAMEMNON_TLS_FLAGS[*]} " == *"/path/to/client-key.pem"* ]]
+}
+
+@test "_agamemnon_build_tls_flags: handles CLIENT_CERT without CLIENT_KEY" {
+    export AGAMEMNON_CLIENT_CERT="/path/to/client-cert.pem"
+    # Deliberately not setting CLIENT_KEY
+    _agamemnon_build_tls_flags
+    # Should still have --cert even if KEY is missing
+    [[ " ${_AGAMEMNON_TLS_FLAGS[*]} " == *" --cert "* ]]
+    # Should NOT have --key
+    [[ " ${_AGAMEMNON_TLS_FLAGS[*]} " != *" --key "* ]]
+}
+
+@test "_agamemnon_build_tls_flags: handles CLIENT_KEY without CLIENT_CERT" {
+    export AGAMEMNON_CLIENT_KEY="/path/to/client-key.pem"
+    # Deliberately not setting CLIENT_CERT
+    _agamemnon_build_tls_flags
+    # Should have --key even if CERT is missing
+    [[ " ${_AGAMEMNON_TLS_FLAGS[*]} " == *" --key "* ]]
+    # Should NOT have --cert
+    [[ " ${_AGAMEMNON_TLS_FLAGS[*]} " != *" --cert "* ]]
+}

--- a/tools/reconciler/tests/unit/test_unmanaged.bats
+++ b/tools/reconciler/tests/unit/test_unmanaged.bats
@@ -1,0 +1,176 @@
+#!/usr/bin/env bats
+# tests/unit/test_unmanaged.bats — unit tests for unmanaged agent reporting in reconcile.sh
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+FIXTURES_DIR="${SCRIPT_DIR}/tests/fixtures"
+
+# Source reconcile.sh before each test (without api.sh dependency)
+setup() {
+    # Stub out api.sh sourcing to avoid connection errors
+    export AGAMEMNON_URL="http://localhost:19999"
+    # Mock log_warn to capture output instead of logging
+    log_warn() {
+        echo "$@"
+    }
+    export -f log_warn
+    # shellcheck source=/dev/null
+    source "${SCRIPT_DIR}/scripts/lib/reconcile.sh"
+}
+
+# ---------------------------------------------------------------------------
+# get_unmanaged_names
+# ---------------------------------------------------------------------------
+
+@test "get_unmanaged_names: empty agents_json returns 0 with no output" {
+    result="$(get_unmanaged_names "" "${FIXTURES_DIR}/agent-valid.yaml")" || true
+    [[ -z "$result" ]]
+}
+
+@test "get_unmanaged_names: agents_json='[]' returns 0 with no output" {
+    result="$(get_unmanaged_names "[]" "${FIXTURES_DIR}/agent-valid.yaml")" || true
+    [[ -z "$result" ]]
+}
+
+@test "get_unmanaged_names: single managed agent in both lists produces no output" {
+    # agent-valid.yaml has metadata.name=test-agent
+    local agents_json='[{"name":"test-agent","status":"active"}]'
+    result="$(get_unmanaged_names "$agents_json" "${FIXTURES_DIR}/agent-valid.yaml")" || true
+    [[ -z "$result" ]]
+}
+
+@test "get_unmanaged_names: unmanaged agent in agents_json is reported" {
+    # Create a minimal agents_json with an unmanaged agent
+    local agents_json='[{"name":"unmanaged-agent","status":"active"}]'
+    result="$(get_unmanaged_names "$agents_json" "${FIXTURES_DIR}/agent-valid.yaml")" || true
+    [[ "$result" == "unmanaged-agent" ]]
+}
+
+@test "get_unmanaged_names: multiple unmanaged agents all reported" {
+    local agents_json='[{"name":"unmanaged-1","status":"active"},{"name":"unmanaged-2","status":"active"}]'
+    result="$(get_unmanaged_names "$agents_json" "${FIXTURES_DIR}/agent-valid.yaml")"
+    # Should output both names (order may vary)
+    [[ "$result" == *"unmanaged-1"* ]]
+    [[ "$result" == *"unmanaged-2"* ]]
+}
+
+@test "get_unmanaged_names: mixed managed and unmanaged agents only reports unmanaged" {
+    # agent-valid.yaml has test-agent, agents_json has both test-agent and unmanaged
+    local agents_json='[{"name":"test-agent","status":"active"},{"name":"rogue-agent","status":"active"}]'
+    result="$(get_unmanaged_names "$agents_json" "${FIXTURES_DIR}/agent-valid.yaml")"
+    # Should only output rogue-agent
+    [[ "$result" == "rogue-agent" ]]
+    [[ ! "$result" == *"test-agent"* ]]
+}
+
+@test "get_unmanaged_names: multiple yaml files with mix of managed and unmanaged" {
+    # agent-valid.yaml (test-agent) + agent-minimal.yaml (minimal-agent)
+    # agents_json has both managed + one unmanaged
+    local agents_json='[{"name":"test-agent","status":"active"},{"name":"minimal-agent","status":"active"},{"name":"unknown-agent","status":"active"}]'
+    result="$(get_unmanaged_names "$agents_json" "${FIXTURES_DIR}/agent-valid.yaml" "${FIXTURES_DIR}/agent-minimal.yaml")"
+    # Should only output unknown-agent
+    [[ "$result" == "unknown-agent" ]]
+    [[ ! "$result" == *"test-agent"* ]]
+    [[ ! "$result" == *"minimal-agent"* ]]
+}
+
+@test "get_unmanaged_names: agents_json with null entries does not crash" {
+    # jq should handle null gracefully
+    local agents_json='[{"name":"agent-1","status":"active"},null,{"name":"agent-2","status":"active"}]'
+    # This should not error out; behavior depends on jq's robustness
+    # At minimum, it should process the valid entries
+    result="$(get_unmanaged_names "$agents_json" "${FIXTURES_DIR}/agent-valid.yaml" 2>&1)" || true
+    # If it succeeds, good; if jq complains, we've caught the error
+    true
+}
+
+# ---------------------------------------------------------------------------
+# report_unmanaged
+# ---------------------------------------------------------------------------
+
+@test "report_unmanaged: empty agents_json produces no output" {
+    result="$(report_unmanaged "" "${FIXTURES_DIR}/agent-valid.yaml")" || true
+    [[ -z "$result" ]]
+}
+
+@test "report_unmanaged: agents_json='[]' produces no output" {
+    result="$(report_unmanaged "[]" "${FIXTURES_DIR}/agent-valid.yaml")" || true
+    [[ -z "$result" ]]
+}
+
+@test "report_unmanaged: all agents managed produces no output" {
+    local agents_json='[{"name":"test-agent","status":"active"}]'
+    result="$(report_unmanaged "$agents_json" "${FIXTURES_DIR}/agent-valid.yaml")" || true
+    [[ -z "$result" ]]
+}
+
+@test "report_unmanaged: unmanaged agent produces [-] UNMANAGED line" {
+    local agents_json='[{"name":"unmanaged-agent","status":"active"}]'
+    result="$(report_unmanaged "$agents_json" "${FIXTURES_DIR}/agent-valid.yaml")" || true
+    [[ "$result" == *"[-]"* ]]
+    [[ "$result" == *"UNMANAGED"* ]]
+    [[ "$result" == *"unmanaged-agent"* ]]
+}
+
+@test "report_unmanaged: unmanaged agent line contains agent name" {
+    local agents_json='[{"name":"my-rogue-agent","status":"active"}]'
+    result="$(report_unmanaged "$agents_json" "${FIXTURES_DIR}/agent-valid.yaml")" || true
+    [[ "$result" == *"my-rogue-agent"* ]]
+}
+
+@test "report_unmanaged: multiple unmanaged agents produce multiple lines" {
+    local agents_json='[{"name":"rogue-1","status":"active"},{"name":"rogue-2","status":"active"}]'
+    result="$(report_unmanaged "$agents_json" "${FIXTURES_DIR}/agent-valid.yaml")"
+    # Count lines containing [-] UNMANAGED
+    local count
+    count=$(echo "$result" | grep -c "UNMANAGED" || true)
+    [[ $count -eq 2 ]]
+}
+
+@test "report_unmanaged: mentions --prune option in output" {
+    local agents_json='[{"name":"unmanaged-agent","status":"active"}]'
+    result="$(report_unmanaged "$agents_json" "${FIXTURES_DIR}/agent-valid.yaml")" || true
+    [[ "$result" == *"--prune"* ]]
+}
+
+@test "report_unmanaged: with multiple yaml files only unmanaged are reported" {
+    local agents_json='[{"name":"test-agent","status":"active"},{"name":"minimal-agent","status":"active"},{"name":"orphan-agent","status":"active"}]'
+    result="$(report_unmanaged "$agents_json" "${FIXTURES_DIR}/agent-valid.yaml" "${FIXTURES_DIR}/agent-minimal.yaml")"
+    # Should contain orphan-agent line
+    [[ "$result" == *"orphan-agent"* ]]
+    # Should NOT contain test-agent or minimal-agent as unmanaged
+    [[ ! "$result" == *"test-agent"* || ! "$result" == *"UNMANAGED test-agent"* ]]
+    [[ ! "$result" == *"minimal-agent"* || ! "$result" == *"UNMANAGED minimal-agent"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+@test "get_unmanaged_names: null agents_json behaves like empty" {
+    # If agents_json is explicitly null (not a string containing "null", but the shell value)
+    # This is more of a guard test; in practice the guard should catch it
+    result="$(get_unmanaged_names "" "${FIXTURES_DIR}/agent-valid.yaml")" || true
+    [[ -z "$result" ]]
+}
+
+@test "report_unmanaged: no yaml files produces no output (guard #130)" {
+    # When no YAML files are passed, the function returns early (guard #130:
+    # if nothing is managed, unmanaged detection is a no-op).
+    local agents_json='[{"name":"any-agent","status":"active"}]'
+    result="$(report_unmanaged "$agents_json")" || true
+    [[ -z "$result" ]]
+}
+
+@test "get_unmanaged_names: agent name with special characters is handled" {
+    # Agent names should be valid identifiers, but if they contain hyphens, underscores, etc.
+    local agents_json='[{"name":"agent-with-dashes_and_underscores","status":"active"}]'
+    result="$(get_unmanaged_names "$agents_json" "${FIXTURES_DIR}/agent-valid.yaml")"
+    [[ "$result" == "agent-with-dashes_and_underscores" ]]
+}
+
+@test "report_unmanaged: agent name with spaces (if present) is preserved" {
+    # Unlikely but test the data path
+    local agents_json='[{"name":"agent with spaces","status":"active"}]'
+    result="$(report_unmanaged "$agents_json" "${FIXTURES_DIR}/agent-valid.yaml")" || true
+    [[ "$result" == *"agent with spaces"* ]]
+}

--- a/tools/reconciler/tests/unit/test_url_security.bats
+++ b/tools/reconciler/tests/unit/test_url_security.bats
@@ -1,0 +1,174 @@
+#!/usr/bin/env bats
+# tests/unit/test_url_security.bats — integration test: malicious AGAMEMNON_URL
+#
+# Issue #120: verify that apply.sh (via agamemnon_check_connection in api.sh)
+# aborts before making any API calls when AGAMEMNON_URL is set to a malicious
+# value.
+#
+# These tests call agamemnon_check_connection directly (which is the first
+# network-touching call in apply.sh's main()) so they cover the integration
+# point without needing a running Agamemnon server.
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+
+# Track whether curl was invoked by the mock
+CURL_INVOKED_FILE=""
+
+setup() {
+    CURL_INVOKED_FILE="$(mktemp)"
+    echo "0" > "$CURL_INVOKED_FILE"
+    export CURL_INVOKED_FILE
+
+    # Unset TLS vars so api.sh sources cleanly
+    unset AGAMEMNON_TLS_VERIFY
+    unset AGAMEMNON_CA_CERT
+    unset AGAMEMNON_CLIENT_CERT
+    unset AGAMEMNON_CLIENT_KEY
+    unset AGAMEMNON_API_KEY
+}
+
+teardown() {
+    [[ -n "$CURL_INVOKED_FILE" && -f "$CURL_INVOKED_FILE" ]] && rm -f "$CURL_INVOKED_FILE"
+    unset CURL_INVOKED_FILE
+}
+
+# ---------------------------------------------------------------------------
+# Helper: source api.sh with a given AGAMEMNON_URL in a subshell.
+# Returns the exit code and captured output.
+# ---------------------------------------------------------------------------
+
+_run_check_connection() {
+    local url="$1"
+    AGAMEMNON_URL="$url" bash -c "
+        source '${SCRIPT_DIR}/scripts/lib/api.sh'
+        agamemnon_check_connection
+    " 2>&1
+}
+
+# ---------------------------------------------------------------------------
+# Tests: malicious URLs must be rejected before any curl call
+# ---------------------------------------------------------------------------
+
+@test "malicious URL: file:// scheme is rejected" {
+    run _run_check_connection "file:///etc/passwd"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"AGAMEMNON_URL"* || "$output" == *"http"* || "$output" == *"scheme"* || "$output" == *"Invalid"* || "$output" == *"failed"* ]]
+}
+
+@test "malicious URL: ftp:// scheme is rejected" {
+    run _run_check_connection "ftp://evil.example.com"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"http"* || "$output" == *"scheme"* || "$output" == *"Invalid"* || "$output" == *"failed"* ]]
+}
+
+@test "malicious URL: javascript: scheme is rejected" {
+    run _run_check_connection "javascript:alert(1)"
+    [ "$status" -ne 0 ]
+}
+
+@test "malicious URL: URL with embedded credentials is rejected" {
+    run _run_check_connection "http://user:password@evil.com"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"credential"* || "$output" == *"Invalid"* || "$output" == *"failed"* || "$output" == *"AGAMEMNON_URL"* ]]
+}
+
+@test "malicious URL: URL with fragment (#) is rejected" {
+    run _run_check_connection "http://evil.com#fragment"
+    [ "$status" -ne 0 ]
+}
+
+@test "malicious URL: URL with query string (?) is rejected" {
+    run _run_check_connection "http://evil.com?redirect=http://attacker.com"
+    [ "$status" -ne 0 ]
+}
+
+@test "malicious URL: empty string is rejected" {
+    run _run_check_connection ""
+    [ "$status" -ne 0 ]
+}
+
+@test "malicious URL: plain string (not a URL) is rejected" {
+    run _run_check_connection "not-a-url"
+    [ "$status" -ne 0 ]
+}
+
+@test "malicious URL: protocol-relative URL is rejected" {
+    run _run_check_connection "//evil.com"
+    [ "$status" -ne 0 ]
+}
+
+@test "malicious URL: non-numeric port is rejected" {
+    run _run_check_connection "http://evil.com:abc"
+    [ "$status" -ne 0 ]
+}
+
+@test "malicious URL: IPv6 bracket notation is rejected" {
+    run _run_check_connection "http://[evil.com]"
+    [ "$status" -ne 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Tests: valid URLs must pass validation (and only fail at connection step)
+# ---------------------------------------------------------------------------
+
+@test "valid URL: http://localhost:8080 passes validation" {
+    # agamemnon_check_connection will fail because nothing is running on the port,
+    # but the error must be about connection (not URL rejection)
+    run _run_check_connection "http://localhost:19998"
+    [ "$status" -ne 0 ]
+    # Should mention that it cannot reach, not that the URL is invalid
+    [[ "$output" == *"Cannot reach"* || "$output" == *"failed"* ]]
+    # Must NOT mention URL validation failure
+    [[ "$output" != *"failed security validation"* ]]
+}
+
+@test "valid URL: https://agamemnon.internal passes validation" {
+    run _run_check_connection "https://agamemnon.internal"
+    [ "$status" -ne 0 ]
+    # Should fail at connect step, not validation step
+    [[ "$output" != *"failed security validation"* ]]
+}
+
+@test "valid URL: http://192.168.1.100:8080 passes validation" {
+    run _run_check_connection "http://192.168.1.100:8080"
+    [ "$status" -ne 0 ]
+    [[ "$output" != *"failed security validation"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test: apply.sh main entry point aborts on malicious URL
+# ---------------------------------------------------------------------------
+
+@test "apply.sh: aborts early on malicious AGAMEMNON_URL without making API calls" {
+    # We verify apply.sh exits non-zero when AGAMEMNON_URL is malicious.
+    # We use a minimal agents directory so the script would proceed past
+    # argument parsing if the URL were valid.
+    local tmpdir
+    tmpdir="$(mktemp -d)"
+    mkdir -p "${tmpdir}/agents/hermes"
+    cat > "${tmpdir}/agents/hermes/testagent.yaml" <<'YAML'
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: test-agent
+  host: hermes
+spec:
+  label: TestAgent
+  program: claude-code
+  workingDirectory: /tmp/test
+  desiredState: active
+YAML
+
+    # Run apply.sh with a malicious URL; it must exit non-zero
+    run bash -c "
+        cd '${SCRIPT_DIR}'
+        AGAMEMNON_URL='file:///etc/passwd' \
+        AIM_LOCK_FILE='${tmpdir}/.lock' \
+        bash '${SCRIPT_DIR}/scripts/apply.sh' 2>&1
+    "
+    rm -rf "$tmpdir"
+
+    [ "$status" -ne 0 ]
+    # Output must mention rejection, not just a connection error to the malicious URL
+    [[ "$output" == *"http"* || "$output" == *"scheme"* || "$output" == *"Invalid"* || "$output" == *"failed"* || "$output" == *"AGAMEMNON_URL"* ]]
+}

--- a/tools/reconciler/tests/unit/test_validate.bats
+++ b/tools/reconciler/tests/unit/test_validate.bats
@@ -1,0 +1,298 @@
+#!/usr/bin/env bats
+# tests/unit/test_validate.bats — unit tests for tests/validate-schemas.sh exit conditions
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+
+setup() {
+    # Create a temporary directory for each test
+    TEST_TMPDIR="$(mktemp -d)"
+    export TEST_TMPDIR
+
+    # Create agents and fleets subdirectories
+    mkdir -p "$TEST_TMPDIR/agents"
+    mkdir -p "$TEST_TMPDIR/fleets"
+}
+
+teardown() {
+    # Clean up temporary directory
+    [[ -d "$TEST_TMPDIR" ]] && rm -rf "$TEST_TMPDIR"
+}
+
+# Helper function to run validate script in temp directory.
+# NOTE: must be exported so BATS's `run` subshell can resolve it.
+run_validate() {
+    cd "$TEST_TMPDIR" || return 1
+    # The script uses REPO_ROOT derived from its own path, so we need to run it
+    # in a way that makes it think the temp dir is the root.
+    # Copy both validate-schemas.sh and validate-fleet-refs.sh so the
+    # in-script call to "${SCRIPT_DIR}/validate-fleet-refs.sh" resolves.
+    mkdir -p "$TEST_TMPDIR/tests"
+    cp "$SCRIPT_DIR/tests/validate-schemas.sh" "$TEST_TMPDIR/tests/"
+    cp "$SCRIPT_DIR/tests/validate-fleet-refs.sh" "$TEST_TMPDIR/tests/"
+    bash "$TEST_TMPDIR/tests/validate-schemas.sh"
+}
+export -f run_validate
+
+# ---------------------------------------------------------------------------
+# Test 1: Valid agent YAML exits 0
+# ---------------------------------------------------------------------------
+@test "valid agent YAML exits 0" {
+    mkdir -p "$TEST_TMPDIR/agents/hermes"
+    cat > "$TEST_TMPDIR/agents/hermes/validagent.yaml" <<'EOF'
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: valid-agent
+  host: hermes
+spec:
+  label: ValidAgent
+  program: claude-code
+  workingDirectory: /tmp/valid
+  deployment:
+    type: local
+  desiredState: active
+EOF
+    run run_validate
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 2: Missing required field (metadata.name) exits non-zero
+# ---------------------------------------------------------------------------
+@test "missing metadata.name exits non-zero" {
+    mkdir -p "$TEST_TMPDIR/agents/hermes"
+    cat > "$TEST_TMPDIR/agents/hermes/missingname.yaml" <<'EOF'
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  host: hermes
+spec:
+  program: claude-code
+  workingDirectory: /tmp/test
+  deployment:
+    type: local
+EOF
+    run run_validate
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"metadata.name is required"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 3: Wrong apiVersion exits non-zero
+# ---------------------------------------------------------------------------
+@test "wrong apiVersion exits non-zero" {
+    mkdir -p "$TEST_TMPDIR/agents/hermes"
+    cat > "$TEST_TMPDIR/agents/hermes/wrongversion.yaml" <<'EOF'
+apiVersion: wrong/v1
+kind: Agent
+metadata:
+  name: test-agent
+  host: hermes
+spec:
+  program: claude-code
+  workingDirectory: /tmp/test
+  deployment:
+    type: local
+EOF
+    run run_validate
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"expected apiVersion=myrmidons/v1"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 4: Invalid desiredState exits non-zero
+# ---------------------------------------------------------------------------
+@test "invalid desiredState exits non-zero" {
+    mkdir -p "$TEST_TMPDIR/agents/hermes"
+    cat > "$TEST_TMPDIR/agents/hermes/invalidstate.yaml" <<'EOF'
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: test-agent
+  host: hermes
+spec:
+  program: claude-code
+  workingDirectory: /tmp/test
+  deployment:
+    type: local
+  desiredState: running
+EOF
+    run run_validate
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"spec.desiredState must be 'active' or 'hibernated'"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 5: No YAML files found exits 0
+# ---------------------------------------------------------------------------
+@test "no YAML files found exits 0" {
+    # Empty agents and fleets directories
+    run run_validate
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Checked: 0 files"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 6: Relative workingDirectory exits non-zero
+# ---------------------------------------------------------------------------
+@test "relative workingDirectory exits non-zero" {
+    mkdir -p "$TEST_TMPDIR/agents/hermes"
+    cat > "$TEST_TMPDIR/agents/hermes/relativedir.yaml" <<'EOF'
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: relative-agent
+  host: hermes
+spec:
+  program: claude-code
+  workingDirectory: ./relative/path
+  deployment:
+    type: local
+EOF
+    run run_validate
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"is not an absolute path"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 7: Valid fleet YAML exits 0
+# ---------------------------------------------------------------------------
+@test "valid fleet YAML exits 0" {
+    mkdir -p "$TEST_TMPDIR/fleets"
+    cat > "$TEST_TMPDIR/fleets/validfleet.yaml" <<'EOF'
+apiVersion: myrmidons/v1
+kind: Fleet
+metadata:
+  name: validfleet
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      environment: test
+EOF
+    run run_validate
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 8: Fleet with mismatched filename exits non-zero
+# ---------------------------------------------------------------------------
+@test "fleet with mismatched filename exits non-zero" {
+    mkdir -p "$TEST_TMPDIR/fleets"
+    cat > "$TEST_TMPDIR/fleets/wrongfilename.yaml" <<'EOF'
+apiVersion: myrmidons/v1
+kind: Fleet
+metadata:
+  name: differentname
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      environment: test
+EOF
+    run run_validate
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"filename"* && "$output" == *"does not match metadata.name"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 9: metadata.host matches directory (issue #150)
+# ---------------------------------------------------------------------------
+@test "metadata.host mismatching directory exits non-zero" {
+    mkdir -p "$TEST_TMPDIR/agents/hermes"
+    cat > "$TEST_TMPDIR/agents/hermes/wronghost.yaml" <<'EOF'
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: wrong-host-agent
+  host: apollo
+spec:
+  program: claude-code
+  workingDirectory: /tmp/test
+  deployment:
+    type: local
+  desiredState: active
+EOF
+    run run_validate
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"does not match directory"* ]]
+}
+
+@test "metadata.host matching directory exits 0" {
+    mkdir -p "$TEST_TMPDIR/agents/hermes"
+    cat > "$TEST_TMPDIR/agents/hermes/correcthost.yaml" <<'EOF'
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: correct-host-agent
+  host: hermes
+spec:
+  program: claude-code
+  workingDirectory: /tmp/test
+  deployment:
+    type: local
+  desiredState: active
+EOF
+    run run_validate
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"does not match directory"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 11: .myrmidons.yaml validation (issue #235)
+# ---------------------------------------------------------------------------
+@test ".myrmidons.yaml with valid fields passes validation" {
+    cat > "$TEST_TMPDIR/.myrmidons.yaml" <<'EOF'
+defaultHost: hermes
+aimHost: http://localhost:8080
+logLevel: info
+prunePolicy: manual
+snapshotRetention: 7
+EOF
+    run run_validate
+    [ "$status" -eq 0 ]
+    [[ "$output" == *".myrmidons.yaml: ok"* ]]
+}
+
+@test ".myrmidons.yaml with invalid logLevel fails validation" {
+    cat > "$TEST_TMPDIR/.myrmidons.yaml" <<'EOF'
+logLevel: verbose
+EOF
+    run run_validate
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"logLevel must be one of:"* ]]
+}
+
+@test ".myrmidons.yaml with invalid prunePolicy fails validation" {
+    cat > "$TEST_TMPDIR/.myrmidons.yaml" <<'EOF'
+prunePolicy: always
+EOF
+    run run_validate
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"prunePolicy must be one of:"* ]]
+}
+
+@test ".myrmidons.yaml with invalid aimHost (no scheme) fails validation" {
+    cat > "$TEST_TMPDIR/.myrmidons.yaml" <<'EOF'
+aimHost: localhost:8080
+EOF
+    run run_validate
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"aimHost must start with http://"* ]]
+}
+
+@test ".myrmidons.yaml with invalid snapshotRetention (non-integer) fails validation" {
+    cat > "$TEST_TMPDIR/.myrmidons.yaml" <<'EOF'
+snapshotRetention: two-weeks
+EOF
+    run run_validate
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"snapshotRetention must be a non-negative integer"* ]]
+}
+
+@test "absent .myrmidons.yaml does not cause validation failure" {
+    # No .myrmidons.yaml in TEST_TMPDIR
+    run run_validate
+    [ "$status" -eq 0 ]
+    [[ "$output" != *".myrmidons.yaml"* ]]
+}

--- a/tools/reconciler/tests/unit/test_validate_fleet_refs.bats
+++ b/tools/reconciler/tests/unit/test_validate_fleet_refs.bats
@@ -1,0 +1,294 @@
+#!/usr/bin/env bats
+# tests/unit/test_validate_fleet_refs.bats — unit tests for tests/validate-fleet-refs.sh
+#
+# The script derives REPO_ROOT from its own path (BASH_SOURCE[0]).
+# Each test copies validate-fleet-refs.sh into a temp directory structure
+# under tests/ so that REPO_ROOT resolves to the temp root, giving full
+# control over the agents/ and fleets/ layout without touching real files.
+#
+# Issue #444: Add fleet ref validation to pre-commit / CI lint step
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+VALIDATE_SCRIPT="${SCRIPT_DIR}/tests/validate-fleet-refs.sh"
+
+# Temporary root created per test
+TMP_ROOT=""
+
+setup() {
+    TMP_ROOT="${SCRIPT_DIR}/_fleet_refs_test_$$_${RANDOM}"
+    mkdir -p "${TMP_ROOT}/tests"
+    mkdir -p "${TMP_ROOT}/agents/hermes"
+    mkdir -p "${TMP_ROOT}/fleets"
+
+    # Copy the script so REPO_ROOT resolves to TMP_ROOT
+    cp "$VALIDATE_SCRIPT" "${TMP_ROOT}/tests/validate-fleet-refs.sh"
+    chmod +x "${TMP_ROOT}/tests/validate-fleet-refs.sh"
+
+    # Create a real agent file that fleet refs can point at
+    cat > "${TMP_ROOT}/agents/hermes/real-agent.yaml" <<'YAML'
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: real-agent
+  host: hermes
+spec:
+  label: RealAgent
+  program: claude-code
+  workingDirectory: /tmp/real
+  deployment:
+    type: local
+  desiredState: active
+YAML
+}
+
+teardown() {
+    if [[ -n "$TMP_ROOT" && -d "$TMP_ROOT" ]]; then
+        rm -rf "$TMP_ROOT"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Helper: run the copied script
+# ---------------------------------------------------------------------------
+_run_validate() {
+    bash "${TMP_ROOT}/tests/validate-fleet-refs.sh"
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: fleet with all valid refs exits 0
+# ---------------------------------------------------------------------------
+
+@test "validate-fleet-refs: exits 0 for fleet with all valid refs" {
+    cat > "${TMP_ROOT}/fleets/valid.yaml" <<YAML
+apiVersion: myrmidons/v1
+kind: Fleet
+metadata:
+  name: valid-fleet
+spec:
+  agents:
+    - ref: hermes/real-agent
+YAML
+
+    run _run_validate
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 2: fleet with a dangling ref exits 1
+# ---------------------------------------------------------------------------
+
+@test "validate-fleet-refs: exits 1 for fleet with dangling ref" {
+    cat > "${TMP_ROOT}/fleets/dangling.yaml" <<YAML
+apiVersion: myrmidons/v1
+kind: Fleet
+metadata:
+  name: dangling-fleet
+spec:
+  agents:
+    - ref: hermes/nonexistent-agent-xyz
+YAML
+
+    run _run_validate
+    [ "$status" -eq 1 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 3: dangling ref output includes FAIL and the ref path
+# ---------------------------------------------------------------------------
+
+@test "validate-fleet-refs: FAIL message includes the ref path for dangling ref" {
+    cat > "${TMP_ROOT}/fleets/dangling.yaml" <<YAML
+apiVersion: myrmidons/v1
+kind: Fleet
+metadata:
+  name: dangling-fleet
+spec:
+  agents:
+    - ref: hermes/ghost-agent
+YAML
+
+    run _run_validate
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"hermes/ghost-agent"* ]]
+    [[ "$output" == *"FAIL"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 4: inline agent with all required fields exits 0
+# ---------------------------------------------------------------------------
+
+@test "validate-fleet-refs: exits 0 for fleet with valid inline agent" {
+    cat > "${TMP_ROOT}/fleets/inline-valid.yaml" <<YAML
+apiVersion: myrmidons/v1
+kind: Fleet
+metadata:
+  name: inline-valid-fleet
+spec:
+  agents:
+    - name: my-inline-agent
+      program: claude-code
+      workingDirectory: /tmp/inline
+YAML
+
+    run _run_validate
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 5: inline agent missing name exits 1
+# ---------------------------------------------------------------------------
+
+@test "validate-fleet-refs: exits 1 for inline agent missing name" {
+    cat > "${TMP_ROOT}/fleets/inline-no-name.yaml" <<YAML
+apiVersion: myrmidons/v1
+kind: Fleet
+metadata:
+  name: inline-no-name-fleet
+spec:
+  agents:
+    - program: claude-code
+      workingDirectory: /tmp/inline
+YAML
+
+    run _run_validate
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"name is required"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 6: inline agent missing program exits 1
+# ---------------------------------------------------------------------------
+
+@test "validate-fleet-refs: exits 1 for inline agent missing program" {
+    cat > "${TMP_ROOT}/fleets/inline-no-program.yaml" <<YAML
+apiVersion: myrmidons/v1
+kind: Fleet
+metadata:
+  name: inline-no-program-fleet
+spec:
+  agents:
+    - name: my-inline-agent
+      workingDirectory: /tmp/inline
+YAML
+
+    run _run_validate
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"program is required"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 7: inline agent missing workingDirectory exits 1
+# ---------------------------------------------------------------------------
+
+@test "validate-fleet-refs: exits 1 for inline agent missing workingDirectory" {
+    cat > "${TMP_ROOT}/fleets/inline-no-workdir.yaml" <<YAML
+apiVersion: myrmidons/v1
+kind: Fleet
+metadata:
+  name: inline-no-workdir-fleet
+spec:
+  agents:
+    - name: my-inline-agent
+      program: claude-code
+YAML
+
+    run _run_validate
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"workingDirectory is required"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 8: fleet with no agents skips cleanly and exits 0
+# ---------------------------------------------------------------------------
+
+@test "validate-fleet-refs: exits 0 for fleet with no agents" {
+    cat > "${TMP_ROOT}/fleets/empty.yaml" <<YAML
+apiVersion: myrmidons/v1
+kind: Fleet
+metadata:
+  name: empty-fleet
+spec:
+  agents: []
+YAML
+
+    run _run_validate
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"no agents"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 9: non-Fleet YAML files are skipped
+# ---------------------------------------------------------------------------
+
+@test "validate-fleet-refs: ignores YAML files with kind != Fleet" {
+    cat > "${TMP_ROOT}/fleets/not-a-fleet.yaml" <<YAML
+apiVersion: myrmidons/v1
+kind: Agent
+metadata:
+  name: some-agent
+spec:
+  program: claude-code
+YAML
+
+    run _run_validate
+    [ "$status" -eq 0 ]
+    # The agent-kind file should not appear in the counted summary
+    [[ "$output" == *"Checked: 0 refs, 0 inline agents"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 10: mixed fleet — one valid ref + one dangling ref exits 1
+# ---------------------------------------------------------------------------
+
+@test "validate-fleet-refs: exits 1 when one of multiple refs is dangling" {
+    cat > "${TMP_ROOT}/fleets/mixed.yaml" <<YAML
+apiVersion: myrmidons/v1
+kind: Fleet
+metadata:
+  name: mixed-fleet
+spec:
+  agents:
+    - ref: hermes/real-agent
+    - ref: hermes/missing-agent
+YAML
+
+    run _run_validate
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"hermes/real-agent"* ]]
+    [[ "$output" == *"hermes/missing-agent"* ]]
+    [[ "$output" == *"FAIL"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 11: summary line includes correct counts
+# ---------------------------------------------------------------------------
+
+@test "validate-fleet-refs: summary line shows correct ref and inline counts" {
+    cat > "${TMP_ROOT}/fleets/counts.yaml" <<YAML
+apiVersion: myrmidons/v1
+kind: Fleet
+metadata:
+  name: counts-fleet
+spec:
+  agents:
+    - ref: hermes/real-agent
+    - name: my-inline
+      program: none
+      workingDirectory: /tmp/inline
+YAML
+
+    run _run_validate
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Checked: 1 refs, 1 inline agents"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 12: empty fleets directory exits 0 with zero errors
+# ---------------------------------------------------------------------------
+
+@test "validate-fleet-refs: exits 0 when fleets directory is empty" {
+    # TMP_ROOT/fleets/ exists but has no YAML files
+    run _run_validate
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Checked: 0 refs, 0 inline agents, Errors: 0"* ]]
+}

--- a/tools/reconciler/tests/unit/test_verify_convergence.bats
+++ b/tools/reconciler/tests/unit/test_verify_convergence.bats
@@ -1,0 +1,370 @@
+#!/usr/bin/env bats
+# tests/unit/test_verify_convergence.bats — regression tests for verify_convergence()
+#
+# Verifies:
+#   - verify_convergence returns 0 when _MODIFIED_NAMES is empty (no-op path)
+#   - verify_convergence returns 0 when all modified agents converged
+#   - verify_convergence returns 1 when an agent fails to converge
+#   - The dead function write_failed_agents_file is NOT defined in apply.sh (F-05 regression)
+#   - Only one verify_convergence definition exists in apply.sh (F-03 regression)
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+APPLY_SH="${SCRIPT_DIR}/scripts/apply.sh"
+
+# ---------------------------------------------------------------------------
+# Static checks — no execution needed, just grep apply.sh
+# ---------------------------------------------------------------------------
+
+@test "F-05 regression: write_failed_agents_file (public variant) is not defined in apply.sh" {
+    # The dead public variant must not exist; only the private _write_failed_agents_file may remain.
+    # grep -c returns non-zero when no lines match, which is what we want.
+    local count
+    count=$(grep -c '^write_failed_agents_file()' "$APPLY_SH" || true)
+    [[ "$count" -eq 0 ]]
+}
+
+@test "F-03 regression: only one verify_convergence definition exists in apply.sh" {
+    local count
+    count=$(grep -c '^verify_convergence()' "$APPLY_SH" || true)
+    [[ "$count" -eq 1 ]]
+}
+
+@test "F-04 regression: repo_root (lowercase) does not appear in apply.sh" {
+    local count
+    count=$(grep -c '\${repo_root}' "$APPLY_SH" || true)
+    [[ "$count" -eq 0 ]]
+}
+
+@test "F-06 regression: bare FAILED_AGENTS array declaration is not present in apply.sh" {
+    # The unified FAILED_AGENT_NAMES/STATUSES/MESSAGES arrays replaced FAILED_AGENTS.
+    # Verify neither the declaration nor a direct append to the bare array exists.
+    local decl_count
+    decl_count=$(grep -cE '^FAILED_AGENTS=\(\)' "$APPLY_SH" || true)
+    [[ "$decl_count" -eq 0 ]]
+    local append_count
+    append_count=$(grep -cE 'FAILED_AGENTS\+=\(' "$APPLY_SH" || true)
+    [[ "$append_count" -eq 0 ]]
+}
+
+# ---------------------------------------------------------------------------
+# Functional tests — source a stripped-down harness that exports the function
+# ---------------------------------------------------------------------------
+
+# Build a minimal sourcing harness so we can call verify_convergence in-process
+# without running main() or requiring a live Agamemnon server.
+
+_source_verify_convergence() {
+    # Extract just the verify_convergence function from apply.sh into a temp file
+    # so we can source it safely in tests.
+    local harness="${BATS_TMPDIR}/vc_harness_$$.sh"
+    cat > "$harness" << 'HARNESS'
+#!/usr/bin/env bash
+set -uo pipefail
+
+# Minimal stubs required by verify_convergence
+OUTPUT_FORMAT="text"
+_MODIFIED_NAMES=()
+_MODIFIED_DESIRED=()
+_PRUNED_NAMES=()
+
+# Stub agamemnon_list_agents — returns the value of _STUB_AGENTS_JSON
+agamemnon_list_agents() {
+    echo "${_STUB_AGENTS_JSON:-[]}"
+}
+
+# ---- paste verify_convergence body inline ----
+verify_convergence() {
+    if [[ ${#_MODIFIED_NAMES[@]} -eq 0 && ${#_PRUNED_NAMES[@]} -eq 0 ]]; then
+        return 0
+    fi
+
+    local failed=0
+    local verified=0
+    local pruned_verified=0
+
+    if [[ "$OUTPUT_FORMAT" != "json" ]]; then
+        echo ""
+        echo "Verifying convergence for ${#_MODIFIED_NAMES[@]} modified agent(s)..."
+    fi
+
+    local agents_json_fresh
+    agents_json_fresh="$(agamemnon_list_agents)"
+
+    for i in "${!_MODIFIED_NAMES[@]}"; do
+        local agent_name="${_MODIFIED_NAMES[$i]}"
+        local desired="${_MODIFIED_DESIRED[$i]}"
+
+        local actual_json actual_status
+        actual_json="$(echo "$agents_json_fresh" | jq -r --arg n "$agent_name" '.[] | select(.name == $n)')"
+
+        if [[ -z "$actual_json" ]]; then
+            if [[ "$OUTPUT_FORMAT" != "json" ]]; then
+                echo "  [!] ${agent_name}: NOT FOUND in Agamemnon after apply (convergence failed)"
+            fi
+            failed=$((failed + 1))
+            continue
+        fi
+
+        actual_status="$(echo "$actual_json" | jq -r '.status // "unknown"')"
+
+        local converged=0
+        if [[ "$desired" == "active" ]]; then
+            if [[ "$actual_status" == "active" || "$actual_status" == "online" || \
+                  "$actual_status" == "starting" ]]; then
+                converged=1
+            fi
+        elif [[ "$desired" == "hibernated" ]]; then
+            if [[ "$actual_status" == "offline" || "$actual_status" == "hibernated" ]]; then
+                converged=1
+            fi
+        else
+            converged=1
+        fi
+
+        if [[ $converged -eq 1 ]]; then
+            if [[ "$OUTPUT_FORMAT" != "json" ]]; then
+                echo "  [ok] ${agent_name}: converged (status=${actual_status})"
+            fi
+            verified=$((verified + 1))
+        else
+            if [[ "$OUTPUT_FORMAT" != "json" ]]; then
+                echo "  [!] ${agent_name}: NOT converged (desired=${desired}, actual_status=${actual_status})"
+            fi
+            failed=$((failed + 1))
+        fi
+    done
+
+    if [[ ${#_PRUNED_NAMES[@]} -gt 0 ]]; then
+        for pruned_name in "${_PRUNED_NAMES[@]}"; do
+            local still_exists
+            still_exists="$(echo "$agents_json_fresh" | jq -r --arg n "$pruned_name" '.[] | select(.name == $n) | .name')"
+            if [[ -n "$still_exists" ]]; then
+                if [[ "$OUTPUT_FORMAT" != "json" ]]; then
+                    echo "  [!] ${pruned_name}: pruned but still present in API (convergence failed)"
+                fi
+                failed=$((failed + 1))
+            else
+                if [[ "$OUTPUT_FORMAT" != "json" ]]; then
+                    echo "  [ok] ${pruned_name}: confirmed absent (pruned)"
+                fi
+                pruned_verified=$((pruned_verified + 1))
+            fi
+        done
+    fi
+
+    if [[ "$OUTPUT_FORMAT" != "json" ]]; then
+        if [[ ${#_PRUNED_NAMES[@]} -gt 0 ]]; then
+            echo "Convergence: ${verified} converged, ${pruned_verified} pruned, ${failed} failed."
+        else
+            echo "Convergence: ${verified} converged, ${failed} failed."
+        fi
+    fi
+
+    if [[ $failed -gt 0 ]]; then
+        return 1
+    fi
+    return 0
+}
+HARNESS
+    echo "$harness"
+}
+
+@test "verify_convergence: returns 0 when _MODIFIED_NAMES is empty" {
+    local harness
+    harness="$(_source_verify_convergence)"
+
+    run bash -c "
+        source '${harness}'
+        _MODIFIED_NAMES=()
+        _MODIFIED_DESIRED=()
+        verify_convergence
+    "
+    [[ "$status" -eq 0 ]]
+    rm -f "$harness"
+}
+
+@test "verify_convergence: returns 0 when modified agent is active and desired is active" {
+    local harness
+    harness="$(_source_verify_convergence)"
+
+    local agents_json='[{"name":"test-agent","status":"active"}]'
+
+    run bash -c "
+        source '${harness}'
+        _MODIFIED_NAMES=(\"test-agent\")
+        _MODIFIED_DESIRED=(\"active\")
+        _STUB_AGENTS_JSON='${agents_json}'
+        verify_convergence
+    "
+    [[ "$status" -eq 0 ]]
+    rm -f "$harness"
+}
+
+@test "verify_convergence: returns 0 when modified agent is online and desired is active" {
+    local harness
+    harness="$(_source_verify_convergence)"
+
+    local agents_json='[{"name":"test-agent","status":"online"}]'
+
+    run bash -c "
+        source '${harness}'
+        _MODIFIED_NAMES=(\"test-agent\")
+        _MODIFIED_DESIRED=(\"active\")
+        _STUB_AGENTS_JSON='${agents_json}'
+        verify_convergence
+    "
+    [[ "$status" -eq 0 ]]
+    rm -f "$harness"
+}
+
+@test "verify_convergence: returns 1 when modified agent is offline but desired is active" {
+    local harness
+    harness="$(_source_verify_convergence)"
+
+    local agents_json='[{"name":"test-agent","status":"offline"}]'
+
+    run bash -c "
+        source '${harness}'
+        _MODIFIED_NAMES=(\"test-agent\")
+        _MODIFIED_DESIRED=(\"active\")
+        _STUB_AGENTS_JSON='${agents_json}'
+        verify_convergence
+    "
+    [[ "$status" -eq 1 ]]
+    rm -f "$harness"
+}
+
+@test "verify_convergence: returns 1 when agent is not found in API" {
+    local harness
+    harness="$(_source_verify_convergence)"
+
+    run bash -c "
+        source '${harness}'
+        _MODIFIED_NAMES=(\"missing-agent\")
+        _MODIFIED_DESIRED=(\"active\")
+        _STUB_AGENTS_JSON='[]'
+        verify_convergence
+    "
+    [[ "$status" -eq 1 ]]
+    rm -f "$harness"
+}
+
+@test "verify_convergence: returns 0 when hibernated agent is offline" {
+    local harness
+    harness="$(_source_verify_convergence)"
+
+    local agents_json='[{"name":"sleepy-agent","status":"offline"}]'
+
+    run bash -c "
+        source '${harness}'
+        _MODIFIED_NAMES=(\"sleepy-agent\")
+        _MODIFIED_DESIRED=(\"hibernated\")
+        _STUB_AGENTS_JSON='${agents_json}'
+        verify_convergence
+    "
+    [[ "$status" -eq 0 ]]
+    rm -f "$harness"
+}
+
+@test "verify_convergence: returns 1 when hibernated agent is still active" {
+    local harness
+    harness="$(_source_verify_convergence)"
+
+    local agents_json='[{"name":"sleepy-agent","status":"active"}]'
+
+    run bash -c "
+        source '${harness}'
+        _MODIFIED_NAMES=(\"sleepy-agent\")
+        _MODIFIED_DESIRED=(\"hibernated\")
+        _STUB_AGENTS_JSON='${agents_json}'
+        verify_convergence
+    "
+    [[ "$status" -eq 1 ]]
+    rm -f "$harness"
+}
+
+@test "verify_convergence: mixed results — 1 converged, 1 not — returns 1" {
+    local harness
+    harness="$(_source_verify_convergence)"
+
+    local agents_json='[{"name":"agent-a","status":"active"},{"name":"agent-b","status":"offline"}]'
+
+    run bash -c "
+        source '${harness}'
+        _MODIFIED_NAMES=(\"agent-a\" \"agent-b\")
+        _MODIFIED_DESIRED=(\"active\" \"active\")
+        _STUB_AGENTS_JSON='${agents_json}'
+        verify_convergence
+    "
+    [[ "$status" -eq 1 ]]
+    rm -f "$harness"
+}
+
+@test "verify_convergence: prune-only run returns 0 and shows pruned count" {
+    local harness
+    harness="$(_source_verify_convergence)"
+
+    run bash -c "
+        source '${harness}'
+        _MODIFIED_NAMES=()
+        _MODIFIED_DESIRED=()
+        _PRUNED_NAMES=(\"a\" \"b\" \"c\")
+        _STUB_AGENTS_JSON='[]'
+        verify_convergence
+    "
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"3 pruned"* ]]
+    rm -f "$harness"
+}
+
+@test "verify_convergence: pruned agent still present returns 1" {
+    local harness
+    harness="$(_source_verify_convergence)"
+
+    run bash -c "
+        source '${harness}'
+        _MODIFIED_NAMES=()
+        _MODIFIED_DESIRED=()
+        _PRUNED_NAMES=(\"ghost\")
+        _STUB_AGENTS_JSON='[{\"name\":\"ghost\",\"status\":\"offline\"}]'
+        verify_convergence
+    "
+    [[ "$status" -eq 1 ]]
+    rm -f "$harness"
+}
+
+@test "verify_convergence: prune-only summary reads '0 converged, 3 pruned, 0 failed.'" {
+    local harness
+    harness="$(_source_verify_convergence)"
+
+    run bash -c "
+        source '${harness}'
+        _MODIFIED_NAMES=()
+        _MODIFIED_DESIRED=()
+        _PRUNED_NAMES=(\"a\" \"b\" \"c\")
+        _STUB_AGENTS_JSON='[]'
+        verify_convergence
+    "
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"Convergence: 0 converged, 3 pruned, 0 failed."* ]]
+    rm -f "$harness"
+}
+
+@test "verify_convergence: no-prune summary does not contain ' pruned'" {
+    local harness
+    harness="$(_source_verify_convergence)"
+
+    local agents_json='[{"name":"test-agent","status":"active"}]'
+
+    run bash -c "
+        source '${harness}'
+        _MODIFIED_NAMES=(\"test-agent\")
+        _MODIFIED_DESIRED=(\"active\")
+        _PRUNED_NAMES=()
+        _STUB_AGENTS_JSON='${agents_json}'
+        verify_convergence
+    "
+    [[ "$status" -eq 0 ]]
+    [[ "$output" != *" pruned"* ]]
+    rm -f "$harness"
+}

--- a/tools/reconciler/tests/unit/test_xtrace_exposure_lint.bats
+++ b/tools/reconciler/tests/unit/test_xtrace_exposure_lint.bats
@@ -1,0 +1,137 @@
+#!/usr/bin/env bats
+# tests/unit/test_xtrace_exposure_lint.bats
+#
+# Issue #430: test coverage for check-xtrace-exposure.sh.
+#
+# The lint script scans shell scripts for curl invocations that expand
+# ${AGAMEMNON_API_KEY} or ${_AUTH_HEADERS...} without a { set +x; } xtrace guard.
+# These tests verify it catches violating files and passes clean ones.
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+LINT_SCRIPT="${SCRIPT_DIR}/scripts/check-xtrace-exposure.sh"
+
+TMP_DIR=""
+
+setup() {
+    TMP_DIR="$(mktemp -d "${SCRIPT_DIR}/_xtrace_lint_test_$$_XXXXXX")"
+}
+
+teardown() {
+    if [[ -n "$TMP_DIR" && -d "$TMP_DIR" ]]; then
+        rm -rf "$TMP_DIR"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: file with inline ${AGAMEMNON_API_KEY} in a curl call is flagged
+# ---------------------------------------------------------------------------
+
+@test "check-xtrace-exposure: flags curl with inline AGAMEMNON_API_KEY" {
+    local f="${TMP_DIR}/bad_key.sh"
+    cat > "$f" <<'EOF'
+#!/usr/bin/env bash
+curl -H "Authorization: Bearer ${AGAMEMNON_API_KEY}" http://localhost/v1/agents
+EOF
+    run bash "$LINT_SCRIPT" "$f"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"xtrace guard"* || "$output" == *"violation"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 2: file with inline ${_AUTH_HEADERS[@]} in a curl call is flagged
+# ---------------------------------------------------------------------------
+
+@test "check-xtrace-exposure: flags curl with inline _AUTH_HEADERS expansion" {
+    local f="${TMP_DIR}/bad_headers.sh"
+    cat > "$f" <<'EOF'
+#!/usr/bin/env bash
+curl "${_AUTH_HEADERS[@]}" http://localhost/v1/agents
+EOF
+    run bash "$LINT_SCRIPT" "$f"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"xtrace guard"* || "$output" == *"violation"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 3: a properly guarded curl (with { set +x; } on same line) is not flagged
+# ---------------------------------------------------------------------------
+
+@test "check-xtrace-exposure: accepts curl with set+x guard on same line" {
+    local f="${TMP_DIR}/guarded.sh"
+    cat > "$f" <<'EOF'
+#!/usr/bin/env bash
+{ set +x; } 2>/dev/null; curl -H "Authorization: Bearer ${AGAMEMNON_API_KEY}" http://localhost/v1/agents
+EOF
+    run bash "$LINT_SCRIPT" "$f"
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 4: comment lines mentioning curl and ${AGAMEMNON_API_KEY} are not flagged
+# ---------------------------------------------------------------------------
+
+@test "check-xtrace-exposure: ignores comment lines" {
+    local f="${TMP_DIR}/comment.sh"
+    cat > "$f" <<'EOF'
+#!/usr/bin/env bash
+# curl -H "Authorization: Bearer ${AGAMEMNON_API_KEY}" http://example.com
+echo "safe"
+EOF
+    run bash "$LINT_SCRIPT" "$f"
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 5: file with no curl calls passes
+# ---------------------------------------------------------------------------
+
+@test "check-xtrace-exposure: passes file with no curl calls" {
+    local f="${TMP_DIR}/no_curl.sh"
+    cat > "$f" <<'EOF'
+#!/usr/bin/env bash
+echo "hello world"
+AGAMEMNON_API_KEY=test
+EOF
+    run bash "$LINT_SCRIPT" "$f"
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 6: file with curl but no auth expansion passes
+# ---------------------------------------------------------------------------
+
+@test "check-xtrace-exposure: passes curl without auth variable expansion" {
+    local f="${TMP_DIR}/safe_curl.sh"
+    cat > "$f" <<'EOF'
+#!/usr/bin/env bash
+curl -s http://localhost/v1/health
+EOF
+    run bash "$LINT_SCRIPT" "$f"
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 7: multiple violations in one file are all reported
+# ---------------------------------------------------------------------------
+
+@test "check-xtrace-exposure: reports multiple violations in one file" {
+    local f="${TMP_DIR}/multi.sh"
+    cat > "$f" <<'EOF'
+#!/usr/bin/env bash
+curl -H "Authorization: Bearer ${AGAMEMNON_API_KEY}" http://localhost/v1/health
+curl "${_AUTH_HEADERS[@]}" http://localhost/v1/agents
+EOF
+    run bash "$LINT_SCRIPT" "$f"
+    [ "$status" -eq 1 ]
+    # Should report 2 violations
+    [[ "$output" == *"2 violation"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 8: clean repo scripts pass the lint check
+# ---------------------------------------------------------------------------
+
+@test "check-xtrace-exposure: all repo scripts pass after fix" {
+    run bash "$LINT_SCRIPT"
+    [ "$status" -eq 0 ]
+}

--- a/tools/reconciler/tests/unit/test_xtrace_guards.bats
+++ b/tools/reconciler/tests/unit/test_xtrace_guards.bats
@@ -1,0 +1,167 @@
+#!/usr/bin/env bats
+# tests/unit/test_xtrace_guards.bats
+#
+# Issue #431: test coverage for check-xtrace-guards.sh.
+#
+# The linter statically flags shell scripts that expand ${AGAMEMNON_API_KEY}
+# outside of a set +x / set -x guard block, preventing API key leakage in
+# bash -x trace output.
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+DETECTOR="${SCRIPT_DIR}/scripts/check-xtrace-guards.sh"
+
+TMP_DIR=""
+
+setup() {
+    TMP_DIR="${SCRIPT_DIR}/_xtrace_test_$$_${RANDOM}"
+    mkdir -p "$TMP_DIR"
+}
+
+teardown() {
+    if [[ -n "$TMP_DIR" && -d "$TMP_DIR" ]]; then
+        rm -rf "$TMP_DIR"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: bare ${AGAMEMNON_API_KEY} in curl without guard → violation
+# ---------------------------------------------------------------------------
+
+@test "check-xtrace-guards: bare expansion in curl exits 1" {
+    local f="${TMP_DIR}/bare.sh"
+    cat > "$f" <<'SH'
+#!/usr/bin/env bash
+curl -H "Authorization: Bearer ${AGAMEMNON_API_KEY}" http://example.com
+SH
+    run bash "$DETECTOR" "$f"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"AGAMEMNON_API_KEY expanded without xtrace guard"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 2: bare $AGAMEMNON_API_KEY (no braces) without guard → violation
+# ---------------------------------------------------------------------------
+
+@test "check-xtrace-guards: bare expansion without braces exits 1" {
+    local f="${TMP_DIR}/bare-no-braces.sh"
+    cat > "$f" <<'SH'
+#!/usr/bin/env bash
+curl -H "X-API-Key: $AGAMEMNON_API_KEY" http://example.com
+SH
+    run bash "$DETECTOR" "$f"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"AGAMEMNON_API_KEY expanded without xtrace guard"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Test 3: expansion inside { set +x; } / set -x guard → clean
+# ---------------------------------------------------------------------------
+
+@test "check-xtrace-guards: expansion inside brace guard exits 0" {
+    local f="${TMP_DIR}/guarded.sh"
+    cat > "$f" <<'SH'
+#!/usr/bin/env bash
+local _had_xtrace=0
+if [[ "$-" == *x* ]]; then _had_xtrace=1; fi
+{ set +x; } 2>/dev/null
+curl -H "Authorization: Bearer ${AGAMEMNON_API_KEY}" http://example.com
+if [[ $_had_xtrace -eq 1 ]]; then set -x; fi
+SH
+    run bash "$DETECTOR" "$f"
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 4: expansion inside bare set +x / set -x guard → clean
+# ---------------------------------------------------------------------------
+
+@test "check-xtrace-guards: expansion inside bare set +x guard exits 0" {
+    local f="${TMP_DIR}/bare-guard.sh"
+    cat > "$f" <<'SH'
+#!/usr/bin/env bash
+set +x
+curl -H "Authorization: Bearer ${AGAMEMNON_API_KEY}" http://example.com
+set -x
+SH
+    run bash "$DETECTOR" "$f"
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 5: suppression annotation → clean
+# ---------------------------------------------------------------------------
+
+@test "check-xtrace-guards: suppressed with xtrace-lint: ok exits 0" {
+    local f="${TMP_DIR}/suppressed.sh"
+    cat > "$f" <<'SH'
+#!/usr/bin/env bash
+curl -H "Authorization: Bearer ${AGAMEMNON_API_KEY}" http://example.com # xtrace-lint: ok
+SH
+    run bash "$DETECTOR" "$f"
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 6: variable assignment (normalisation) → clean
+# ---------------------------------------------------------------------------
+
+@test "check-xtrace-guards: AGAMEMNON_API_KEY= assignment exits 0" {
+    local f="${TMP_DIR}/assign.sh"
+    cat > "$f" <<'SH'
+#!/usr/bin/env bash
+AGAMEMNON_API_KEY="${AGAMEMNON_API_KEY:-}"
+echo "ready"
+SH
+    run bash "$DETECTOR" "$f"
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 7: comment-only reference → clean
+# ---------------------------------------------------------------------------
+
+@test "check-xtrace-guards: comment-only reference exits 0" {
+    local f="${TMP_DIR}/comment.sh"
+    cat > "$f" <<'SH'
+#!/usr/bin/env bash
+# Use ${AGAMEMNON_API_KEY} for authentication
+echo "hello"
+SH
+    run bash "$DETECTOR" "$f"
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 8: violation after guard block ends → violation
+# ---------------------------------------------------------------------------
+
+@test "check-xtrace-guards: expansion after guard block ends exits 1" {
+    local f="${TMP_DIR}/post-guard.sh"
+    cat > "$f" <<'SH'
+#!/usr/bin/env bash
+{ set +x; } 2>/dev/null
+curl -H "Authorization: Bearer ${AGAMEMNON_API_KEY}" http://example.com/guarded
+if [[ $_had_xtrace -eq 1 ]]; then set -x; fi
+curl -H "Authorization: Bearer ${AGAMEMNON_API_KEY}" http://example.com/unguarded
+SH
+    run bash "$DETECTOR" "$f"
+    [ "$status" -eq 1 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 9: scripts/lib/api.sh in repo passes the linter
+# ---------------------------------------------------------------------------
+
+@test "check-xtrace-guards: repo api.sh exits 0" {
+    run bash "$DETECTOR" "${SCRIPT_DIR}/scripts/lib/api.sh"
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 10: default full-repo scan exits 0 (all expansions are guarded)
+# ---------------------------------------------------------------------------
+
+@test "check-xtrace-guards: full-repo default scan exits 0" {
+    run bash "$DETECTOR"
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

- Imports the GitOps reconciler from `HomericIntelligence/Myrmidons` to `tools/reconciler/`.
- 108 files, ~22k LOC: scripts (apply/plan/status/export/diff/rollback/new-agent/doctor), `scripts/lib/` (api, reconcile, report, prompt, config, git-safety, log), bats tests + integration + fixtures + mock_server, ADR-007 (Nomad) + ADR-009 (compute_drift), `apply.yml` + `runner-health.yml` workflows.
- Closes #403.

## Why

`HomericIntelligence/Myrmidons` is being narrowed to its **dataset-only charter**: YAML schema + agent/fleet descriptions + dataset validators + docs + CI wrappers for the validators. Anything that *drives* Agamemnon's API is consumer-side and belongs here.

## Coordination

Coordinates with the matching deletion PR in `HomericIntelligence/Myrmidons` (to be opened next). The Myrmidons deletion does not merge until this lands. Reconciler will continue to target Myrmidons as its dataset source — only the *code* relocates.

## Path choice: `tools/reconciler/`

Bash + bats reconciler under a dedicated subdir keeps it isolated from this repo's C++/CMake/Conan build. Reviewer decisions to make before/after merge:

- **Promote `tools/reconciler/.github/workflows/apply.yml` to `.github/workflows/apply.yml`** once ready. GitHub only auto-discovers workflows at root `.github/workflows/`, so the imported workflow is parked and inert until promoted (intentional — gives reviewers time to re-point secrets like `AGAMEMNON_URL`, `AGAMEMNON_API_KEY`, TLS materials).
- **Prune `tools/reconciler/tests/unit/`** if any imported unit tests turn out to be dataset-validator tests that should stay in Myrmidons. Most are reconciler-flavored; a quick scan: anything testing `compute_drift`/`verify_convergence`/`api`/`apply` is reconciler; anything testing schema/lint stays in Myrmidons. I erred on the side of importing all of them.
- **Decide on Myrmidons consumption pattern**: git submodule of Myrmidons, fetch-on-demand in apply.yml, or container-image dataset bake — pick one before promoting apply.yml.

## What was NOT carried over

- Myrmidons' `pixi.toml` build env (Bash/bats deps) — this repo's `pixi.toml` may need `bats-core`, `shellcheck`, `jq`, `yq` added under a new `[feature.reconciler]` env. Left for the reviewer.
- README/CLAUDE.md/CONTRIBUTING.md docs surrounding the reconciler in Myrmidons — those sections are being deleted in the Myrmidons cleanup PR. A condensed `tools/reconciler/README.md` is included here.
- `~83 reconciler-related issues` that were closed in Myrmidons during the narrowing pass. Triage and refile here as needed if any describe live bugs:
  697, 696, 695, 694, 693, 654, 651, 647, 640, 632, 631, 630, 628, 627, 626, 625, 624,
  622, 621, 620, 619, 612, 610, 609, 606, 605, 603, 602, 601, 599, 598, 596, 594, 593,
  592, 590, 589, 586, 585, 581, 579, 578, 577, 575, 574, 573, 571, 570, 547, 546, 544,
  542, 541, 540, 538, 537, 536, 530, 529, 527, 525, 523, 522, 521, 520, 515, 514, 512,
  511, 509, 508, 506, 504, 503, 501, 500, 499, 497, 496, 493, 491, 488, 486, 484, 483,
  474, 469, 464, 398.

## Test plan

- [ ] Reviewer confirms `tools/reconciler/` location is acceptable (or proposes alternative)
- [ ] Reviewer adds `[feature.reconciler]` env to `pixi.toml` with `bats-core`, `shellcheck`, `jq`, `yq` if they want the imported tests runnable
- [ ] Run `bats tools/reconciler/tests/unit/` once env is wired
- [ ] Promote `apply.yml` to `.github/workflows/` once secrets are wired
- [ ] Decide on dataset consumption pattern (submodule / fetch-on-demand / image bake)

🤖 Generated with [Claude Code](https://claude.com/claude-code)