### PR TITLE
fix(api): reconcile OpenAPI <-> implementation drift (S14 cluster)

### DIFF
--- a/clients/python/src/agamemnon_client/client.py
+++ b/clients/python/src/agamemnon_client/client.py
@@ -70,10 +70,19 @@ class AgamemnonClient:
     async def _request(self, method: str, path: str, **kwargs: Any) -> Any:
         """Send an HTTP request and return the parsed JSON response.
 
+        If ``self._config.api_key`` is set, an
+        ``Authorization: Bearer <key>`` header is added to every request.
+        Caller-supplied ``Authorization`` headers (passed via ``headers=...``)
+        are preserved and take precedence.
+
         Raises:
             AgamemnonConnectionError: If the server cannot be reached.
             AgamemnonAPIError: If the server returns a non-2xx status.
         """
+        if self._config.api_key:
+            headers = dict(kwargs.pop("headers", {}) or {})
+            headers.setdefault("Authorization", f"Bearer {self._config.api_key}")
+            kwargs["headers"] = headers
         try:
             response = await self._client.request(method, path, **kwargs)
         except httpx.ConnectError as exc:

--- a/clients/python/src/agamemnon_client/models.py
+++ b/clients/python/src/agamemnon_client/models.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from typing import Any
 
 from pydantic import BaseModel, Field
@@ -9,12 +10,34 @@ from pydantic import BaseModel, Field
 # ── Configuration ─────────────────────────────────────────────────────────────
 
 
+def _default_api_key() -> str | None:
+    """Return the AGAMEMNON_API_KEY env var, or None if unset/empty.
+
+    An explicitly empty value is treated as unset so that the server-side
+    "development escape hatch" semantics line up: empty env var → no auth header
+    is sent.
+    """
+    value = os.environ.get("AGAMEMNON_API_KEY")
+    if value is None or value == "":
+        return None
+    return value
+
+
 class AgamemnonConfig(BaseModel):
-    """Configuration for the AgamemnonClient."""
+    """Configuration for the AgamemnonClient.
+
+    When ``api_key`` is set (either explicitly or via the ``AGAMEMNON_API_KEY``
+    environment variable), the client will send an
+    ``Authorization: Bearer <api_key>`` header on every request. If
+    ``api_key`` is ``None`` (the default when the env var is unset/empty),
+    no auth header is added — appropriate for talking to a server that was
+    itself launched without ``AGAMEMNON_API_KEY``.
+    """
 
     host: str = "localhost"
     port: int = 8080
     timeout: float = 30.0
+    api_key: str | None = Field(default_factory=_default_api_key)
 
 
 # ── Health / Version ──────────────────────────────────────────────────────────

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -483,3 +483,48 @@ async def test_request_returns_none_on_204(client: AgamemnonClient) -> None:
 async def test_aclose() -> None:
     c = AgamemnonClient()
     await c.aclose()  # Should not raise
+
+
+# ── Authentication ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_request_sends_bearer_when_api_key_configured() -> None:
+    """When AgamemnonConfig.api_key is set, every request carries Authorization: Bearer."""
+    config = AgamemnonConfig(host="localhost", port=8080, api_key="s3cret-key")
+    authed = AgamemnonClient(config)
+    route = respx.get(f"{BASE_URL}/v1/version").mock(
+        return_value=httpx.Response(
+            200, json={"version": "0.1.0", "name": "ProjectAgamemnon"}
+        )
+    )
+    try:
+        await authed.version()
+    finally:
+        await authed.aclose()
+
+    assert route.called
+    sent = route.calls.last.request
+    assert sent.headers.get("Authorization") == "Bearer s3cret-key"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_request_omits_authorization_when_api_key_unset() -> None:
+    """With no api_key, no Authorization header is added (dev escape hatch)."""
+    config = AgamemnonConfig(host="localhost", port=8080, api_key=None)
+    unauthed = AgamemnonClient(config)
+    route = respx.get(f"{BASE_URL}/v1/version").mock(
+        return_value=httpx.Response(
+            200, json={"version": "0.1.0", "name": "ProjectAgamemnon"}
+        )
+    )
+    try:
+        await unauthed.version()
+    finally:
+        await unauthed.aclose()
+
+    assert route.called
+    sent = route.calls.last.request
+    assert "Authorization" not in sent.headers

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -112,7 +112,7 @@ in issue #144 — docker-hosted agents are created via `POST /v1/agents` with `h
 | `assigneeAgentId` | string | Assigned agent UUID; empty if unassigned |
 | `blockedBy` | string[] | Task IDs blocking this task |
 | `type` | string | Default `"general"`; used as myrmidon queue key |
-| `status` | string | `pending`\|`in_progress`\|`completed`\|`failed`; always `"pending"` at creation |
+| `status` | string | `pending`\|`running`\|`completed`\|`failed`\|`blocked`; always `"pending"` at creation |
 | `createdAt` | ISO 8601 UTC | Assigned at creation; immutable |
 | `completedAt` | ISO 8601 UTC \| null | Auto-set when `status` → `"completed"` |
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -4,7 +4,17 @@ Full machine-readable spec: [`openapi.yaml`](openapi.yaml) (OpenAPI 3.1)
 
 **Base URL:** `http://localhost:8080` (override port with `PORT` env var)
 
-**Authentication:** None — Phase 1 is unauthenticated. All endpoints are open.
+**Authentication:** All endpoints other than `/health` and `/v1/health` require an API key
+when the server is launched with the `AGAMEMNON_API_KEY` environment variable set. Two
+header forms are accepted:
+
+- `Authorization: Bearer <key>`
+- `X-API-Key: <key>`
+
+The expected key is the value of the server's `AGAMEMNON_API_KEY` env var. If
+`AGAMEMNON_API_KEY` is **unset or empty** in the server environment, authentication is
+disabled and all requests are accepted (development escape hatch). Production deployments
+MUST set this variable.
 
 ---
 

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1075,8 +1075,10 @@ components:
           default: local
         status:
           type: string
-          enum: [online, offline]
-          description: Set to `offline` at creation; changed by /start and /stop
+          enum: [online, offline, error]
+          description: |
+            Set to `offline` at creation; changed by `/start` (`online`) and `/stop`
+            (`offline`). May also be `error` if the agent reports a fatal failure.
         createdAt:
           type: string
           format: date-time
@@ -1143,7 +1145,7 @@ components:
           type: string
         status:
           type: string
-          enum: [online, offline]
+          enum: [online, offline, error]
 
     AgentWrapper:
       type: object
@@ -1168,7 +1170,7 @@ components:
       properties:
         status:
           type: string
-          enum: [online, offline]
+          enum: [online, offline, error]
         id:
           type: string
 
@@ -1282,7 +1284,7 @@ components:
           default: general
         status:
           type: string
-          enum: [pending, in_progress, completed, failed]
+          enum: [pending, running, completed, failed, blocked]
           default: pending
         createdAt:
           type: string
@@ -1327,7 +1329,7 @@ components:
           type: string
         status:
           type: string
-          enum: [pending, in_progress, completed, failed]
+          enum: [pending, running, completed, failed, blocked]
 
     TaskWrapper:
       type: object

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -125,6 +125,9 @@ paths:
       operationId: listAgents
       tags: [agents]
       summary: List all agents
+      parameters:
+        - $ref: "#/components/parameters/LimitParam"
+        - $ref: "#/components/parameters/OffsetParam"
       responses:
         "200":
           description: Array of all registered agents
@@ -325,6 +328,9 @@ paths:
       operationId: listTeams
       tags: [teams]
       summary: List all teams
+      parameters:
+        - $ref: "#/components/parameters/LimitParam"
+        - $ref: "#/components/parameters/OffsetParam"
       responses:
         "200":
           description: Array of all teams
@@ -441,6 +447,9 @@ paths:
       operationId: listAllTasks
       tags: [tasks]
       summary: List all tasks across all teams
+      parameters:
+        - $ref: "#/components/parameters/LimitParam"
+        - $ref: "#/components/parameters/OffsetParam"
       responses:
         "200":
           description: Array of all tasks
@@ -456,6 +465,8 @@ paths:
       summary: List tasks for a team
       parameters:
         - $ref: "#/components/parameters/TeamIdPath"
+        - $ref: "#/components/parameters/LimitParam"
+        - $ref: "#/components/parameters/OffsetParam"
       responses:
         "200":
           description: Array of tasks belonging to this team
@@ -777,6 +788,9 @@ paths:
       operationId: listFaults
       tags: [chaos]
       summary: List active chaos faults
+      parameters:
+        - $ref: "#/components/parameters/LimitParam"
+        - $ref: "#/components/parameters/OffsetParam"
       responses:
         "200":
           description: Array of active faults
@@ -861,6 +875,33 @@ components:
         authentication is disabled (development escape hatch).
 
   parameters:
+    LimitParam:
+      name: limit
+      in: query
+      required: false
+      schema:
+        type: integer
+        format: int32
+        minimum: 1
+        maximum: 1000
+        default: 100
+      description: |
+        Maximum number of items to return. Defaults to 100; capped at 1000.
+        Values outside the allowed range may be silently clamped by the server.
+
+    OffsetParam:
+      name: offset
+      in: query
+      required: false
+      schema:
+        type: integer
+        format: int32
+        minimum: 0
+        default: 0
+      description: |
+        Number of items to skip before starting to return results. Pair with
+        `limit` to paginate through large collections.
+
     AgentId:
       name: id
       in: path

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -57,6 +57,11 @@ tags:
     description: Workflow management (placeholder — not yet implemented)
   - name: chaos
     description: Chaos fault injection (for ProjectCharybdis integration)
+  - name: HMAS
+    description: |
+      Hierarchical Multi-Agent System (HMAS) orchestration — submit researched
+      briefs, retrieve generated task trees, and drive L0–L3 state transitions
+      (escalate / complete / state lookup).
 
 paths:
 
@@ -617,6 +622,153 @@ paths:
                 $ref: "#/components/schemas/WorkflowList"
               example:
                 workflows: []
+
+  # ── HMAS Orchestration ────────────────────────────────────────────────────────
+
+  /v1/briefs:
+    post:
+      operationId: submitBrief
+      tags: [HMAS]
+      summary: Submit a TaskBrief for HMAS orchestration
+      description: |
+        Accepts a researched `TaskBrief` (title, description, repos, modules,
+        per-module impl notes) and registers it with the orchestrator. The
+        orchestrator decomposes the brief into a tree of HMAS tasks and returns
+        the resulting plan.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TaskBrief"
+            example:
+              title: Wire X-API-Key header into SDK
+              description: Auth roundtrip implementation
+              repos: ["ProjectAgamemnon"]
+              modules:
+                ProjectAgamemnon: ["clients/python"]
+              impls:
+                ProjectAgamemnon:
+                  clients/python: ["Add api_key to AgamemnonConfig"]
+      responses:
+        "201":
+          description: Brief submitted; returns the generated plan
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HmasPlan"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+
+  /v1/briefs/{id}/plan:
+    get:
+      operationId: getBriefPlan
+      tags: [HMAS]
+      summary: Retrieve the HMAS task tree for a brief
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Brief ID returned by `POST /v1/briefs`
+      responses:
+        "200":
+          description: Plan found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HmasPlan"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /v1/tasks/{id}/escalate:
+    post:
+      operationId: escalateHmasTask
+      tags: [HMAS]
+      summary: Escalate an in-progress HMAS task
+      description: |
+        Escalates the task to the parent layer in the HMAS hierarchy. The escalation
+        record (with `reason` and `from_layer`) is appended to the task's
+        `escalations` array and published to NATS.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: HMAS task ID
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/HmasEscalateRequest"
+            example:
+              reason: blocked on upstream decision
+      responses:
+        "200":
+          description: Task escalated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HmasEscalateResponse"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /v1/tasks/{id}/complete:
+    post:
+      operationId: completeHmasTask
+      tags: [HMAS]
+      summary: Mark an HMAS task as completed
+      description: |
+        Reports completion of an HMAS task (used by myrmidons via the Telemachy
+        completion protocol). The orchestrator records the completion and may
+        unblock dependent tasks.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: HMAS task ID
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              description: Optional completion payload (free-form for now)
+              additionalProperties: true
+      responses:
+        "200":
+          description: Task marked completed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HmasCompleteResponse"
+
+  /v1/tasks/{id}/state:
+    get:
+      operationId: getHmasTaskState
+      tags: [HMAS]
+      summary: Get current HMAS task state
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: HMAS task ID
+      responses:
+        "200":
+          description: HMAS task state
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HmasTaskStateResponse"
+        "404":
+          $ref: "#/components/responses/NotFound"
 
   # ── Chaos ─────────────────────────────────────────────────────────────────────
 
@@ -1196,3 +1348,169 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Fault"
+
+    # ── HMAS ────────────────────────────────────────────────────────────────
+
+    HmasLayer:
+      type: string
+      enum: [L0_ChiefArchitect, L1_ComponentLead, L2_ModuleLead, L3_TaskAgent]
+      description: HMAS hierarchy layer (L0 highest, L3 lowest)
+
+    HmasTaskState:
+      type: string
+      enum: [Pending, Decomposing, Delegated, InProgress, Escalated, Completed, Failed]
+      description: HMAS task state machine value
+
+    HmasEscalationRecord:
+      type: object
+      required: [task_id, reason, escalated_at, from_layer]
+      properties:
+        task_id:
+          type: string
+        reason:
+          type: string
+        escalated_at:
+          type: string
+          format: date-time
+        from_layer:
+          $ref: "#/components/schemas/HmasLayer"
+
+    HmasTask:
+      type: object
+      required:
+        - id
+        - brief_id
+        - layer
+        - state
+        - subject
+        - blocked_by
+        - child_task_ids
+        - escalations
+      properties:
+        id:
+          type: string
+        brief_id:
+          type: string
+        parent_task_id:
+          type: string
+          description: Empty string for the root task
+        layer:
+          $ref: "#/components/schemas/HmasLayer"
+        state:
+          $ref: "#/components/schemas/HmasTaskState"
+        subject:
+          type: string
+        description:
+          type: string
+        repo:
+          type: string
+        module:
+          type: string
+        assigned_lead_id:
+          type: string
+        blocked_by:
+          type: array
+          items:
+            type: string
+        child_task_ids:
+          type: array
+          items:
+            type: string
+        created_at:
+          type: string
+          format: date-time
+        completed_at:
+          type: ["string", "null"]
+          format: date-time
+        escalations:
+          type: array
+          items:
+            $ref: "#/components/schemas/HmasEscalationRecord"
+
+    TaskBrief:
+      type: object
+      required: [title]
+      properties:
+        id:
+          type: string
+          description: Optional client-supplied ID; server generates one if omitted
+        title:
+          type: string
+        description:
+          type: string
+        repos:
+          type: array
+          items:
+            type: string
+          description: Repos in scope for this brief
+        modules:
+          type: object
+          description: Map of repo → list of module names
+          additionalProperties:
+            type: array
+            items:
+              type: string
+        impls:
+          type: object
+          description: Nested map repo → module → list of implementation tasks
+          additionalProperties:
+            type: object
+            additionalProperties:
+              type: array
+              items:
+                type: string
+
+    HmasPlan:
+      type: object
+      required: [brief_id, root, tasks]
+      properties:
+        brief_id:
+          type: string
+        root:
+          oneOf:
+            - $ref: "#/components/schemas/HmasTask"
+            - type: "null"
+          description: Root task of the plan tree, or null if no tasks were generated
+        tasks:
+          type: array
+          items:
+            $ref: "#/components/schemas/HmasTask"
+
+    HmasEscalateRequest:
+      type: object
+      properties:
+        reason:
+          type: string
+          description: Free-form escalation reason; defaults to "unspecified"
+          default: unspecified
+
+    HmasEscalateResponse:
+      type: object
+      required: [task_id, escalated]
+      properties:
+        task_id:
+          type: string
+        escalated:
+          type: boolean
+
+    HmasCompleteResponse:
+      type: object
+      required: [task_id, completed]
+      properties:
+        task_id:
+          type: string
+        completed:
+          type: boolean
+
+    HmasTaskStateResponse:
+      type: object
+      required: [task_id, state, layer, task]
+      properties:
+        task_id:
+          type: string
+        state:
+          $ref: "#/components/schemas/HmasTaskState"
+        layer:
+          $ref: "#/components/schemas/HmasLayer"
+        task:
+          $ref: "#/components/schemas/HmasTask"

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -7,8 +7,15 @@ info:
     REST API for ProjectAgamemnon — the planning, coordination, and agentic orchestration
     service for the HomericIntelligence distributed agent mesh.
 
-    **Authentication:** Phase 1 has no authentication. All endpoints are unauthenticated.
-    Authentication will be added in a future phase.
+    **Authentication:** All endpoints (except `/health` and `/v1/health`) require an API key
+    when the server is launched with `AGAMEMNON_API_KEY` set. Two header forms are accepted:
+
+    * `Authorization: Bearer <key>`
+    * `X-API-Key: <key>`
+
+    If `AGAMEMNON_API_KEY` is unset or empty in the server environment, authentication is
+    disabled and requests are accepted unauthenticated (development escape hatch). In
+    production deployments the environment variable MUST be set.
 
     **Transport:** Internal mesh traffic only (no TLS). Intended to be reached over Tailscale
     (100.x.x.x) or localhost.
@@ -32,6 +39,10 @@ servers:
       port:
         default: "8080"
         description: Port Agamemnon is listening on (PORT env var; default 8080)
+
+security:
+  - bearerAuth: []
+  - apiKeyAuth: []
 
 tags:
   - name: health
@@ -57,6 +68,7 @@ paths:
       tags: [health]
       summary: Root health check
       description: Unauthenticated liveness probe. Returns service name.
+      security: []
       responses:
         "200":
           description: Service is alive
@@ -74,6 +86,7 @@ paths:
       tags: [health]
       summary: Versioned health check
       description: Preferred liveness probe for v1 clients.
+      security: []
       responses:
         "200":
           description: Service is alive
@@ -675,6 +688,25 @@ paths:
 # ── Components ────────────────────────────────────────────────────────────────
 
 components:
+
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      description: |
+        API key supplied as `Authorization: Bearer <key>`. The expected key is the
+        value of the server's `AGAMEMNON_API_KEY` environment variable. When the
+        server is launched without `AGAMEMNON_API_KEY` (or with an empty value),
+        authentication is disabled (development escape hatch).
+    apiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-Key
+      description: |
+        API key supplied as `X-API-Key: <key>`. The expected key is the value of
+        the server's `AGAMEMNON_API_KEY` environment variable. When the server is
+        launched without `AGAMEMNON_API_KEY` (or with an empty value),
+        authentication is disabled (development escape hatch).
 
   parameters:
     AgentId:


### PR DESCRIPTION
## Summary
Reconciles the OpenAPI spec with the actual server implementation per the strict audit (S14 cluster).

- Documents existing auth (Bearer/X-API-Key via `AGAMEMNON_API_KEY` env var)
- Adds 5 previously-undocumented HMAS endpoints
- Documents pagination on 5 collection endpoints
- Aligns Agent/Task status enums to the implementation (`error`, `running`, `blocked`)
- Wires `Authorization: Bearer <key>` into the Python SDK

## Audit references
Resolves audit findings S14-1, S14-2, S14-3, S14-4, S14-5.

## Backwards-compat note
Any consumer currently sending `"in_progress"` for task status was already rejected by server validation (`kValidTaskStatuses` in `src/routes.cpp`). This is documentation correctness, not a behavior change.

The Python SDK auth wiring is purely additive: a new optional `api_key` field on `AgamemnonConfig` whose default reads `AGAMEMNON_API_KEY` from the environment. When unset (or empty) no `Authorization` header is sent, preserving the existing behavior against dev servers launched without `AGAMEMNON_API_KEY`.

## Test plan
- [x] `python -c "import yaml; yaml.safe_load(open('docs/api/openapi.yaml'))"` — YAML parses
- [x] `pre-commit run --files <changed>` — all hooks except OpenAPI validator (pre-existing tooling issue, unrelated to changes) pass
- [x] `cd clients/python && pixi run test tests/test_client.py -k "bearer or omits"` — both new auth tests pass
- [x] Spectral `spectral:oas` ruleset — only pre-existing warnings/error remain (the `/v1/chaos/{type}` vs `/v1/chaos/{id}` collision predates this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)