### PR TITLE
refactor: code quality (PUT/PATCH dedup, shared_lock reads, NatsPublisher widening)

### DIFF
--- a/include/projectagamemnon/nats_client.hpp
+++ b/include/projectagamemnon/nats_client.hpp
@@ -74,11 +74,10 @@ class NatsClient : public NatsPublisher {
                    const nlohmann::json& metadata) override;
 
   /// Access the dead-letter queue (for drain/clear endpoints).
-  DeadLetterQueue& dead_letter_queue() { return dlq_; }
-  const DeadLetterQueue& dead_letter_queue() const { return dlq_; }
+  DeadLetterQueue* dead_letter_queue() override { return &dlq_; }
 
   /// Access the circuit breaker (for health endpoints).
-  const CircuitBreaker& circuit_breaker() const { return breaker_; }
+  CircuitBreaker* circuit_breaker() override { return &breaker_; }
 
  private:
   MetricsRegistry* metrics_ = nullptr;

--- a/include/projectagamemnon/nats_publisher.hpp
+++ b/include/projectagamemnon/nats_publisher.hpp
@@ -6,6 +6,9 @@
 
 namespace projectagamemnon {
 
+class CircuitBreaker;
+class DeadLetterQueue;
+
 /// Abstract interface for NATS publishing.  Allows tests to inject a fake
 /// publisher without requiring a live NATS connection.
 class NatsPublisher {
@@ -16,6 +19,16 @@ class NatsPublisher {
 
   virtual void publish_log(const std::string& subject, const std::string& level,
                            const std::string& message, const nlohmann::json& metadata) = 0;
+
+  /// Access the underlying dead-letter queue, if the publisher has one.
+  /// Returns nullptr for publishers that don't track DLQ state (e.g.
+  /// FakeNatsPublisher in tests).  Removes the need for dynamic_cast in
+  /// route handlers that surface DLQ state via /v1/dead-letter.
+  virtual DeadLetterQueue* dead_letter_queue() { return nullptr; }
+
+  /// Access the underlying circuit breaker, if the publisher has one.
+  /// Returns nullptr for publishers that don't track breaker state.
+  virtual CircuitBreaker* circuit_breaker() { return nullptr; }
 };
 
 }  // namespace projectagamemnon

--- a/src/routes.cpp
+++ b/src/routes.cpp
@@ -659,55 +659,8 @@ void register_routes(httplib::Server& server, Store& store, NatsPublisher& nats,
   // PUT /v1/teams/:team_id/tasks/:task_id — Telemachy uses PUT for task updates
   server.Put(R"(/v1/teams/([^/]+)/tasks/([^/]+))", update_task_handler);
 
-  // PATCH /v1/teams/:team_id/tasks/:task_id
-  server.Patch(R"(/v1/teams/([^/]+)/tasks/([^/]+))", [sp, np](const httplib::Request& req,
-                                                              httplib::Response& res) {
-    std::string team_id = req.matches[1];
-    std::string task_id = req.matches[2];
-    json body;
-    if (!parse_body(req, res, body)) return;
-    if (body.contains("subject") && !body["subject"].is_string()) {
-      reply_bad_request(res, "'subject' must be a string");
-      return;
-    }
-    if (body.contains("subject") &&
-        !check_field_length(res, "subject", body["subject"].get<std::string>(), kMaxSubjectLen))
-      return;
-    if (body.contains("description") && !body["description"].is_string()) {
-      reply_bad_request(res, "'description' must be a string");
-      return;
-    }
-    if (body.contains("description") &&
-        !check_field_length(res, "description", body["description"].get<std::string>(),
-                            kMaxDescriptionLen))
-      return;
-    if (body.contains("status") && body["status"].is_string() &&
-        !require_enum(res, body["status"].get<std::string>(), "status", kValidTaskStatuses))
-      return;
-    if (body.contains("type") && body["type"].is_string() &&
-        !require_enum(res, body["type"].get<std::string>(), "type", kValidTaskTypes))
-      return;
-    if (body.contains("blockedBy") && !require_string_array(res, body["blockedBy"], "blockedBy"))
-      return;
-    json result = sp->update_task(team_id, task_id, body);
-    if (result.is_null()) {
-      reply_not_found(res, "task");
-      return;
-    }
-    std::string status = result.value("status", "");
-    json wrapped = {{"task", result}};
-    np->publish("hi.tasks." + team_id + "." + task_id + ".updated", wrapped.dump());
-    if (status == "completed") {
-      std::string task_type = result.value("type", "unknown");
-      std::string assignee = result.value("assigneeAgentId", "");
-      np->publish_log("hi.logs.agamemnon.task_completed", "info", "Task completed: " + task_id,
-                      {{"task_id", task_id},
-                       {"team_id", team_id},
-                       {"type", task_type},
-                       {"assignee", assignee}});
-    }
-    reply_json(res, 200, wrapped);
-  });
+  // PATCH /v1/teams/:team_id/tasks/:task_id — same semantics as PUT, share the handler.
+  server.Patch(R"(/v1/teams/([^/]+)/tasks/([^/]+))", update_task_handler);
 
   // ── Chaos ────────────────────────────────────────────────────────────────
 

--- a/src/routes.cpp
+++ b/src/routes.cpp
@@ -1,9 +1,10 @@
 #include "projectagamemnon/routes.hpp"
 
 #include "projectagamemnon/auth.hpp"
+#include "projectagamemnon/circuit_breaker.hpp"
+#include "projectagamemnon/dead_letter_queue.hpp"
 #include "projectagamemnon/hmas_types.hpp"
 #include "projectagamemnon/metrics.hpp"
-#include "projectagamemnon/nats_client.hpp"  // NatsClient derives NatsPublisher; needed for dynamic_cast
 #include "projectagamemnon/nats_publisher.hpp"
 #include "projectagamemnon/orchestrator.hpp"
 #include "projectagamemnon/rate_limiter.hpp"
@@ -194,10 +195,11 @@ void register_routes(httplib::Server& server, Store& store, NatsPublisher& nats,
                      Orchestrator& orchestrator) {
   Store* sp = &store;
   NatsPublisher* np = &nats;
-  // nc is non-null only when a real NatsClient is passed (production).
-  // In tests, a FakeNatsPublisher is passed and nc will be nullptr —
-  // guarded accesses below skip NatsClient-only features (circuit breaker, DLQ).
-  NatsClient* nc = dynamic_cast<NatsClient*>(np);
+  // Production NatsClient overrides dead_letter_queue()/circuit_breaker() to
+  // return non-null pointers; FakeNatsPublisher in tests returns nullptr.
+  // Guarded accesses below skip these features when not available.
+  CircuitBreaker* breaker = np->circuit_breaker();
+  DeadLetterQueue* dlq = np->dead_letter_queue();
   RateLimiter* rl = &rate_limiter;
   AuthMiddleware* ap = &auth;
   MetricsRegistry* mp = &metrics;
@@ -245,21 +247,23 @@ void register_routes(httplib::Server& server, Store& store, NatsPublisher& nats,
     reply_json(res, 200, {{"status", "ok"}, {"service", "ProjectAgamemnon"}});
   });
 
-  server.Get("/v1/health", [nc](const httplib::Request&, httplib::Response& res) {
+  server.Get("/v1/health", [breaker, dlq](const httplib::Request&, httplib::Response& res) {
     json body = {{"status", "ok"}};
-    if (nc != nullptr) {
-      body["nats_circuit"] = nc->circuit_breaker().state_label();
-      body["dlq_depth"] = nc->dead_letter_queue().size();
+    if (breaker != nullptr) {
+      body["nats_circuit"] = breaker->state_label();
+    }
+    if (dlq != nullptr) {
+      body["dlq_depth"] = dlq->size();
     }
     reply_json(res, 200, body);
   });
 
   // GET /v1/dead-letter — drain and return all dead-lettered messages
-  // nc is owned by main() and outlives the server; reference capture is safe.
-  server.Get("/v1/dead-letter", [nc](const httplib::Request&, httplib::Response& res) {
+  // dlq is owned by main() (via NatsClient) and outlives the server.
+  server.Get("/v1/dead-letter", [dlq](const httplib::Request&, httplib::Response& res) {
     json arr = json::array();
-    if (nc != nullptr) {
-      auto entries = nc->dead_letter_queue().drain();
+    if (dlq != nullptr) {
+      auto entries = dlq->drain();
       for (const auto& e : entries) {
         arr.push_back({{"subject", e.subject},
                        {"payload", e.payload},
@@ -271,9 +275,9 @@ void register_routes(httplib::Server& server, Store& store, NatsPublisher& nats,
   });
 
   // DELETE /v1/dead-letter — discard all dead-lettered messages
-  server.Delete("/v1/dead-letter", [nc](const httplib::Request&, httplib::Response& res) {
-    if (nc != nullptr) {
-      nc->dead_letter_queue().clear();
+  server.Delete("/v1/dead-letter", [dlq](const httplib::Request&, httplib::Response& res) {
+    if (dlq != nullptr) {
+      dlq->clear();
     }
     reply_json(res, 200, {{"cleared", true}});
   });

--- a/src/store.cpp
+++ b/src/store.cpp
@@ -260,7 +260,7 @@ json Store::create_agent(const json& body) {
 
 json Store::get_agent(const std::string& id) {
   ensure_agents_loaded_();
-  std::unique_lock<std::shared_mutex> lk(mutex_);
+  std::shared_lock<std::shared_mutex> lk(mutex_);
   auto it = agents_.find(id);
   if (it == agents_.end()) return nullptr;
   return it->second;
@@ -277,7 +277,7 @@ json Store::get_agent_by_name(const std::string& name) {
 
 json Store::list_agents(std::size_t limit, std::size_t offset) {
   ensure_agents_loaded_();
-  std::unique_lock<std::shared_mutex> lk(mutex_);
+  std::shared_lock<std::shared_mutex> lk(mutex_);
   // #340: deterministic pagination — collect into sorted vector, then slice.
   std::vector<std::pair<std::string, json>> sorted(agents_.begin(), agents_.end());
   std::sort(sorted.begin(), sorted.end(),
@@ -372,7 +372,7 @@ json Store::create_team(const json& body) {
 
 json Store::get_team(const std::string& id) {
   ensure_teams_loaded_();
-  std::unique_lock<std::shared_mutex> lk(mutex_);
+  std::shared_lock<std::shared_mutex> lk(mutex_);
   auto it = teams_.find(id);
   if (it == teams_.end()) return nullptr;
   return it->second;
@@ -380,7 +380,7 @@ json Store::get_team(const std::string& id) {
 
 json Store::list_teams(std::size_t limit, std::size_t offset) {
   ensure_teams_loaded_();
-  std::unique_lock<std::shared_mutex> lk(mutex_);
+  std::shared_lock<std::shared_mutex> lk(mutex_);
   // #340: deterministic pagination — sort by key then slice.
   std::vector<std::pair<std::string, json>> sorted(teams_.begin(), teams_.end());
   std::sort(sorted.begin(), sorted.end(),
@@ -459,7 +459,7 @@ json Store::get_task(const std::string& team_id, const std::string& task_id) {
   // wildcard — callers must provide the owning team for cross-team safety.
   if (team_id.empty()) return nullptr;
   ensure_tasks_loaded_();
-  std::unique_lock<std::shared_mutex> lk(mutex_);
+  std::shared_lock<std::shared_mutex> lk(mutex_);
   auto it = tasks_.find(task_id);
   if (it == tasks_.end()) return nullptr;
   if (it->second.value("teamId", "") != team_id) return nullptr;
@@ -497,7 +497,7 @@ json Store::update_task(const std::string& team_id, const std::string& task_id, 
 
 json Store::list_tasks_for_team(const std::string& team_id, std::size_t limit, std::size_t offset) {
   ensure_tasks_loaded_();
-  std::unique_lock<std::shared_mutex> lk(mutex_);
+  std::shared_lock<std::shared_mutex> lk(mutex_);
   // #340: deterministic pagination — collect team tasks, sort by key, then slice.
   std::vector<std::pair<std::string, json>> team_tasks;
   for (auto& [id, task] : tasks_) {
@@ -515,7 +515,7 @@ json Store::list_tasks_for_team(const std::string& team_id, std::size_t limit, s
 
 json Store::list_all_tasks(std::size_t limit, std::size_t offset) {
   ensure_tasks_loaded_();
-  std::unique_lock<std::shared_mutex> lk(mutex_);
+  std::shared_lock<std::shared_mutex> lk(mutex_);
   // #340: deterministic pagination — sort by key then slice.
   std::vector<std::pair<std::string, json>> sorted(tasks_.begin(), tasks_.end());
   std::sort(sorted.begin(), sorted.end(),


### PR DESCRIPTION
## Summary

Phase F-4 code quality wins from the F-phase audit. Three independent
refactors, one atomic commit each, no behavior change.

### 1. Deduplicate PUT/PATCH task update handler (S3)

`src/routes.cpp` had two copy-pasted lambdas — one registered for
`PUT /v1/teams/:team_id/tasks/:task_id` and another (byte-identical
body) for `PATCH`. Register the existing `update_task_handler` lambda
for both verbs so future changes don't need to be made twice.

### 2. Use `shared_lock` for read-only Store accessors (S4)

`get_agent`, `list_agents`, `get_team`, `list_teams`, `get_task`,
`list_all_tasks`, and `list_tasks_for_team` were holding an exclusive
`unique_lock`, serializing reads unnecessarily. Switch them to
`shared_lock<shared_mutex>`, matching the pattern already used in
`get_hmas_task` and `list_hmas_tasks_by_*`. The `ensure_*_loaded_`
helpers handle their own write locking internally, so the now-shared
lock here only guards in-memory map lookups. `test_store_concurrent`
passes unchanged.

### 3. Widen NatsPublisher to remove `dynamic_cast` (S4)

`routes.cpp` did `dynamic_cast<NatsClient*>(NatsPublisher*)` purely to
reach `dead_letter_queue()` and `circuit_breaker()`, coupling the
route registrar to the concrete `NatsClient` type and pulling the
heavy `nats_client.hpp` header into the routes TU.

Widen the abstract base with two virtual accessors:

```cpp
virtual DeadLetterQueue* dead_letter_queue() { return nullptr; }
virtual CircuitBreaker*  circuit_breaker()   { return nullptr; }
```

Default implementations return `nullptr` so `FakeNatsPublisher` and
any future test double Just Work. `NatsClient` overrides both to
return pointers to its owned `dlq_` / `breaker_` members.
`routes.cpp` now calls the virtual methods through the base pointer
and the `dynamic_cast` is gone.

## Test plan

- [x] `cmake --build --preset debug` — clean build
- [x] `ctest --preset debug` — 425/426 pass (the one failure,
      `PeerDiscoveryTest.EmptyTailscaleOutputReturnsEmpty`, is an
      environmental flake on hosts with a live tailscale daemon and is
      not touched by this PR)
- [x] `test_store_concurrent` — all 8 concurrent tests pass with the
      new shared_lock pattern
- [x] `pre-commit run --all-files` — clang-format clean
      (`validate-openapi` failure is environmental; needs npm registry
      access for spectral ruleset)

## Audit refs

- Phase F-4 plan: `~/.claude/plans/analyze-and-figure-out-abstract-charm.md`
- Finding clusters: S3 (PUT/PATCH dedup), S4 (lock contention,
  `dynamic_cast`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)