### PR TITLE
docs(changelog): date v0.1.0 release as 2026-05-18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - `release`: add RELEASING.md and pre-release readiness check script (#19)
 
-## [0.1.0] - TBD
+## [0.1.0] - 2026-05-18
 
 ### Added
 


### PR DESCRIPTION
Sets [0.1.0] release date in CHANGELOG.md following v0.1.0 tag push. Phase F-6 final touch.