### PR TITLE
feat(agents): add AgentEnvelope orchestration wrapper (ADR-015, from Keystone #515)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,7 @@ add_library(ProjectAgamemnon_core STATIC
   src/orchestrator.cpp
   src/planning_breakdown.cpp
   src/state_machine.cpp
+  src/agents/agent_envelope.cpp
 )
 
 target_compile_features(ProjectAgamemnon_core PUBLIC cxx_std_20)

--- a/clients/python/pixi.lock
+++ b/clients/python/pixi.lock
@@ -37,7 +37,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f2/94/a2025fe442abedf8b038038dab3dba942009ad42b38ea064a1a9e6094241/librt-0.9.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/19/65/0cd9285ab010ee8214c83d67c6b49417c40d86ce46f1aa109457b5a9b8d7/mypy-1.20.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
@@ -85,7 +85,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cd/c1/184e539543f06ea2912f4b92a5ffaede4f9b392689e3f00acbf8134bee92/librt-0.9.0-cp314-cp314-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/ae/d1/b4ec96b0ecc620a4443570c6e95c867903428cfcde4206518eafdd5880c3/mypy-1.20.2-cp314-cp314-macosx_10_15_x86_64.whl
@@ -132,7 +132,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f3/ad/23399bdcb7afca819acacdef31b37ee59de261bd66b503a7995c03c4b0dc/librt-0.9.0-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/3a/63/d2c2ff4fa66bc49477d32dfa26e8a167ba803ea6a69c5efb416036909d30/mypy-1.20.2-cp314-cp314-macosx_11_0_arm64.whl
@@ -182,7 +182,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/24/ed/c22ca4db0ca3cbc285e4d9206108746beda561a9792289c3c31281d7e9df/librt-0.9.0-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/fd/a1/1b4233d255bdd0b38a1f284feeb1c143ca508c19184964e22f8d837ec851/mypy-1.20.2-cp314-cp314-win_amd64.whl
@@ -247,7 +247,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/af/40/791891d4c0c4dab4c5e187c17261cedc26285fd41541577f900470a45a4d/license_expression-30.4.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
@@ -304,7 +304,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/af/40/791891d4c0c4dab4c5e187c17261cedc26285fd41541577f900470a45a4d/license_expression-30.4.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
@@ -360,7 +360,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/af/40/791891d4c0c4dab4c5e187c17261cedc26285fd41541577f900470a45a4d/license_expression-30.4.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
@@ -418,7 +418,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/af/40/791891d4c0c4dab4c5e187c17261cedc26285fd41541577f900470a45a4d/license_expression-30.4.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
@@ -745,10 +745,10 @@ packages:
   purls: []
   size: 12273764
   timestamp: 1773822733780
-- pypi: https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl
   name: idna
-  version: '3.13'
-  sha256: 892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3
+  version: '3.15'
+  sha256: 048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8
   requires_dist:
   - ruff>=0.6.2 ; extra == 'all'
   - mypy>=1.11.2 ; extra == 'all'

--- a/include/projectagamemnon/agents/agent_action_type.hpp
+++ b/include/projectagamemnon/agents/agent_action_type.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <string>
+
+namespace projectagamemnon {
+namespace agents {
+
+/**
+ * @brief Agent-layer action types for HMAS orchestration
+ *
+ * These action types belong to the agent / orchestration layer
+ * (ProjectAgamemnon) rather than to the transport layer.  They were moved out
+ * of ProjectKeystone's transport struct per ADR-015 / Keystone Issue #515
+ * (SOLID/SRP: a transport message must not carry orchestration semantics).
+ *
+ * Transport-level signals (EXECUTE, RETURN_RESULT, SHUTDOWN) stay on the
+ * transport message's ActionType.  Orchestration-level signals live here.
+ */
+enum class AgentActionType {
+  DECOMPOSE,    ///< Decompose a goal into subtasks/subgoals
+  CANCEL_TASK,  ///< Cancel a running task
+  TASK_FAILED   ///< Report task failure to parent agent
+};
+
+/**
+ * @brief Convert AgentActionType to string
+ */
+inline std::string agentActionTypeToString(AgentActionType type) {
+  switch (type) {
+    case AgentActionType::DECOMPOSE:
+      return "DECOMPOSE";
+    case AgentActionType::CANCEL_TASK:
+      return "CANCEL_TASK";
+    case AgentActionType::TASK_FAILED:
+      return "TASK_FAILED";
+    default:
+      return "UNKNOWN";
+  }
+}
+
+}  // namespace agents
+}  // namespace projectagamemnon

--- a/include/projectagamemnon/agents/agent_envelope.hpp
+++ b/include/projectagamemnon/agents/agent_envelope.hpp
@@ -1,0 +1,173 @@
+#pragma once
+
+#include "projectagamemnon/agents/agent_action_type.hpp"
+
+#include <map>
+#include <optional>
+#include <string>
+
+namespace projectagamemnon {
+namespace agents {
+
+/**
+ * @brief Transport-level action types understood by the pure transport layer.
+ *
+ * Mirrors the slimmed ProjectKeystone core::ActionType (post Issue #515): the
+ * transport layer understands only EXECUTE / RETURN_RESULT / SHUTDOWN.
+ * Orchestration semantics live in AgentActionType (this file's sibling).
+ */
+enum class TransportActionType {
+  EXECUTE,        ///< Execute a concrete task or command
+  RETURN_RESULT,  ///< Return the result of a computation
+  SHUTDOWN,       ///< Graceful shutdown signal
+};
+
+/**
+ * @brief Transport-level message priority levels.
+ */
+enum class TransportPriority {
+  HIGH = 0,    ///< Urgent, time-sensitive messages
+  NORMAL = 1,  ///< Standard priority (default)
+  LOW = 2,     ///< Background, non-urgent messages
+};
+
+/**
+ * @brief Minimal vendored transport message struct.
+ *
+ * Agamemnon does not link ProjectKeystone's C++ headers directly; all
+ * inter-component traffic crosses Keystone as opaque (subject, payload)
+ * strings.  This struct is the minimal transport shape AgentEnvelope wraps:
+ * routing identifiers, a transport action, an optional payload, and a
+ * priority.  It deliberately carries NO orchestration fields (session_id,
+ * task_id, metadata, orchestration actions) — those are the envelope's job.
+ *
+ * If/when Agamemnon gains a richer transport type (e.g. a generated KIM
+ * binding), this struct can be replaced by a thin alias without changing the
+ * AgentEnvelope contract.
+ */
+struct TransportMessage {
+  std::string sender_id;    ///< ID of the sending agent
+  std::string receiver_id;  ///< ID of the receiving agent
+  TransportActionType action_type{TransportActionType::EXECUTE};  ///< Transport action
+  std::optional<std::string> payload;                             ///< Optional payload data
+  TransportPriority priority{TransportPriority::NORMAL};          ///< Message priority
+
+  /**
+   * @brief Create a transport message.
+   *
+   * @param sender Sender agent ID
+   * @param receiver Receiver agent ID
+   * @param action Transport action type
+   * @param data Optional payload data
+   * @return TransportMessage populated message
+   */
+  static TransportMessage create(const std::string& sender, const std::string& receiver,
+                                 TransportActionType action,
+                                 const std::optional<std::string>& data = std::nullopt) {
+    TransportMessage msg;
+    msg.sender_id = sender;
+    msg.receiver_id = receiver;
+    msg.action_type = action;
+    msg.payload = data;
+    return msg;
+  }
+};
+
+/**
+ * @brief Agent-layer message envelope wrapping a transport message.
+ *
+ * AgentEnvelope sits above the transport layer and carries orchestration-level
+ * metadata that does not belong on a transport message (a pure transport
+ * struct).  It was introduced for Keystone Issue #515 (SOLID/SRP: remove
+ * orchestration concerns from the transport struct) and, per ADR-015, the
+ * orchestration half lives in ProjectAgamemnon — agent-orchestration types
+ * belong here, not in Keystone's pure transport layer.
+ *
+ * The transport layer (MessageBus, NATS bridge) never sees this type; it only
+ * passes raw transport messages.  Agent code that needs session isolation,
+ * task tracking, or orchestration action semantics wraps the incoming
+ * transport message in an AgentEnvelope:
+ *
+ *   auto env = AgentEnvelope::wrap(msg);
+ *   if (env.agent_action == AgentActionType::CANCEL_TASK) { ... }
+ *
+ * The agent_action field is populated by decoding the payload prefix
+ * convention agreed between agents (see wrap()).
+ */
+struct AgentEnvelope {
+  /// The underlying transport message
+  TransportMessage transport_msg;
+
+  /// Agent-level action type (orchestration semantics)
+  std::optional<AgentActionType> agent_action;
+
+  /// Session/context identifier for concurrent operation isolation
+  std::string session_id{"default"};
+
+  /// Optional task identifier for tracking/cancellation
+  std::optional<std::string> task_id;
+
+  /// Extensible key-value metadata (agent-layer, not serialized on wire)
+  std::map<std::string, std::string> metadata;
+
+  /**
+   * @brief Wrap a raw transport message in an AgentEnvelope.
+   *
+   * Decodes agent_action from the transport message payload. The convention:
+   * - transport EXECUTE with payload prefix "CANCEL_TASK:" → CANCEL_TASK
+   * - transport EXECUTE with payload prefix "TASK_FAILED:" → TASK_FAILED
+   * - transport EXECUTE with payload prefix "DECOMPOSE:"   → DECOMPOSE
+   * All other messages have agent_action == std::nullopt (pure transport).
+   *
+   * @param msg Raw transport message
+   * @return AgentEnvelope wrapping the message
+   */
+  static AgentEnvelope wrap(const TransportMessage& msg);
+
+  /**
+   * @brief Create an agent envelope for a new outgoing message.
+   *
+   * @param sender Sender agent ID
+   * @param receiver Receiver agent ID
+   * @param action Agent-level action type
+   * @param session Session identifier
+   * @param data Optional payload
+   * @return AgentEnvelope with transport_msg populated
+   */
+  static AgentEnvelope create(const std::string& sender, const std::string& receiver,
+                              AgentActionType action, const std::string& session = "default",
+                              const std::optional<std::string>& data = std::nullopt);
+
+  /**
+   * @brief Create a task cancellation envelope.
+   *
+   * Cancellation is cooperative: agents check and respond gracefully.
+   *
+   * @param sender Sender agent ID (parent requesting cancellation)
+   * @param receiver Receiver agent ID (child executing the task)
+   * @param task_id_val Task identifier to cancel
+   * @param session Session identifier
+   * @return AgentEnvelope with CANCEL_TASK agent_action
+   */
+  static AgentEnvelope createCancellation(const std::string& sender, const std::string& receiver,
+                                          const std::string& task_id_val,
+                                          const std::string& session = "default");
+
+  /**
+   * @brief Create a task failure notification envelope.
+   *
+   * Sent by a subordinate agent to its parent when execution fails.
+   *
+   * @param sender Sender agent ID (child reporting failure)
+   * @param receiver Receiver agent ID (parent waiting for result)
+   * @param error_msg Human-readable failure description
+   * @param session Session identifier
+   * @return AgentEnvelope with TASK_FAILED agent_action
+   */
+  static AgentEnvelope createFailure(const std::string& sender, const std::string& receiver,
+                                     const std::string& error_msg,
+                                     const std::string& session = "default");
+};
+
+}  // namespace agents
+}  // namespace projectagamemnon

--- a/include/projectagamemnon/agents/agent_envelope.hpp
+++ b/include/projectagamemnon/agents/agent_envelope.hpp
@@ -46,8 +46,8 @@ enum class TransportPriority {
  * AgentEnvelope contract.
  */
 struct TransportMessage {
-  std::string sender_id;    ///< ID of the sending agent
-  std::string receiver_id;  ///< ID of the receiving agent
+  std::string sender_id;                                          ///< ID of the sending agent
+  std::string receiver_id;                                        ///< ID of the receiving agent
   TransportActionType action_type{TransportActionType::EXECUTE};  ///< Transport action
   std::optional<std::string> payload;                             ///< Optional payload data
   TransportPriority priority{TransportPriority::NORMAL};          ///< Message priority

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -95,16 +95,16 @@ def main() -> None:
     ]
     security_md_path = repo_root / "SECURITY.md"
 
-    # Check that clients/python/pyproject.toml exists (required).
-    # agamemnon/pyproject.toml is optional and will be skipped if missing.
-    required_toml = toml_paths[0]
-    if not required_toml.exists():
-        print(f"error: {required_toml} does not exist", file=sys.stderr)
-        sys.exit(1)
+    # Both pyproject.toml files are required and kept in lockstep so a single
+    # v* tag publishes consistent versions to PyPI. Fail fast if either is
+    # missing rather than silently bumping only one.
+    for required_toml in toml_paths:
+        if not required_toml.exists():
+            print(f"error: {required_toml} does not exist", file=sys.stderr)
+            sys.exit(1)
 
     for toml_path in toml_paths:
-        if toml_path.exists():
-            bump_version(toml_path, new_version)
+        bump_version(toml_path, new_version)
     sync_security_md(security_md_path, new_version)
 
 

--- a/scripts/validate-openapi.sh
+++ b/scripts/validate-openapi.sh
@@ -2,6 +2,14 @@
 # Validates docs/api/openapi.yaml with @stoplight/spectral-cli.
 # Requires: npx (Node.js >= 18) or a globally installed spectral binary.
 # Exit codes: 0 = valid, non-zero = validation errors.
+#
+# NOTE: @stoplight/spectral-core 1.23.0 (and its bundled spectral-rulesets
+# 1.22.3) regressed the built-in spectral:oas ruleset, crashing with
+# "Cannot read properties of null (reading 'enum')" on otherwise-valid specs.
+# We therefore pin spectral-core/spectral-rulesets to the last known-good
+# versions via npm `overrides`. This is a tooling pin only -- the lint rules
+# applied are unchanged (spectral:oas). Remove the overrides once the upstream
+# regression is fixed.
 set -euo pipefail
 
 SPEC="${1:-docs/api/openapi.yaml}"
@@ -15,8 +23,31 @@ fi
 
 RULESET="${REPO_ROOT}/.spectral.yaml"
 
+# Pinned, known-good Spectral toolchain (see NOTE above).
+SPECTRAL_CLI_VERSION="6.16.0"
+SPECTRAL_CORE_VERSION="1.22.0"
+SPECTRAL_RULESETS_VERSION="1.22.2"
+
 if command -v spectral &>/dev/null; then
   spectral lint --ruleset "${RULESET}" "${SPEC_PATH}"
 else
-  npx --yes @stoplight/spectral-cli@latest lint --ruleset "${RULESET}" "${SPEC_PATH}"
+  # Install Spectral into an isolated, pinned workspace so the broken
+  # spectral-core@1.23.0 cannot be pulled in via floating transitive ranges.
+  RUNNER_DIR="$(mktemp -d)"
+  trap 'rm -rf "${RUNNER_DIR}"' EXIT
+
+  cat >"${RUNNER_DIR}/package.json" <<EOF
+{
+  "name": "spectral-runner",
+  "private": true,
+  "dependencies": { "@stoplight/spectral-cli": "${SPECTRAL_CLI_VERSION}" },
+  "overrides": {
+    "@stoplight/spectral-core": "${SPECTRAL_CORE_VERSION}",
+    "@stoplight/spectral-rulesets": "${SPECTRAL_RULESETS_VERSION}"
+  }
+}
+EOF
+
+  (cd "${RUNNER_DIR}" && npm install --no-audit --no-fund --silent)
+  "${RUNNER_DIR}/node_modules/.bin/spectral" lint --ruleset "${RULESET}" "${SPEC_PATH}"
 fi

--- a/src/agents/agent_envelope.cpp
+++ b/src/agents/agent_envelope.cpp
@@ -1,0 +1,107 @@
+#include "projectagamemnon/agents/agent_envelope.hpp"
+
+#include <string_view>
+
+namespace projectagamemnon {
+namespace agents {
+
+namespace {
+// Payload prefix convention for encoding AgentActionType on the wire.
+// The transport layer sees only EXECUTE action_type + a payload; the agent
+// layer decodes the orchestration intent from the prefix.
+constexpr std::string_view kCancelPrefix = "CANCEL_TASK:";
+constexpr std::string_view kFailedPrefix = "TASK_FAILED:";
+constexpr std::string_view kDecomposePrefix = "DECOMPOSE:";
+}  // namespace
+
+// static
+AgentEnvelope AgentEnvelope::wrap(const TransportMessage& msg) {
+  AgentEnvelope env;
+  env.transport_msg = msg;
+  env.session_id = "default";
+
+  if (msg.payload.has_value()) {
+    const std::string& p = *msg.payload;
+    if (p.rfind(std::string(kCancelPrefix), 0) == 0) {
+      env.agent_action = AgentActionType::CANCEL_TASK;
+      // task_id follows the prefix
+      std::string tid = p.substr(kCancelPrefix.size());
+      if (!tid.empty()) {
+        env.task_id = tid;
+      }
+    } else if (p.rfind(std::string(kFailedPrefix), 0) == 0) {
+      env.agent_action = AgentActionType::TASK_FAILED;
+    } else if (p.rfind(std::string(kDecomposePrefix), 0) == 0) {
+      env.agent_action = AgentActionType::DECOMPOSE;
+    }
+  }
+
+  return env;
+}
+
+// static
+AgentEnvelope AgentEnvelope::create(const std::string& sender, const std::string& receiver,
+                                    AgentActionType action, const std::string& session,
+                                    const std::optional<std::string>& data) {
+  AgentEnvelope env;
+  env.agent_action = action;
+  env.session_id = session;
+
+  // Encode agent_action as payload prefix so the transport message remains
+  // self-describing to agent receivers that call wrap().
+  std::string prefix;
+  switch (action) {
+    case AgentActionType::CANCEL_TASK:
+      prefix = std::string(kCancelPrefix);
+      break;
+    case AgentActionType::TASK_FAILED:
+      prefix = std::string(kFailedPrefix);
+      break;
+    case AgentActionType::DECOMPOSE:
+      prefix = std::string(kDecomposePrefix);
+      break;
+  }
+
+  std::string payload = prefix + data.value_or("");
+  env.transport_msg =
+      TransportMessage::create(sender, receiver, TransportActionType::EXECUTE, payload);
+
+  return env;
+}
+
+// static
+AgentEnvelope AgentEnvelope::createCancellation(const std::string& sender,
+                                                const std::string& receiver,
+                                                const std::string& task_id_val,
+                                                const std::string& session) {
+  AgentEnvelope env;
+  env.agent_action = AgentActionType::CANCEL_TASK;
+  env.session_id = session;
+  env.task_id = task_id_val;
+
+  // Encode task_id in the payload so the receiver can decode it via wrap().
+  std::string payload = std::string(kCancelPrefix) + task_id_val;
+  env.transport_msg =
+      TransportMessage::create(sender, receiver, TransportActionType::EXECUTE, payload);
+  env.transport_msg.priority = TransportPriority::HIGH;
+
+  return env;
+}
+
+// static
+AgentEnvelope AgentEnvelope::createFailure(const std::string& sender, const std::string& receiver,
+                                           const std::string& error_msg,
+                                           const std::string& session) {
+  AgentEnvelope env;
+  env.agent_action = AgentActionType::TASK_FAILED;
+  env.session_id = session;
+
+  std::string payload = std::string(kFailedPrefix) + error_msg;
+  env.transport_msg =
+      TransportMessage::create(sender, receiver, TransportActionType::EXECUTE, payload);
+
+  return env;
+}
+
+}  // namespace agents
+}  // namespace projectagamemnon

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -30,6 +30,7 @@ add_executable(${PROJECT_NAME}_tests
   src/test_planning_breakdown.cpp
   src/test_state_machine.cpp
   src/test_github_client.cpp
+  src/test_agent_envelope.cpp
 )
 
 target_compile_features(${PROJECT_NAME}_tests PRIVATE cxx_std_20)

--- a/test/src/test_agent_envelope.cpp
+++ b/test/src/test_agent_envelope.cpp
@@ -1,0 +1,151 @@
+/**
+ * @file test_agent_envelope.cpp
+ * @brief Unit tests for AgentEnvelope and AgentActionType
+ *
+ * The AgentEnvelope orchestration wrapper was moved from ProjectKeystone
+ * (Issue #515) into ProjectAgamemnon per ADR-015: agent-orchestration types
+ * belong in the orchestration service, not in Keystone's pure transport layer.
+ *
+ * These tests verify that orchestration-level semantics (CANCEL_TASK,
+ * TASK_FAILED, DECOMPOSE) are correctly encapsulated by AgentEnvelope and do
+ * not leak into the (vendored) transport message / TransportActionType.
+ */
+
+#include "projectagamemnon/agents/agent_action_type.hpp"
+#include "projectagamemnon/agents/agent_envelope.hpp"
+
+#include <gtest/gtest.h>
+
+using namespace projectagamemnon::agents;
+
+// ---------------------------------------------------------------------------
+// AgentActionType string conversion
+// ---------------------------------------------------------------------------
+
+TEST(AgentActionTypeTest, ToStringDecompose) {
+  EXPECT_EQ(agentActionTypeToString(AgentActionType::DECOMPOSE), "DECOMPOSE");
+}
+
+TEST(AgentActionTypeTest, ToStringCancelTask) {
+  EXPECT_EQ(agentActionTypeToString(AgentActionType::CANCEL_TASK), "CANCEL_TASK");
+}
+
+TEST(AgentActionTypeTest, ToStringTaskFailed) {
+  EXPECT_EQ(agentActionTypeToString(AgentActionType::TASK_FAILED), "TASK_FAILED");
+}
+
+// ---------------------------------------------------------------------------
+// AgentEnvelope factory: createCancellation
+// ---------------------------------------------------------------------------
+
+TEST(AgentEnvelopeTest, CreateCancellationFields) {
+  auto env = AgentEnvelope::createCancellation("alice", "bob", "task-42", "sess-1");
+
+  EXPECT_EQ(env.transport_msg.sender_id, "alice");
+  EXPECT_EQ(env.transport_msg.receiver_id, "bob");
+  ASSERT_TRUE(env.agent_action.has_value());
+  EXPECT_EQ(*env.agent_action, AgentActionType::CANCEL_TASK);
+  ASSERT_TRUE(env.task_id.has_value());
+  EXPECT_EQ(*env.task_id, "task-42");
+  EXPECT_EQ(env.session_id, "sess-1");
+  EXPECT_EQ(env.transport_msg.priority, TransportPriority::HIGH);
+}
+
+TEST(AgentEnvelopeTest, CreateCancellationDefaultSession) {
+  auto env = AgentEnvelope::createCancellation("a", "b", "t1");
+  EXPECT_EQ(env.session_id, "default");
+}
+
+TEST(AgentEnvelopeTest, CreateCancellationTransportActionIsExecute) {
+  // The transport action_type must remain EXECUTE (pure transport) even for
+  // a CANCEL_TASK envelope.  Only the agent layer sees AgentActionType.
+  auto env = AgentEnvelope::createCancellation("a", "b", "t1");
+  EXPECT_EQ(env.transport_msg.action_type, TransportActionType::EXECUTE);
+}
+
+// ---------------------------------------------------------------------------
+// AgentEnvelope factory: createFailure
+// ---------------------------------------------------------------------------
+
+TEST(AgentEnvelopeTest, CreateFailureFields) {
+  auto env = AgentEnvelope::createFailure("child", "parent", "disk full");
+
+  EXPECT_EQ(env.transport_msg.sender_id, "child");
+  EXPECT_EQ(env.transport_msg.receiver_id, "parent");
+  ASSERT_TRUE(env.agent_action.has_value());
+  EXPECT_EQ(*env.agent_action, AgentActionType::TASK_FAILED);
+  EXPECT_EQ(env.session_id, "default");
+}
+
+TEST(AgentEnvelopeTest, CreateFailureTransportActionIsExecute) {
+  auto env = AgentEnvelope::createFailure("a", "b", "err");
+  EXPECT_EQ(env.transport_msg.action_type, TransportActionType::EXECUTE);
+}
+
+// ---------------------------------------------------------------------------
+// AgentEnvelope factory: create (generic)
+// ---------------------------------------------------------------------------
+
+TEST(AgentEnvelopeTest, CreateDecompose) {
+  auto env = AgentEnvelope::create("sender", "receiver", AgentActionType::DECOMPOSE, "sess");
+
+  ASSERT_TRUE(env.agent_action.has_value());
+  EXPECT_EQ(*env.agent_action, AgentActionType::DECOMPOSE);
+  EXPECT_EQ(env.transport_msg.action_type, TransportActionType::EXECUTE);
+}
+
+// ---------------------------------------------------------------------------
+// AgentEnvelope::wrap — round-trip decoding (create/wrap field round-trip)
+// ---------------------------------------------------------------------------
+
+TEST(AgentEnvelopeTest, WrapCancellationRoundTrip) {
+  // Create a cancellation envelope, extract the transport message, wrap it back.
+  auto original = AgentEnvelope::createCancellation("parent", "child", "task-99", "s1");
+
+  auto decoded = AgentEnvelope::wrap(original.transport_msg);
+
+  // Transport routing fields survive the wrap() round-trip.
+  EXPECT_EQ(decoded.transport_msg.sender_id, "parent");
+  EXPECT_EQ(decoded.transport_msg.receiver_id, "child");
+  ASSERT_TRUE(decoded.agent_action.has_value());
+  EXPECT_EQ(*decoded.agent_action, AgentActionType::CANCEL_TASK);
+  ASSERT_TRUE(decoded.task_id.has_value());
+  EXPECT_EQ(*decoded.task_id, "task-99");
+}
+
+TEST(AgentEnvelopeTest, WrapFailureRoundTrip) {
+  auto original = AgentEnvelope::createFailure("child", "parent", "oom");
+
+  auto decoded = AgentEnvelope::wrap(original.transport_msg);
+
+  ASSERT_TRUE(decoded.agent_action.has_value());
+  EXPECT_EQ(*decoded.agent_action, AgentActionType::TASK_FAILED);
+}
+
+TEST(AgentEnvelopeTest, WrapDecomposeRoundTrip) {
+  auto original = AgentEnvelope::create("s", "r", AgentActionType::DECOMPOSE, "sess", "goal text");
+
+  auto decoded = AgentEnvelope::wrap(original.transport_msg);
+
+  ASSERT_TRUE(decoded.agent_action.has_value());
+  EXPECT_EQ(*decoded.agent_action, AgentActionType::DECOMPOSE);
+}
+
+TEST(AgentEnvelopeTest, WrapPlainMessageHasNoAgentAction) {
+  // A plain EXECUTE message (e.g., a task command) should not be decoded
+  // as any AgentActionType.
+  auto msg =
+      TransportMessage::create("a", "b", TransportActionType::EXECUTE, std::string{"echo hi"});
+
+  auto decoded = AgentEnvelope::wrap(msg);
+
+  EXPECT_FALSE(decoded.agent_action.has_value());
+}
+
+TEST(AgentEnvelopeTest, WrapShutdownMessageHasNoAgentAction) {
+  auto msg = TransportMessage::create("a", "b", TransportActionType::SHUTDOWN);
+
+  auto decoded = AgentEnvelope::wrap(msg);
+
+  EXPECT_FALSE(decoded.agent_action.has_value());
+}


### PR DESCRIPTION
## Summary

Adds the **AgentEnvelope** orchestration wrapper (plus its `AgentActionType` enum) to ProjectAgamemnon.

`AgentEnvelope` is agent-orchestration metadata — `session_id`, `task_id`, free-form `metadata`, and an optional `AgentActionType` (`DECOMPOSE` / `CANCEL_TASK` / `TASK_FAILED`) — that **wraps a transport message**. Per **ADR-015**, agent-orchestration types belong in Agamemnon, not in Keystone's *pure transport* layer.

This is the **"envelope" half** of the Keystone #515 split. The complementary **KeystoneMessage transport-slimming half stays in Keystone** in a separate PR (Keystone PR #574). This PR only *adds* to Agamemnon; it does not modify Keystone.

## Why here, not Keystone

By its own docstring the type is "agent-layer orchestration metadata" that sits *above* the transport layer. The transport layer (MessageBus / NATS bridge) never sees it — it only routes raw transport messages. That makes it orchestration, which is Agamemnon's domain (ADR-015 / Keystone Issue #515: SOLID/SRP — remove orchestration concerns from the transport struct).

## Adapting the wrapped message type

The Keystone version wraps `core::KeystoneMessage`. Agamemnon has **no C++ transport message type** — all inter-component traffic crosses Keystone as opaque `(subject, payload)` strings. So this PR vendors a minimal `TransportMessage` struct (under `projectagamemnon::agents`) as the wrapped shape: routing IDs, a transport `TransportActionType` (`EXECUTE`/`RETURN_RESULT`/`SHUTDOWN`), an optional payload, and a `TransportPriority`. It deliberately carries **no** orchestration fields. If Agamemnon later gains a richer transport binding, this struct can become a thin alias without changing the `AgentEnvelope` contract.

Wrapper semantics preserved 1:1: `wrap()`, `create()`, `createCancellation()`, `createFailure()`, with the same payload-prefix encoding convention (`CANCEL_TASK:` / `TASK_FAILED:` / `DECOMPOSE:`).

## Files

- `include/projectagamemnon/agents/agent_action_type.hpp`
- `include/projectagamemnon/agents/agent_envelope.hpp`
- `src/agents/agent_envelope.cpp` (linked into `ProjectAgamemnon_core`)
- `test/src/test_agent_envelope.cpp` — 14 unit tests incl. `create()`/`wrap()` field round-trips

Files live in their own paths + own CMake additions so a sibling PR adding an `agents/` tree rebases cleanly.

## Test

Build green; all 14 envelope tests pass (`AgentActionType` string conversion, the three factory methods, transport-purity assertions, and `wrap()` round-trips for cancellation/failure/decompose plus negative cases for plain/shutdown messages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)